### PR TITLE
Fix Helix skill frontmatter YAML

### DIFF
--- a/plugins/epistemic-skills/skills/helix/SKILL.md
+++ b/plugins/epistemic-skills/skills/helix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helix
-description: The tandem entry point when a workflow-skill layer (such as superpowers) runs alongside the epistemic-skills collection — read at the start of any non-trivial task to interleave the two strands: which epistemic discipline fires before, inside, or after each workflow stage (brainstorming, writing-plans, test-driven-development, systematic-debugging, verification-before-completion, finishing-a-development-branch), with the epistemic member first at every stage boundary. Use when both layers are installed and a task is about to begin, when a workflow skill has just fired and you must check its epistemic pair, or when sequencing the two collections is ambiguous. It pairs stages; it never replaces either collection's own router.
+description: "The tandem entry point when a workflow-skill layer (such as superpowers) runs alongside the epistemic-skills collection — read at the start of any non-trivial task to interleave the two strands: which epistemic discipline fires before, inside, or after each workflow stage (brainstorming, writing-plans, test-driven-development, systematic-debugging, verification-before-completion, finishing-a-development-branch), with the epistemic member first at every stage boundary. Use when both layers are installed and a task is about to begin, when a workflow skill has just fired and you must check its epistemic pair, or when sequencing the two collections is ambiguous. It pairs stages; it never replaces either collection's own router."
 ---
 
 # helix — two strands, one axis


### PR DESCRIPTION
## What changed

- quote the `helix` frontmatter description so its embedded colon is valid YAML

## Root cause

The unquoted plain scalar contained `strands: which`, which YAML parsed as a mapping boundary. Codex installed the 2.5.0 plugin but the skill validator could not parse Helix.

## Verification

- reproduced the original `mapping values are not allowed here` validator failure
- Helix passes `quick_validate.py` after the one-line fix
- all eight skills pass `quick_validate.py` in UTF-8 mode
- plugin validation passes
- gauntlet repository suite passes
- `git diff --check` passes
