### PR TITLE
feat: add Kimi Code plugin manifest

### DIFF
--- a/.kimi-plugin/marketplace.json
+++ b/.kimi-plugin/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "version": "2",
+  "plugins": [
+    {
+      "id": "epistemic-skills",
+      "displayName": "Epistemic Skills",
+      "source": "https://github.com/ZMS-Labs/epistemic-skills"
+    }
+  ]
+}

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "epistemic-skills",
+  "version": "2.3.1",
+  "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-locked UAT, and multi-lens adversarial review.",
+  "author": {
+    "name": "ZMS Labs",
+    "url": "https://github.com/ZMS-Labs"
+  },
+  "homepage": "https://github.com/ZMS-Labs/epistemic-skills",
+  "license": "GPL-3.0-or-later",
+  "keywords": [
+    "agent-skills",
+    "epistemics",
+    "formal-rigor",
+    "adversarial-review",
+    "uat"
+  ],
+  "skills": "./plugins/epistemic-skills/skills/",
+  "skillInstructions": "Kimi Code tool mapping for Epistemic Skills:\n\n- When a skill asks the user a question, asks for a choice, or presents multiple-choice options, call Kimi Code's `AskUserQuestion` tool. Provide 1 question with 2-4 concrete options; put the recommended option first and suffix its label with `(Recommended)`. Do not render choices as plain assistant text unless `AskUserQuestion` is unavailable or the session is in auto permission mode.\n- When a skill refers to `TodoWrite` or a todo list, use Kimi Code's `TodoList` tool.\n- When a skill dispatches subagents or role agents — gauntlet Step 5 role panel, evidence-locked-uat actor / blinded verifier / deterministic judge — use Kimi Code's `Agent` tool. Do not pass `general-purpose` as `subagent_type`. Use `coder` for implementation and review roles, `explore` for read-only investigation, and `plan` for read-only design. Paste the full role definition from this plugin's `agents/<role>.md` into the subagent prompt; each role agent is a separate `Agent` call so contexts stay isolated. Keep dependent role calls sequential; use parallel or background `Agent` calls only for roles that are independent by design.\n- When a skill refers to the `Skill` tool, use Kimi Code's native `Skill` tool.\n- Use Kimi Code's `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `FetchURL`, and `WebSearch` tools by their actual exposed names. Search file contents with `Grep`; find files by path or pattern with `Glob`.\n- Run the gauntlet helper scripts (`skills/gauntlet/scripts/*.py`, stdlib-only) with `python` via `Bash`.",
+  "interface": {
+    "displayName": "Epistemic Skills",
+    "shortDescription": "Evidence-grounded methods for agentic work",
+    "longDescription": "Six composable disciplines for reconnaissance, formal reasoning, scholarly evidence, adversarial review, and evidence-locked acceptance testing.",
+    "developerName": "ZMS Labs",
+    "websiteURL": "https://github.com/ZMS-Labs/epistemic-skills"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Epistemic-discipline skills for agentic coding — how an agent **knows** things
 
 **Version 2.3.1.** **License: [GPL-3.0-or-later](LICENSE).**
 
-**Harness-agnostic.** The skills are plain [Agent Skills](https://agentskills.io/specification) (`SKILL.md` + supporting files) describing *methods*, not any one tool's mechanics. They run in any harness that can load a skill or a context file — Claude Code, Codex, Cursor, Gemini CLI, Antigravity, or your own agent loop. Where a step needs a runtime primitive (concurrent sub-agents, a structured-output schema, an MCP tool), the skill states the **contract** and points at a labeled *reference implementation* for one harness; other harnesses meet the same contract with their own primitives. See [Using these in any harness](#using-these-in-any-harness).
+**Harness-agnostic.** The skills are plain [Agent Skills](https://agentskills.io/specification) (`SKILL.md` + supporting files) describing *methods*, not any one tool's mechanics. They run in any harness that can load a skill or a context file — Claude Code, Codex, Cursor, Gemini CLI, Antigravity, Kimi Code, or your own agent loop. Where a step needs a runtime primitive (concurrent sub-agents, a structured-output schema, an MCP tool), the skill states the **contract** and points at a labeled *reference implementation* for one harness; other harnesses meet the same contract with their own primitives. See [Using these in any harness](#using-these-in-any-harness).
 
 Most skill collections cover the *workflow* layer: test-driven development, systematic debugging, plan writing (see [superpowers](https://github.com/obra/superpowers), which these compose with). This collection covers the layer underneath: the disciplines that keep an agent's claims tethered to evidence and its effort aimed at the real target.
 
@@ -52,6 +52,7 @@ epistemic-skills/                         # repo root
 ├── .cursor-plugin/plugin.json            # Cursor whole-repo plugin
 ├── .cursor-plugin/marketplace.json       # Cursor team-marketplace index
 ├── gemini-extension.json + GEMINI.md     # Gemini CLI extension
+├── .kimi-plugin/plugin.json              # Kimi Code plugin (points at the same skills tree)
 └── plugin.json                           # Antigravity native plugin
 ```
 
@@ -136,6 +137,22 @@ agy plugin validate /path/to/epistemic-skills
 ```
 
 Prefer **one** of: native `agy plugin install`, Gemini extension link, or `agy plugin import gemini` — not several copies.
+
+### Kimi Code
+
+```text
+/plugins install https://github.com/ZMS-Labs/epistemic-skills
+# local dev, from a clone:
+/plugins install /path/to/epistemic-skills
+```
+
+Run `/reload` or start a new session after install. Entrypoint: root `.kimi-plugin/plugin.json`, which points at the same canonical `plugins/epistemic-skills/skills/` tree; its `skillInstructions` carries the Kimi tool mapping (gauntlet role agents and the UAT actor/verifier/judge dispatch through the `Agent` tool in isolated contexts). If the plugin manager is unavailable, junction the skills into the user skills directory instead — pick exactly one mechanism:
+
+```powershell
+Get-ChildItem .\plugins\epistemic-skills\skills -Directory | ForEach-Object {
+  New-Item -ItemType Junction -Path "$env:USERPROFILE\.kimi-code\skills\$($_.Name)" -Target $_.FullName
+}
+```
 
 ### Using these in any harness
 

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "epistemic-skills",
+  "version": "2.3.1",
+  "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-locked UAT, and multi-lens adversarial review.",
+  "author": {
+    "name": "ZMS Labs",
+    "url": "https://github.com/ZMS-Labs"
+  },
+  "homepage": "https://github.com/ZMS-Labs/epistemic-skills",
+  "license": "GPL-3.0-or-later",
+  "keywords": [
+    "agent-skills",
+    "epistemics",
+    "formal-rigor",
+    "adversarial-review",
+    "uat"
+  ],
+  "skills": "./skills/",
+  "skillInstructions": "Kimi Code tool mapping for Epistemic Skills:\n\n- When a skill asks the user a question, asks for a choice, or presents multiple-choice options, call Kimi Code's `AskUserQuestion` tool. Provide 1 question with 2-4 concrete options; put the recommended option first and suffix its label with `(Recommended)`. Do not render choices as plain assistant text unless `AskUserQuestion` is unavailable or the session is in auto permission mode.\n- When a skill refers to `TodoWrite` or a todo list, use Kimi Code's `TodoList` tool.\n- When a skill dispatches subagents or role agents \u00e2\u20ac\u201d gauntlet Step 5 role panel, evidence-locked-uat actor / blinded verifier / deterministic judge \u00e2\u20ac\u201d use Kimi Code's `Agent` tool. Do not pass `general-purpose` as `subagent_type`. Use `coder` for implementation and review roles, `explore` for read-only investigation, and `plan` for read-only design. Paste the full role definition from this plugin's `agents/<role>.md` into the subagent prompt; each role agent is a separate `Agent` call so contexts stay isolated. Keep dependent role calls sequential; use parallel or background `Agent` calls only for roles that are independent by design.\n- When a skill refers to the `Skill` tool, use Kimi Code's native `Skill` tool.\n- Use Kimi Code's `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `FetchURL`, and `WebSearch` tools by their actual exposed names. Search file contents with `Grep`; find files by path or pattern with `Glob`.\n- Run the gauntlet helper scripts (`skills/gauntlet/scripts/*.py`, stdlib-only) with `python` via `Bash`.",
+  "interface": {
+    "displayName": "Epistemic Skills",
+    "shortDescription": "Evidence-grounded methods for agentic work",
+    "longDescription": "Six composable disciplines for reconnaissance, formal reasoning, scholarly evidence, adversarial review, and evidence-locked acceptance testing.",
+    "developerName": "ZMS Labs",
+    "websiteURL": "https://github.com/ZMS-Labs/epistemic-skills"
+  }
+}


### PR DESCRIPTION
## What

Adds a Kimi Code harness entrypoint so the collection installs natively in Kimi Code, closing the last peer-harness gap (Claude Code, Codex, Cursor, Gemini CLI, Antigravity already covered).

- **`.kimi-plugin/plugin.json`** at repo root (Kimi's manifest lookup location, same as `gemini-extension.json` and the Antigravity `plugin.json`): points at the canonical `plugins/epistemic-skills/skills/` tree — no content fork — and carries `skillInstructions` with the Kimi tool mapping (gauntlet role agents and the evidence-locked-uat actor/verifier/judge dispatch via Kimi's `Agent` tool in isolated contexts; `AskUserQuestion`; `TodoList`; real tool names for Read/Write/Edit/Bash/Grep/Glob/FetchURL/WebSearch).
- **README**: new `### Kimi Code` install section (`/plugins install` from GitHub or a local clone, plus a junction fallback for plugin-manager-less setups), layout-tree entry, and Kimi Code added to the harness list.

## Why

Kimi Code joined the ZMS-Labs peer fleet. Every other harness has a native manifest; Kimi was the gap. Manifest format and install mechanics follow the official docs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html

## Verification

- Manifest parses as valid JSON; `skills` path resolves within the plugin root.
- Live smoke on the operator machine: the six skills junctioned into `~/.kimi-code/skills/` all resolve with valid `name`/`description` frontmatter and are picked up as user-level skills.
- No skill content changed; manifests/docs only.

## Notes

- Exactly-one-mechanism rule applies as with every harness: plugin install OR skills-dir junction, not both (documented in the README section).