### PR TITLE
Make the skills harness-agnostic — usable by any agentic coding process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # epistemic-skills
 
-Epistemic-discipline skills for [Claude Code](https://claude.com/claude-code) — how an agent **knows** things before, during, and after work.
+Epistemic-discipline skills for agentic coding — how an agent **knows** things before, during, and after work.
 
-Most public skill collections cover the *workflow* layer: test-driven development, systematic debugging, plan writing (see [superpowers](https://github.com/obra/superpowers), which these skills are designed to compose with). This collection covers the layer underneath: the disciplines that keep an agent's claims tethered to evidence and its effort aimed at the real target.
+**Harness-agnostic.** The skills are plain [Agent Skills](https://agentskills.io/specification) (`SKILL.md` + supporting files) describing *methods*, not any one tool's mechanics. They run in any harness that can load a skill or a context file — Claude Code, Codex, Cursor, Gemini, or your own agent loop. Where a step needs a runtime primitive (concurrent sub-agents, a structured-output schema, an MCP tool), the skill states the **contract** and points at a labeled *reference implementation* for one harness; other harnesses meet the same contract with their own primitives. See [Using these in any harness](#using-these-in-any-harness).
+
+Most skill collections cover the *workflow* layer: test-driven development, systematic debugging, plan writing (see [superpowers](https://github.com/obra/superpowers), which these compose with). This collection covers the layer underneath: the disciplines that keep an agent's claims tethered to evidence and its effort aimed at the real target.
 
 **Start with `using-epistemic-skills`** — the router. It answers *which* of these applies to a given task, in *what order*, and how each one's output feeds the next. The five below are the disciplines it routes to; install the router plus whichever ones you want.
 
@@ -33,6 +35,8 @@ Most tasks fire zero or one. The router's value is the case where more than one 
 
 ## Install
 
+### Claude Code (plugin marketplace)
+
 ```
 /plugin marketplace add ZMS-Labs/epistemic-skills
 /plugin install using-epistemic-skills@epistemic-skills
@@ -44,6 +48,34 @@ Most tasks fire zero or one. The router's value is the case where more than one 
 ```
 
 Each skill is a separate plugin — install only what you want.
+
+### Using these in any harness
+
+The skills are just files. In this repo each lives at
+`plugins/<name>/skills/<name>/` — a `SKILL.md` plus any references, scripts, and
+role-agent definitions. That layout follows the [Agent Skills spec](https://agentskills.io/specification),
+so any harness that reads skills or context files can use them:
+
+- **Point your agent at the `SKILL.md`.** Its frontmatter `description` is the trigger
+  ("use when…"); the body is the method. Load it as a skill, an `AGENTS.md`/`GEMINI.md`
+  include, a Cursor rule, or plain context.
+- **Meet the contract, not the tool.** A few skills need a runtime primitive. Each states
+  the harness-agnostic contract and labels its Claude Code implementation as a *reference*:
+  - **gauntlet** Step 5 wants *concurrent, context-isolated role-agents behind a barrier*.
+    Any parallel-subagent primitive works; with none, use the documented degrade fallback
+    (sequential isolated calls). Role-agent definitions are in each plugin's `agents/`
+    directory — register them however your harness registers agents, or inline the persona
+    text if it has no agent concept.
+  - **evidence-locked-uat** wants the *actor / blinded-verifier / deterministic-judge*
+    roles kept in separate contexts — same subagent story.
+  - **evidence-research** needs the Consensus and/or Scite tools (MCP); identify them by
+    server, not by any harness's tool-naming. It degrades explicitly when one is absent.
+  - **applying-formal-rigor** and **blindspot-pass** are pure method — no runtime
+    dependency at all.
+- **`using-epistemic-skills`** is the router; read it first to see which skill a task needs
+  and how their outputs chain.
+
+The scripts (`gauntlet/scripts/*.py`) are stdlib-only Python and run anywhere Python does.
 
 ## Design principles
 

--- a/plugins/evidence-locked-uat/.claude-plugin/plugin.json
+++ b/plugins/evidence-locked-uat/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "evidence-locked-uat",
   "description": "User acceptance testing where no agent certifies its own work: separated actor / blinded verifier / deterministic judge roles, per-case evidence packets, and a strict verdict vocabulary that cannot round INCONCLUSIVE up to PASS.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/evidence-locked-uat/skills/evidence-locked-uat/SKILL.md
+++ b/plugins/evidence-locked-uat/skills/evidence-locked-uat/SKILL.md
@@ -34,8 +34,11 @@ URL), STOP and report `BLOCKED_ENVIRONMENT` — do not substitute code reading f
 
 ## Step 2 — Run the Workflow
 
-Read `references/workflow-template.mjs` and invoke the Workflow tool with its content as
-`script` and:
+Orchestrate the roles as concurrent, context-isolated sub-agents behind a barrier — the
+separation of actor / verifier / judge is the mechanism, so they must not share context.
+`references/workflow-template.mjs` is a Claude Code reference implementation (invoke the
+Workflow tool with its content as `script`); other harnesses meet the same contract with
+their own subagent primitive. Parameters:
 
 ```json
 {

--- a/plugins/evidence-locked-uat/skills/evidence-locked-uat/references/workflow-template.mjs
+++ b/plugins/evidence-locked-uat/skills/evidence-locked-uat/references/workflow-template.mjs
@@ -1,3 +1,6 @@
+// CLAUDE CODE REFERENCE IMPLEMENTATION of the evidence-locked-UAT role separation
+// (actor / blinded verifier / deterministic judge as concurrent isolated sub-agents).
+// Other harnesses meet the same contract with their own subagent primitive.
 export const meta = {
   name: 'evidence-locked-uat',
   description: 'Evidence-locked UAT: compile contracts, human-mode actor executes, blinded verifier judges, deterministic gate',

--- a/plugins/evidence-research/.claude-plugin/plugin.json
+++ b/plugins/evidence-research/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "evidence-research",
   "description": "Establish a verifiable scholarly record with two independent engines: Consensus discovers what the literature says, Scite interrogates how each finding was received (supporting/contrasting citations, retractions).",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/evidence-research/skills/evidence-research/SKILL.md
+++ b/plugins/evidence-research/skills/evidence-research/SKILL.md
@@ -33,9 +33,9 @@ skill prevents is citing a refuted or retracted paper as support.**
 ## Non-negotiable boundaries (inherited and binding)
 
 - This skill is the **mandatory prerequisite before every scholarly-connector
-  tool call** — every Consensus variant (`mcp__claude_ai_Consensus__search`,
-  `consensus_search`, `consensus_fetch`, …) **and every Scite variant**
-  (`mcp__scite__*` or any tool whose server is api.scite.ai). No direct-call
+  tool call** — every Consensus tool and every Scite tool, however your harness
+  names them (e.g. in Claude Code, `mcp__claude_ai_Consensus__search` and
+  `mcp__scite__*`; identify them by server — the Consensus MCP, and api.scite.ai). No direct-call
   exception: a trivial lookup, a known DOI, or a single fetch still requires
   this skill first. If a call is about to happen and this skill is not active,
   stop, load it, then continue.
@@ -104,8 +104,9 @@ connector rules) warrant. Record every query, filters, counts, IDs. `Top N of
 M` is a plan cap, not scarcity evidence.
 
 ### 4. Interrogate (Scite leads) — the reception pass
-**Harness note (2026-07-17, see reference/scite-profile.md):** the Claude
-Code Scite MCP returns slim records only — no inline tallies or citation
+**Harness note (observed in Claude Code, 2026-07-17, see reference/scite-profile.md;
+your harness may differ — the live-schema rule above governs):** that Scite MCP returns
+slim records only — no inline tallies or citation
 contexts. The reception pass there runs at **filter level**: retraction/
 notice checks via `has_retraction`/`has_concern` membership tests, reception
 signal via `contrasting_from`/`supporting_from` threshold tests. Record

--- a/plugins/gauntlet/.claude-plugin/plugin.json
+++ b/plugins/gauntlet/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gauntlet",
   "description": "Consolidated adversarial-review staple: multi-lens panel review of a frozen subject with falsifier discipline, mechanical evidence verification, a 102-lens registry with deterministic selection, and a computed GO/CONDITIONAL/NO-GO verdict.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/gauntlet/skills/gauntlet/SKILL.md
+++ b/plugins/gauntlet/skills/gauntlet/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: gauntlet
-description: The consolidated adversarial-review staple. Auto-fires (triage-gated) at high-stakes, irreversible, one-way-door, or high-blast-radius decision points in the superpowers workflow, and on explicit request ("gauntlet", "stress-test this", "sovereign gauntlet", "red-team-gauntlet", "deep-mode review", "GO/NO-GO review"). Fuses Sovereign-Gauntlet evidence-verified lens review with DeepReason conjecture→falsify→reinstate mechanics and a computed GO/CONDITIONAL/NO-GO verdict. Use before approving architecture/design (during brainstorming approval), before writing-plans on risky steps, at finishing-a-development-branch / pre-merge for irreversible-infra or security changes, and as a verification-before-completion escalation for high-stakes hard-to-verify claims. Do NOT use for reversible low-stakes work, lookups, ordinary code review, or deterministic test-failure triage.
+description: The consolidated adversarial-review staple. Auto-fires (triage-gated) at high-stakes, irreversible, one-way-door, or high-blast-radius decision points in your development workflow, and on explicit request ("gauntlet", "stress-test this", "sovereign gauntlet", "red-team-gauntlet", "deep-mode review", "GO/NO-GO review"). Fuses Sovereign-Gauntlet evidence-verified lens review with DeepReason conjecture→falsify→reinstate mechanics and a computed GO/CONDITIONAL/NO-GO verdict. Use before approving architecture/design (during brainstorming approval), before writing-plans on risky steps, at finishing-a-development-branch / pre-merge for irreversible-infra or security changes, and as a verification-before-completion escalation for high-stakes hard-to-verify claims. Do NOT use for reversible low-stakes work, lookups, ordinary code review, or deterministic test-failure triage.
 ---
 
 # The Gauntlet — consolidated adversarial-review staple
 
-The fleet's standing **adversarial-review reflex**. One staple with a depth
+A standing **adversarial-review reflex**. One staple with a depth
 dial, fusing three lineages into one:
 
 - **Sovereign-Gauntlet** discipline — machine-readable lens registry
@@ -23,7 +23,7 @@ dial, fusing three lineages into one:
 
 > **Provenance:** merged from a 3-agent bake-off (2026-07-07) — Cursor's
 > auto-firing MCP-wired skill as the spine, Codex's durable-plugin + labeled
-> docket-modes + role-boundary discipline, Claude's consolidation + phased
+> docket-modes + role-boundary discipline, a consolidation pass + phased
 > self-measured roadmap.
 
 ## Relationship to the other gates (READ FIRST)
@@ -40,7 +40,8 @@ red-team gate, override P1/P2 semantics, or convert hypotheses into facts.
 
 ## Auto-fire discipline (staple, not nag)
 
-`using-superpowers` makes this self-suggest. It **fires on a blast-radius
+A skill-triggering harness (e.g. superpowers' `using-superpowers`) makes this
+self-suggest. It **fires on a blast-radius
 trigger**, then Step-2 triage decides whether to run the full engine:
 
 - **Triggers (consider firing):** irreversible / one-way-door; infra-class
@@ -212,38 +213,43 @@ The **judge seat must use a different model family than the lenses** when
 configurable. Show the panel for operator sign-off when they are in the loop;
 in autonomous flow, select without blocking.
 
-### Step 5 — Independent lens passes (STANDARD: Workflow + role-agents)
+### Step 5 — Independent lens passes (STANDARD: concurrent isolated role-agents)
 
-**Standard method (depth ≥ standard) — see `reference/execution-model.md`:**
-orchestrate the panel as a **dynamic Workflow** (`assets/gauntlet-workflow.template.js`)
-that fans out the selected lenses with a **barrier before arbitration**, and
-dispatch each lens as a **predefined role-agent** (`gauntlet-adversary` /
-`-constructive` / `-metatextual`), NOT a fresh general-purpose agent. **Agent-type
-resolution:** these definitions live in this skill's sibling `agents/` directory. Some
-harnesses namespace plugin-provided agents (`gauntlet:gauntlet-adversary`); if the bare
-name does not resolve, try the namespaced form, and if neither registers, say so and use
-the degrade fallback below — never silently substitute a general-purpose agent, which
-drops the falsifier contract and evidence tiers the role prompt carries. Dispatch
-the **shadow-seat lens** in the same fan-out as the core panel — same contract,
-same barrier; skipping it starves the probation lifecycle of data. Its report is
-withheld from the arbitrator (shadow semantics, Step 4). The role
-agent carries the base discipline (falsifier contract, `[V]`/`[I]`/`[H]` evidence
-tiers, verbalized sampling) in its system prompt; the roster card is injected as
-`{{PERSONA_SPEC}}`. Structured schemas force the `finding-set@1` contract —
-findings with no structurally-observable falsifier (method + threshold +
-timeframe) are rejected at the tool layer. The Workflow journal
-is the append-only replayable record and `budget.spent()` is the meter (two
-DeepReason disciplines, delivered natively).
+**The contract (harness-agnostic).** Run the selected lenses as **concurrent,
+context-isolated sub-agent invocations behind a barrier before arbitration**, each
+dispatched as a **predefined role-agent** (adversary / constructive / metatextual),
+NOT a fresh general-purpose agent. The role agent carries the base discipline
+(falsifier contract, `[V]`/`[I]`/`[H]` evidence tiers, verbalized sampling) in its
+system prompt; the roster card is injected as `{{PERSONA_SPEC}}`. Findings with no
+structurally-observable falsifier (method + threshold + timeframe) are rejected —
+enforce this with a structured-output schema (`finding-set@1`) if your harness has one,
+by explicit instruction otherwise. Keep an append-only record of the run and a token/step
+meter. Also dispatch the **shadow-seat lens** in the same fan-out (same contract, same
+barrier; skipping it starves the probation lifecycle) — its report is withheld from the
+arbitrator (shadow semantics, Step 4).
 
-**Independence is the value — never make the lenses a team.** They must not see
-each other's findings before arbitration; the Workflow `parallel()` barrier
-keeps them concurrent + isolated. (Agent teams are allowed ONLY at Step-7
-bounded reinstatement.)
+**Reference implementation (one harness).** In Claude Code this is a dynamic Workflow
+(`assets/gauntlet-workflow.template.js`, `reference/execution-model.md`): `parallel()`
+gives the isolation barrier, the journal is the replayable record, `budget.spent()` is the
+meter, and structured schemas enforce the falsifier contract at the tool layer. Other
+harnesses meet the same contract with their own primitives (a parallel-subagent API, a
+task pool, or — worst case — the degrade fallback below).
 
-**Degrade fallback (`orchestration: manual-degraded`, disclose loudly):** when
-Workflow is unavailable/unauthorized, consecutive `Agent` calls with strict
-per-lens context partition — still the role-agents, still the falsifier
-contract. Save reports to `reports/<lens>.md`.
+**Agent-type resolution.** The role-agent definitions live in the `agents/` directory
+(at the plugin/skill root, where your harness registers them). Some harnesses namespace
+them (`gauntlet:gauntlet-adversary`); if the bare name does not resolve, try the
+namespaced form, and if neither registers, **say so and use the degrade fallback** — never
+silently substitute a general-purpose agent, which drops the falsifier contract and
+evidence tiers the role prompt carries.
+
+**Independence is the value — never make the lenses a team.** They must not see each
+other's findings before arbitration; the barrier keeps them concurrent + isolated. (Agent
+teams are allowed ONLY at Step-7 bounded reinstatement.)
+
+**Degrade fallback (`orchestration: manual-degraded`, disclose loudly):** when no
+concurrent-subagent primitive is available, run consecutive isolated agent calls with
+strict per-lens context partition — still the role-agents, still the falsifier contract.
+Save reports to `reports/<lens>.md`.
 
 ### Step 6 — Mechanical criticism
 
@@ -296,10 +302,10 @@ ruling — no open-ended cycles. Calibration rulings (disagreement with a
 
 **When:** `max` depth OR a one-way-door / irreversible risk class — AND only with
 operator authorization (it needs a signed-in browser; never silent, never on the
-autonomous path). Skip otherwise. Rationale: Step 7's arbitrator is a Claude
-agent, so the highest-stakes verdicts lack a cross-*family* check; an independent
-GPT-5.6 Pro read supplies the grader-family independence the eval program treats
-as the gold standard for a certified result.
+autonomous path). Skip otherwise. Rationale: Step 7's arbitrator is a
+same-model-family agent, so the highest-stakes verdicts lack a cross-*family* check; an
+independent read from a different model family supplies the grader-family independence the
+eval program treats as the gold standard for a certified result.
 
 **How (baked in — `scripts/consult_packet.py`):**
 1. `python scripts/consult_packet.py build --input run.json --stub resp.json` assembles a
@@ -381,9 +387,9 @@ it **measures cost-positive** on the battery. Full map: `reference/roadmap.md`.
 
 ## Resources
 
-- **Execution model (STANDARD): `reference/execution-model.md`** — Workflow
-  orchestration + predefined role-agents; the required way to run the panel at
-  depth ≥ standard.
+- **Execution model (STANDARD): `reference/execution-model.md`** — the orchestration
+  contract (concurrent isolated role-agents + barrier) and a Claude Code reference
+  implementation; the required way to run the panel at depth ≥ standard.
 - Panel Workflow template: `assets/gauntlet-workflow.template.js`
 - Role agents: `gauntlet-{adversary,constructive,metatextual,arbitrator}` — definitions in the sibling `agents/` directory (plugin root when installed as a plugin, so the harness registers them)
 - Deep-mode MCP protocol: `reference/deep-mode-mcp.md`

--- a/plugins/gauntlet/skills/gauntlet/assets/gauntlet-workflow.template.js
+++ b/plugins/gauntlet/skills/gauntlet/assets/gauntlet-workflow.template.js
@@ -1,3 +1,6 @@
+// Gauntlet panel orchestration — CLAUDE CODE REFERENCE IMPLEMENTATION of the
+// harness-agnostic Step-5 contract (concurrent isolated role-agents + barrier).
+// Other harnesses meet the same contract with their own subagent primitive.
 // Gauntlet panel orchestration — the STANDARD execution model (Phase 0.6).
 // generate_options (open axis) -> deterministic fan-out -> barrier -> mechanical
 // criticism -> arbitrate -> verdict. Pass the frozen dossier + the selection made by

--- a/plugins/gauntlet/skills/gauntlet/reference/execution-model.md
+++ b/plugins/gauntlet/skills/gauntlet/reference/execution-model.md
@@ -7,6 +7,13 @@
 
 ## Two decisions, now standard
 
+> **Scope.** This document is the **Claude Code reference implementation** of the
+> harness-agnostic Step-5 contract (concurrent, context-isolated role-agents behind a
+> barrier). The *contract* is what binds; the Workflow-tool specifics below are one way to
+> meet it. On a harness without a parallel-subagent primitive, use the degrade fallback
+> (consecutive isolated agent calls) — the isolation and falsifier discipline are the
+> invariants, not the Workflow API.
+
 ### 1. Orchestrate the panel as a dynamic Workflow (not consecutive subagents)
 
 The panel is a deterministic **fan-out → barrier → mechanical-criticism →

--- a/plugins/gauntlet/skills/gauntlet/runs/README.md
+++ b/plugins/gauntlet/skills/gauntlet/runs/README.md
@@ -9,7 +9,7 @@ Step 8, not optional.
 
 Aggregate + threshold check: `python scripts/lens_stats.py` (add `--json` for machine
 output). This ledger lives in the durable repo (commit it with the run), never only in
-the `~/.claude/skills` cache.
+the deployed skill cache (`~/.claude/skills` or your harness's equivalent).
 
 ## Record schema (one line per run)
 

--- a/plugins/using-epistemic-skills/.claude-plugin/plugin.json
+++ b/plugins/using-epistemic-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "using-epistemic-skills",
   "description": "Entry point and router for the epistemic-skills collection: which discipline applies to a task, in what order, and how each one's output feeds the next.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": { "name": "ZMS Labs" }
 }

--- a/plugins/using-epistemic-skills/skills/using-epistemic-skills/SKILL.md
+++ b/plugins/using-epistemic-skills/skills/using-epistemic-skills/SKILL.md
@@ -6,9 +6,9 @@ description: Entry point and router for the epistemic-skills collection — read
 # Using Epistemic Skills — the router
 
 These five skills are one system: **how an agent knows things** before, during, and after
-work. Superpowers (if you have it) is the *workflow* layer — brainstorming, TDD,
-systematic-debugging, writing-plans, verification-before-completion. This collection is the
-*epistemics* layer underneath it: the disciplines that keep every claim tethered to
+work. A **workflow-skill layer** (such as [superpowers](https://github.com/obra/superpowers)) —
+brainstorming, TDD, systematic-debugging, plan-writing, verification-before-completion — covers
+*how you do* the work. This collection is the *epistemics* layer underneath it: the disciplines that keep every claim tethered to
 evidence and every effort aimed at the real target. This skill is the map; it routes you to
 the right member and tells you how they chain. **It never does the work itself — always read
 the skill it points you to.**
@@ -90,10 +90,11 @@ resemblance:
    actor never judges its own work; the highest-stakes verdicts want a different-family or
    deterministic judge.
 
-## Composition with superpowers
+## Composition with a workflow-skill layer
 
-If both are installed, the epistemic skills **interleave** with the workflow skills rather
-than replacing them:
+If you also run a workflow-skill layer (such as superpowers), the epistemic skills
+**interleave** with the workflow skills rather than replacing them (skill names below are
+superpowers' — map them to your layer's equivalents):
 
 - **blindspot-pass** runs *before* `brainstorming` — recon the territory, then design.
 - **applying-formal-rigor** runs *inside* `brainstorming` / design — derive the choice.


### PR DESCRIPTION
The disciplines never depended on Claude — the *wording* did (Workflow tool, `Agent` dispatch, MCP tool names, `using-superpowers`, "Claude agent"). This rewrites the content so the skills read for **any** agentic harness — Codex, Cursor, Gemini, or a custom loop — with Claude Code kept as one clearly-labeled *reference implementation* rather than the assumed runtime.

**Contract, not tool.** Where a skill needs a runtime primitive, it now states the harness-agnostic **contract** and points at a labeled reference implementation:
- **gauntlet** Step 5 → *concurrent, context-isolated role-agents behind a barrier*. The Workflow-tool version (`execution-model.md`, `gauntlet-workflow.template.js`) is labeled "Claude Code reference implementation"; other harnesses use their own parallel-subagent primitive, or the documented degrade fallback.
- **evidence-locked-uat** → *actor / blinded-verifier / deterministic-judge in separate contexts*; the `.mjs` is a labeled reference impl.
- **evidence-research** → identify the Consensus/Scite tools *by server*, not by any harness's tool-naming; already degrades explicitly when one is absent.
- **applying-formal-rigor**, **blindspot-pass** → pure method, no runtime dependency.

**README** now opens harness-agnostic, adds a **"Using these in any harness"** section (point your agent at the `SKILL.md`; meet the contract; register the `agents/` however your harness does), and splits Install into a Claude Code marketplace block + generic file-based usage. The skills follow the [Agent Skills spec](https://agentskills.io/specification).

**Kept (legitimately):** the Shihipar essay citation, the UAT standard's explicitly multi-harness audience line ("Claude Code, Codex, Cursor, Gemini…"), and the observed-harness Scite/Consensus profiles — now labeled as one harness's observation, governed by the skill's live-schema-wins rule.

Versions: gauntlet 1.3.0; using-epistemic-skills / evidence-research / evidence-locked-uat 1.1.0. Scrub clean (63 files); selector suite green; marketplace valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTqwPfm1LLbTbVQ8aoZ3q7