### PR TITLE
fix(gauntlet): evidence oracles fail closed; verify_evidence is binary-aware (v1.1.0)

### DIFF
--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gauntlet",
   "description": "Consolidated adversarial-review staple: multi-lens panel review of a frozen subject with falsifier discipline, mechanical evidence verification, a 102-lens registry with deterministic selection, and a computed GO/CONDITIONAL/NO-GO verdict.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/gauntlet/skills/gauntlet/SKILL.md
+++ b/plugins/gauntlet/skills/gauntlet/SKILL.md
@@ -260,6 +260,17 @@ per admission round 1): for every claim of the form "verified/tested/passes",
 check the cited oracle actually exercises the asserted behavior — a mocked
 dependency, a test that can't fail, or a check green for unrelated reasons is
 an inadequate oracle; downgrade the claim's tier to `[H]` and flag it.
+**Oracles FAIL CLOSED (non-negotiable):** a check whose tool is absent, whose
+command errored, or that is structurally incapable of observing what the claim
+asserts yields `[H]`/ERROR — **never** a verified negative. Absence of evidence
+produced by a broken oracle is not evidence of absence. Two mandatory guards:
+(a) **verify the tool exists before trusting its silence** — an empty result from
+a missing binary is indistinguishable from a clean result; (b) **match the oracle
+to the medium** — a line/text oracle (`grep`, `git grep -I`, line-bounds checks)
+cannot read binary content, so it may never clear a claim about a binary
+artifact; enumerate binary blobs and use a binary-aware check. `verify_evidence.py`
+enforces (b) for `[V path:line]` tags by design. Prove a scan can fail (plant a
+positive, watch it fire) before believing it passed.
 
 ### Step 7 — Arbitrate + bounded reinstatement
 

--- a/plugins/gauntlet/skills/gauntlet/scripts/verify_evidence.py
+++ b/plugins/gauntlet/skills/gauntlet/scripts/verify_evidence.py
@@ -70,6 +70,21 @@ def _file_line_count(path: Path) -> int | None:
         return None
 
 
+def _is_binary(path: Path) -> bool | None:
+    """True if the file looks binary, None if it can't be read.
+
+    Same NUL-in-prefix heuristic git uses. Exists because a line-oriented oracle
+    cannot observe the contents of a binary blob: counting newlines in a .pyc
+    yields a number, so a bare line-bounds check would certify [V some.pyc:5] as
+    verified even though "line 5" is meaningless there. See ORACLE ADEQUACY below.
+    """
+    try:
+        with path.open("rb") as fh:
+            return b"\x00" in fh.read(8000)
+    except OSError:
+        return None
+
+
 def verify_tag(path: str, line: int, evidence_root: Path) -> TagResult:
     raw = f"[V {path}:{line}]"
     # Resolve path against evidence root. Treat path as relative if not absolute.
@@ -82,6 +97,22 @@ def verify_tag(path: str, line: int, evidence_root: Path) -> TagResult:
 
     if not resolved.exists() or not resolved.is_file():
         return TagResult(raw=raw, path=path, line=line, status="H", reason="File Not Found")
+
+    # ORACLE ADEQUACY (F13, gauntlet-plugin-publish-2026-07-17): fail CLOSED when the
+    # oracle cannot observe what the tag asserts. A line citation into a binary blob is
+    # not verifiable by a line-oriented check, so it must never be certified [V] —
+    # downgrade to [H] and say why. The precedent: a text-grep scrub certified that a
+    # committed .pyc embedded no local path; it did (marshalled co_filename), and the
+    # grep was structurally incapable of seeing it. An oracle that cannot fail is not
+    # evidence.
+    binary = _is_binary(resolved)
+    if binary is None:
+        return TagResult(raw=raw, path=path, line=line, status="H", reason="File Not Readable")
+    if binary:
+        return TagResult(
+            raw=raw, path=path, line=line, status="H",
+            reason="Binary File - line citation not verifiable by a text oracle",
+        )
 
     if line < 1:
         return TagResult(raw=raw, path=path, line=line, status="H", reason="Line Out of Bounds")

