### PR TITLE
DCO negative control (expected failure)

### DIFF
--- a/docs/release/DCO-NEGATIVE-CONTROL.tmp.md
+++ b/docs/release/DCO-NEGATIVE-CONTROL.tmp.md
@@ -1,0 +1,3 @@
+# DCO negative control
+
+This temporary file exists only to prove that the live GitHub DCO check rejects an unsigned commit. The pull request will be closed without merging and the branch removed after the failure is recorded.


### PR DESCRIPTION
Expected negative control: the DCO check must fail because commit 88ac20e intentionally has no Signed-off-by trailer. This PR will not be merged.