### PR TITLE
hygiene: router + helix precision repairs (drift audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Most tasks fire zero or one. The router's value is the case where more than one 
 
 | Skill | Role |
 |---|---|
-| **using-epistemic-skills** | **Router** (not a discipline). Routes a task to the right discipline(s), sequences them (recon → design → evidence → gate → verify), and defines handoff contracts. Read it first; it never does the work itself. |
+| **using-epistemic-skills** | **Router** (not a discipline). Routes a task to the right discipline(s), sequences them (recon → decide → [evidence] → contract → gate → prove), and defines handoff contracts. Read it first; it never does the work itself. |
 | **helix** | **Tandem entry point** (not a discipline). When a workflow-skill layer (such as superpowers) runs alongside this collection, helix pairs each workflow stage with its epistemic discipline — before, inside, or after — with the epistemic member first at every boundary. It pairs stages; the two routers keep routing. |
 | **applying-formal-rigor** | Design *and complexity* decisions. Sets a graduate-level formal-theory floor: name the *precise* construct (the exact normal form, the named isolation anomaly, the Master-Theorem case, the Ω lower bound), **derive** the conclusion instead of asserting it, and sweep every relevant lens. Ships a 7-lens theory battery; lens 4 is a full standalone Big-O / complexity analysis. |
 | **blindspot-pass** | The moment *before* work begins. Cheap read-only reconnaissance that surfaces landmines, hidden context, exemplars, and expert questions — then **rewrites the request** so downstream work aims at the territory, not the map. Provenance: Thariq Shihipar (Anthropic), *"A Field Guide to Claude Fable 5: Finding Your Unknowns"* (2026). |

--- a/plugins/epistemic-skills/skills/helix/SKILL.md
+++ b/plugins/epistemic-skills/skills/helix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helix
-description: "Use when both a workflow-skill layer (such as superpowers) and the epistemic-skills collection are installed and a task is about to begin; when a workflow skill (brainstorming, writing-plans, test-driven-development, systematic-debugging, verification-before-completion, finishing-a-development-branch) has just fired and its epistemic pair needs checking; or when sequencing the two collections is ambiguous. Not for single-collection routing (that's using-superpowers / using-epistemic-skills) or trivial, fully-held-context work needing no ceremony."
+description: "Use when both a workflow-skill layer (such as superpowers) and the epistemic-skills collection are installed and a task is about to begin; when a workflow skill (brainstorming, writing-plans, executing-plans, test-driven-development, systematic-debugging, verification-before-completion, finishing-a-development-branch) has just fired and its epistemic pair needs checking; or when sequencing the two collections is ambiguous. Not for single-collection routing (that's using-superpowers / using-epistemic-skills) or trivial, fully-held-context work needing no ceremony."
 ---
 
 # helix — two strands, one axis
@@ -36,37 +36,50 @@ archaeology, and evidence after the verdict is rationalization.
 |---|---|---|
 | task start (non-trivial, unfamiliar territory) | **blindspot-pass** | *before* brainstorming — recon the territory, then design |
 | brainstorming (any ≥2-option design choice) | **applying-formal-rigor** | *inside* — the choice is derived from named theory, not asserted |
-| brainstorming (a premise leans on "research says…") | **evidence-research** | *cross-cutting* — reception-check the literature before the premise bears load |
-| brainstorming approval / writing-plans (irreversible or one-way-door design) | **gauntlet** | *at approval* — freeze the design as the subject; GO/CONDITIONAL/NO-GO before planning on top of it |
-| executing-plans / persistent or long-horizon runs (explicit goal intent only) | **write-goal** | *before* persistent execution — bind the outcome to proof and stop rules |
+| any stage (a premise leans on "research says…", or any scholarly-tool call) | **evidence-research** | *cross-cutting* — reception-check the literature before the premise bears load |
+| brainstorming approval / writing-plans (irreversible or one-way-door design) | **gauntlet** | *at approval* — after the design doc is written and committed (brainstorming step 6), before writing-plans is invoked; freeze the committed design doc as the gauntlet subject |
+| persistent or long-horizon goal-mode runs (explicit goal-authoring intent only — plan execution alone is not intent) | **write-goal** | *before* persistent execution — bind the outcome to proof and stop rules |
+| subagent-driven-development / dispatching-parallel-agents (first dispatch) | **blindspot-pass** | *before* the first dispatch — recon the territory before a wrong premise multiplies across isolated agents |
 | test-driven-development / implementation | (none mandatory) | epistemic disciplines fire only on their own triggers; clean implementation needs no ceremony |
 | systematic-debugging (fix rests on a complexity or correctness claim) | **applying-formal-rigor** | *inside* — "this is O(n log n) now" and "this can't race" are derived, not asserted |
 | verification-before-completion (UI-facing surface) | **evidence-locked-uat** | *is* that skill's UI-facing instance — blinded verifier, never self-certification |
-| finishing-a-development-branch (irreversible / high-blast-radius change) | **gauntlet** | *pre-merge* — the last gate before a commit you can't take back |
+| finishing-a-development-branch (irreversible / high-blast-radius change) | **gauntlet** | *pre-merge* — after the user selects merge or push+PR (finishing-a-development-branch Step 5), before the merge/push executes |
+| receiving-code-review (feedback asserts a design claim or proposes an alternative) | **applying-formal-rigor** | *inside* — derive the claim from named theory before implementing it or pushing back on it |
 | any workflow stage not listed above | *(none mandatory)* | disciplines still fire on their own standalone triggers — e.g. gauntlet's own trigger, not helix, governs a code-review approval |
 
 Positions mean exactly what they say: *before* = the epistemic output is an
 input to the stage; *inside* = the stage pauses at the decision point, runs
 the discipline, and resumes with its verdict; *at approval* / *pre-merge* =
 the stage's exit gate; *cross-cutting* = called at the moment a qualifying
-premise appears, at any stage.
+premise appears, at any stage; *is* = the workflow stage and the discipline
+are the same act for that surface — running the stage under that surface
+condition means running the discipline.
 
 ## Co-fire checklist
 
-When a strand fires, check its pair — in both directions. Make the check auditable: at each
-stage boundary, emit one line in the form `helix-check: <stage> → <pair> → fired|skipped(<reason>)`.
+When a strand fires, check its pair — in both directions. Make the check auditable: emit one
+line per pairing row whose stage fired, in the form `helix-check: <stage> → <pair> →
+fired|skipped(<reason>)` — at each stage boundary *and* at the moment a cross-cutting
+trigger appears. Stages whose row is "(none mandatory)" emit no line — the map row itself
+is the record.
 
 - **A workflow stage just fired.** Ask: does its epistemic pair's own trigger
   match right now? If yes, run it in its position. If no, skip it **and say
   you skipped it** — an unfired pair is a stated decision, not an omission.
 - **brainstorming is starting** → did blindspot-pass run, or was its trigger
-  absent (territory already fully held in context)?
+  absent (its skip gate passed — the gate is defined in blindspot-pass, not here)?
 - **a design choice is being argued** → is "better / cleaner / faster" being
   asserted? That is applying-formal-rigor's trigger.
 - **a plan is about to be approved** → is anything in it irreversible? That
   is gauntlet's trigger, now — before effort is spent building on it.
 - **a persistent goal is being created** → only on explicit goal-authoring
   intent does write-goal fire; length of task alone is not intent.
+- **a fix rests on a complexity or correctness claim** → "this is O(n log n)
+  now" / "this can't race" is applying-formal-rigor's trigger inside
+  systematic-debugging.
+- **subagents are about to be dispatched** → did blindspot-pass run on the
+  brief being fanned out, or did its skip gate pass? A wrong premise in the
+  dispatch is copied into every isolated context.
 - **"it's done" is about to be claimed** → verification-before-completion is
   the stage; if the surface is UI-facing, the stage *is* evidence-locked-uat.
 - **a branch is about to merge** → irreversible or high-blast-radius? gauntlet

--- a/plugins/epistemic-skills/skills/using-epistemic-skills/SKILL.md
+++ b/plugins/epistemic-skills/skills/using-epistemic-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-epistemic-skills
-description: Use when a task might need more than one of blindspot-pass, applying-formal-rigor, evidence-research, write-goal, gauntlet, or evidence-locked-uat, when unsure which one applies, or when sequencing them (recon → decide → [evidence] → contract → gate → prove). Do not use as a substitute for reading the skill it routes to. This is the entry point and router for the epistemic-skills collection.
+description: Use when a task might need more than one of blindspot-pass, applying-formal-rigor, evidence-research, write-goal, gauntlet, or evidence-locked-uat, when unsure which one applies, or when sequencing them (recon → decide → [evidence] → contract → gate → prove). Do not use as a substitute for reading the skill it routes to. This is the entry point and router for the epistemic-skills collection; when a workflow-skill layer (such as superpowers) is also present, helix is the tandem entry point pairing the two.
 ---
 
 # Using Epistemic Skills — the router
@@ -52,6 +52,10 @@ task ──▶│ blindspot-    │─▶│ formal-rigor +   │─▶│ write
 The arc is need-driven, not mandatory: skip any stage whose trigger is absent, and say you
 skipped it. Running a stage on work that doesn't need it is ceremony.
 
+Make the routing decision auditable, like helix's `helix-check` and gauntlet's skip record:
+emit one line in the form `router: fired=[skill] skipped=[skill(trigger-absent)]` — name
+each considered skill and, for every skip, the absent trigger, not an adjective.
+
 ## Routing — which one fires
 
 Match the trigger you can *observe*, not a vibe:
@@ -68,6 +72,9 @@ Match the trigger you can *observe*, not a vibe:
 If **none** match, none fire — this router does not manufacture work. If **two** match, run
 them in arc order (recon → decide → contract → gate → prove) and pass each output to the next per the
 handoff table.
+
+If the routed-to skill is absent or uninstalled in your harness, say so and stop — never
+improvise the discipline inline.
 
 gauntlet and evidence-locked-uat can both fire on the same merge (irreversible infra/security +
 user-facing surface) — gauntlet gates first, evidence-locked-uat proves after, per arc order.


### PR DESCRIPTION
Minimal, targeted drift/hygiene repairs from a precision audit. No redesign, no new features — smallest diffs that fix the cited drift.

**Router (`using-epistemic-skills`)**
- Add a mandated one-line routing record — `router: fired=[skill] skipped=[skill(trigger-absent)]` — mirroring helix's `helix-check` and gauntlet's cited-evidence skip format, so routing decisions are auditable.
- Fail closed when the routed-to skill is absent/uninstalled in the harness: say so and stop; never improvise the discipline inline.
- Frontmatter `description`: name helix as the tandem entry point when a workflow-skill layer is present.

**Helix**
- Pairing map: add the first-dispatch fan-out row (subagent-driven-development / dispatching-parallel-agents → blindspot-pass) — blindspot-pass's own trigger list names multi-agent fan-out; the map omitted it.
- Pin both gauntlet rows to executable moments: *at approval* = after the committed design doc (brainstorming step 6), before writing-plans; *pre-merge* = after the user selects merge or push+PR (finishing-a-development-branch Step 5), before the merge/push executes.
- Add a receiving-code-review row: feedback asserting a design claim or proposing an alternative fires applying-formal-rigor *inside*.
- Re-anchor the write-goal row to explicit goal-authoring intent (plan execution alone is not intent; executing-plans dropped from the stage cell).
- Widen the evidence-research stage cell to `any stage` — matches its *cross-cutting* position and evidence-research's mandatory-prerequisite trigger.
- Position legend: define `*is*` (the stage and the discipline are the same act for that surface).
- Co-fire checklist: add systematic-debugging and dispatch fan-out prompts; point the blindspot-pass skip check at the member skill's own gate instead of restating it here.
- `helix-check` spec: emit per fired pairing row, at stage boundaries *and* at cross-cutting triggers; "(none mandatory)" rows emit no line — the map row is the record.
- Frontmatter `description`: add executing-plans to the enumerated stage list.

**README**
- Reconcile the router row's arc wording with the router's arc nouns: recon → decide → [evidence] → contract → gate → prove.

Note: branch is based on current `origin/main` (6deee81, which includes #13) — main advanced one commit past the 61fbf95 (v2.6.0) baseline the audit cited.