--- a/plugins/gauntlet/skills/gauntlet/tests/run_tests.py
+++ b/plugins/gauntlet/skills/gauntlet/tests/run_tests.py
@@ -68,7 +68,7 @@ def main():
          {"subject": "anything", "axis": "fixed", "depth": "quick", "domains": ["infra"], "risk_classes": []},
          lambda r: r["selection"]["judge"] == "pragmatic-judge"),
         ("mutex pair never co-selected without contrast",
-         {"subject": "cloud sovereignty tradeoff for self-hosted services", "axis": "open", "depth": "max",
+         {"subject": "cloud sovereignty tradeoff for homelab services", "axis": "open", "depth": "max",
           "domains": ["cloud", "sovereignty", "self-hosting", "infra"], "risk_classes": []},
          lambda r: sum(1 for e in r["selection"]["evaluators"]
                        if e["id"] in ("cloud-native-purist", "local-first-survivalist")) <= 1),
@@ -122,6 +122,12 @@ def main():
     except AssertionError as e:
         print(f"[FAIL] consult_packet: {e}")
         failures.append("consult_packet")
+
+    try:
+        test_verify_evidence_fails_closed_on_binary()
+    except AssertionError as e:
+        print(f"[FAIL] verify_evidence fail-closed: {e}")
+        failures.append("verify_evidence-fail-closed")
 
     print(f"\n{'ALL PASS' if not failures else 'FAILURES: ' + ', '.join(failures)}")
     return 0 if not failures else 1
@@ -205,6 +211,41 @@ def test_lens_stats_aggregation():
     finally:
         os.unlink(path)
     print("[PASS] lens_stats aggregation + lifecycle threshold flags")
+
+
+def test_verify_evidence_fails_closed_on_binary():
+    """F13 regression (gauntlet-plugin-publish-2026-07-17).
+
+    A [V path:line] tag citing a BINARY file must downgrade to [H]: a line-oriented
+    oracle cannot observe binary content, and before this guard the verifier counted
+    newlines in a .pyc and certified the tag 100% verified. An oracle that cannot fail
+    is not evidence. Also asserts the positive control -- a real text citation still
+    verifies -- so the guard cannot pass by rejecting everything.
+    """
+    import py_compile
+    import tempfile
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import verify_evidence
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        blob = root / "blob.pyc"
+        py_compile.compile(str(ROOT / "scripts" / "select_lenses.py"), cfile=str(blob))
+        text = root / "real.md"
+        text.write_text("line one\nline two\n", encoding="utf-8")
+
+        binary_tag = verify_evidence.verify_tag("blob.pyc", 5, root)
+        assert binary_tag.status == "H", f"binary [V] must fail closed, got {binary_tag.status}"
+        assert "Binary" in binary_tag.reason, f"reason must name the cause, got {binary_tag.reason!r}"
+
+        # positive control: the guard must not have broken ordinary verification
+        text_tag = verify_evidence.verify_tag("real.md", 1, root)
+        assert text_tag.status == "V", f"text [V] must still verify, got {text_tag.status}"
+
+        missing = verify_evidence.verify_tag("nope.md", 1, root)
+        assert missing.status == "H"
+    print("[PASS] verify_evidence fails closed on binary [V] tags (F13 regression)")
+
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
The gauntlet's own publish review (PR #1) found that the run's verification step had produced a **false verified-negative**: a text-grep scrub certified that a committed `.pyc` embedded no local filesystem path. It did — a marshalled `co_filename` — and the scrub shelled out to `strings`, which wasn't installed, so empty output read as "clean".

That was a process failure. This PR fixes the **mechanized** version of the same defect, which was real and live in the shipped code:

`verify_evidence.py` counted newlines in *any* file, so a tag like `[V blob.pyc:5]` — a line citation into a binary blob, where "line 5" is meaningless — was certified **100% verified**. An oracle that cannot observe the claim was returning a pass.

**Changes**
- `scripts/verify_evidence.py` — `[V path:line]` citing a binary file (NUL-in-prefix, same heuristic git uses) downgrades to `[H]` naming the cause; unreadable files fail closed rather than silently.
- `SKILL.md` Step 6 — new binding rule: **oracles fail closed.** A check whose tool is absent, whose command errored, or that is structurally incapable of observing what the claim asserts yields `[H]`/ERROR, never a verified negative. Two guards: verify the tool exists before trusting its silence; match the oracle to the medium (a text oracle may never clear a claim about a binary artifact).
- `tests/run_tests.py` — F13 regression covering the binary tag, plus a **positive control** (a real text citation must still verify, so the guard can't pass by rejecting everything). Validated by mutation: removing the guard makes the test fail with `binary [V] must fail closed, got V`.

Kept byte-identical with the private fleet copy this skill is extracted from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTqwPfm1LLbTbVQ8aoZ3q7