### PR TITLE
feat: add Kimi Code plugin adapter

### DIFF
--- a/.kimi-plugin/marketplace.json
+++ b/.kimi-plugin/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "version": "2",
+  "plugins": [
+    {
+      "id": "epistemic-skills",
+      "displayName": "Epistemic Skills",
+      "source": "https://github.com/ZMS-Labs/epistemic-skills"
+    }
+  ]
+}

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "epistemic-skills",
+  "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-locked UAT, and multi-lens adversarial review. Each skill self-triggers by relevance.",
+  "version": "2.3.1",
+  "author": {
+    "name": "ZMS Labs",
+    "url": "https://github.com/ZMS-Labs"
+  },
+  "homepage": "https://github.com/ZMS-Labs/epistemic-skills",
+  "repository": "https://github.com/ZMS-Labs/epistemic-skills",
+  "license": "GPL-3.0-or-later",
+  "keywords": [
+    "agent-skills",
+    "epistemics",
+    "formal-rigor",
+    "adversarial-review",
+    "uat",
+    "blindspot",
+    "evidence"
+  ],
+  "skills": "./plugins/epistemic-skills/skills/",
+  "sessionStart": {
+    "skill": "using-epistemic-skills"
+  },
+  "interface": {
+    "displayName": "Epistemic Skills",
+    "shortDescription": "Evidence-grounded methods for agentic work",
+    "longDescription": "Six composable disciplines for reconnaissance, formal reasoning, scholarly evidence, adversarial review, and evidence-locked acceptance testing.",
+    "developerName": "ZMS Labs",
+    "websiteURL": "https://github.com/ZMS-Labs/epistemic-skills"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Epistemic-discipline skills for agentic coding — how an agent **knows** things
 
 **Version 2.3.1.** **License: [GPL-3.0-or-later](LICENSE).**
 
-**Harness-agnostic.** The skills are plain [Agent Skills](https://agentskills.io/specification) (`SKILL.md` + supporting files) describing *methods*, not any one tool's mechanics. They run in any harness that can load a skill or a context file — Claude Code, Codex, Cursor, Gemini CLI, Antigravity, or your own agent loop. Where a step needs a runtime primitive (concurrent sub-agents, a structured-output schema, an MCP tool), the skill states the **contract** and points at a labeled *reference implementation* for one harness; other harnesses meet the same contract with their own primitives. See [Using these in any harness](#using-these-in-any-harness).
+**Harness-agnostic.** The skills are plain [Agent Skills](https://agentskills.io/specification) (`SKILL.md` + supporting files) describing *methods*, not any one tool's mechanics. They run in any harness that can load a skill or a context file — Claude Code, Codex, Cursor, Gemini CLI, Kimi Code, Antigravity, or your own agent loop. Where a step needs a runtime primitive (concurrent sub-agents, a structured-output schema, an MCP tool), the skill states the **contract** and points at a labeled *reference implementation* for one harness; other harnesses meet the same contract with their own primitives. See [Using these in any harness](#using-these-in-any-harness).
 
 Most skill collections cover the *workflow* layer: test-driven development, systematic debugging, plan writing (see [superpowers](https://github.com/obra/superpowers), which these compose with). This collection covers the layer underneath: the disciplines that keep an agent's claims tethered to evidence and its effort aimed at the real target.
 
@@ -44,13 +44,16 @@ epistemic-skills/                         # repo root
 │   ├── agents/                           # gauntlet role-agents (five)
 │   ├── .claude-plugin/plugin.json
 │   ├── .codex-plugin/plugin.json
-│   └── .cursor-plugin/plugin.json
+│   ├── .cursor-plugin/plugin.json
+│   └── .kimi-plugin/plugin.json
 ├── skills/  → plugins/epistemic-skills/skills/    # symlink (Gemini / root scanners)
 ├── agents/  → plugins/epistemic-skills/agents/    # symlink
 ├── .claude-plugin/marketplace.json
 ├── .agents/plugins/marketplace.json      # Codex marketplace index
 ├── .cursor-plugin/plugin.json            # Cursor whole-repo plugin
 ├── .cursor-plugin/marketplace.json       # Cursor team-marketplace index
+├── .kimi-plugin/plugin.json              # Kimi Code whole-repo plugin
+├── .kimi-plugin/marketplace.json         # Kimi Code custom-marketplace index
 ├── gemini-extension.json + GEMINI.md     # Gemini CLI extension
 └── plugin.json                           # Antigravity native plugin
 ```
@@ -113,6 +116,33 @@ ln -sfn "$(pwd)/plugins/epistemic-skills" ~/.cursor/plugins/local/epistemic-skil
 Then **Developer: Reload Window**. Success check: all six skills under Customize → Skills, and auto-trigger on matching prompts (for example an irreversible / stress-test ask should surface the router or `gauntlet`).
 
 Do **not** also install these skills into `~/.cursor/skills/` while the plugin is loaded.
+
+### Kimi Code
+
+```
+/plugins install https://github.com/ZMS-Labs/epistemic-skills
+/reload
+```
+
+Entrypoints: root `.kimi-plugin/plugin.json` (whole-repo install above) and
+`plugins/epistemic-skills/.kimi-plugin/plugin.json` (subdirectory / local
+installs). Both manifests set `sessionStart.skill: using-epistemic-skills`, so
+the router loads into every new or resumed session and routes non-trivial work
+to the right discipline; the five disciplines still self-trigger only when
+their own `description` matches. Remove the `sessionStart` block if you prefer
+pure self-triggering.
+
+A custom-marketplace index ships at `.kimi-plugin/marketplace.json` for
+`/plugins marketplace <path-or-url>` or `KIMI_CODE_PLUGIN_MARKETPLACE_URL`.
+
+Kimi Code plugin manifests do not register custom agent types; the gauntlet
+runs its role-agents through the replayable materialized-role adapter in
+[`skills/gauntlet/reference/runtime-role-binding.md`](plugins/epistemic-skills/skills/gauntlet/reference/runtime-role-binding.md),
+with sequential isolated calls as the documented degrade for concurrent
+sub-agents.
+
+As with every harness: install exactly one mechanism — the plugin **or**
+`SKILL.md` copies under `~/.kimi-code/skills/`, not both.
 
 ### Gemini CLI
 

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -1,0 +1,32 @@
+{
+  "name": "epistemic-skills",
+  "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-locked UAT, and multi-lens adversarial review. Each skill self-triggers by relevance.",
+  "version": "2.3.1",
+  "author": {
+    "name": "ZMS Labs",
+    "url": "https://github.com/ZMS-Labs"
+  },
+  "homepage": "https://github.com/ZMS-Labs/epistemic-skills",
+  "repository": "https://github.com/ZMS-Labs/epistemic-skills",
+  "license": "GPL-3.0-or-later",
+  "keywords": [
+    "agent-skills",
+    "epistemics",
+    "formal-rigor",
+    "adversarial-review",
+    "uat",
+    "blindspot",
+    "evidence"
+  ],
+  "skills": "./skills/",
+  "sessionStart": {
+    "skill": "using-epistemic-skills"
+  },
+  "interface": {
+    "displayName": "Epistemic Skills",
+    "shortDescription": "Evidence-grounded methods for agentic work",
+    "longDescription": "Six composable disciplines for reconnaissance, formal reasoning, scholarly evidence, adversarial review, and evidence-locked acceptance testing.",
+    "developerName": "ZMS Labs",
+    "websiteURL": "https://github.com/ZMS-Labs/epistemic-skills"
+  }
+}


### PR DESCRIPTION
## What

Adds a [Kimi Code](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html) harness adapter alongside the existing Claude / Codex / Cursor / Gemini / Antigravity ones, following the repo's "one tree of method files; harness-specific manifests only" convention.

## Files

- **`.kimi-plugin/plugin.json`** — whole-repo manifest; enables `/plugins install https://github.com/ZMS-Labs/epistemic-skills`. Mirrors the root `.cursor-plugin/plugin.json` shape, using Kimi's manifest fields (`skills`, `interface`, `sessionStart`).
- **`plugins/epistemic-skills/.kimi-plugin/plugin.json`** — per-plugin manifest for subdirectory/local installs, parallel to `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`.
- **`.kimi-plugin/marketplace.json`** — custom-marketplace index in Kimi's documented format (`version: "2"`, `id` + `source`), for `/plugins marketplace <path-or-url>` / `KIMI_CODE_PLUGIN_MARKETPLACE_URL`.
- **README** — layout entries, a "Kimi Code" install section, and Kimi Code added to the harness list.

## Decisions to review

1. **`sessionStart.skill: "using-epistemic-skills"`** is set in both manifests, so the router loads into every new/resumed session (Kimi's native equivalent of "read the router first"). The five disciplines still self-trigger only by `description`. If you'd rather keep pure self-triggering, dropping that one block is the only change needed.
2. **No role-agent bridge script.** Kimi plugin manifests don't register custom agent types (unsupported fields are ignored with a diagnostic), so the gauntlet falls through to the already-documented materialized-role adapter in `runtime-role-binding.md` — stated in the README section, no new code.
3. No `agents` field copied over from the Cursor manifest, for the same reason.

## Validation

- All three JSON files parse.
- Field set checked against the official plugin-manifest docs: `name` matches `[a-z0-9][a-z0-9_-]{0,63}`, `skills` paths stay within the plugin root, only supported fields used.
- No skill content touched; no per-harness forks.

DCO sign-off included.