### PR TITLE
hygiene: fix gauntlet doc/template drift to match code and shipped files

### DIFF
--- a/plugins/epistemic-skills/skills/gauntlet/SKILL.md
+++ b/plugins/epistemic-skills/skills/gauntlet/SKILL.md
@@ -175,11 +175,17 @@ python scripts/select_lenses.py --subject subject.json --out prompts/selection.j
 ```
 (plain Python — no Claude Code dependency)
 
-The selector gates by lifecycle/role/axis/contraindications, scores fit +
+The selector gates by lifecycle/role/axis (contraindications are a score
+penalty, not a gate), scores fit +
 uncovered-capability gain + stance diversity − overlap − cost (constrained MMR,
 deterministic ID tie-break), and records a full **replay record** (registry
 sha256, subject vector, scores, exclusions, selected ids@versions) into the run
-directory. **A lens is never selected merely because its domain keyword appears**
+directory. **Honesty note (2026-07-14):** the selector's fit-scoring layer is
+FROZEN — measurement showed no detectable benefit over random fill under the
+same hard constraints (recorded in `scripts/select_lenses.py`). Panel
+composition today is constraint-satisfaction + diversity-maximization, with
+task-fit carried by the hard gates and the domain-specialist seed.
+**A lens is never selected merely because its domain keyword appears**
 — role/status/axis gates run before any scoring. Load full card text only for
 the selected ids.
 
@@ -264,7 +270,9 @@ custom-role registry alone does **not** require degraded orchestration.
 (plain Python — no Claude Code dependency).
 Tiers: `[V path:line]` mechanically verified; `[I <- Vref]` inference — valid
 only while its cited `[V]` anchors verify; `[H]` hypothesis — zero weight at
-arbitration. **Semantic note (2026-07-14):** `[V]` certifies *source anchoring*
+arbitration. Disclosure: the verifier mechanically checks `[V path:line]` tags
+only; `[I]` inference anchors are **spot-checked by the arbitrator**, not
+mechanically verified (see `scripts/verify_evidence.py`). **Semantic note (2026-07-14):** `[V]` certifies *source anchoring*
 (the cited line exists and says this), NOT that the proposition is true — a real
 citation can still support a wrong claim; truth lives in the oracle-adequacy and
 falsifier checks, not the tag. Accepted factual claims require `[V]` or anchored `[I]` → Sovereign
@@ -423,7 +431,8 @@ rigor, measurement bundle) remain designs. Each later piece is integrated only i
 - Registry model, lifecycle, collision + admission policy: `reference/lens-registry.md`
 - Selector: `scripts/select_lenses.py` · Validator: `scripts/validate_roster.py`
   · Renderer: `scripts/render_roster.py` · Tests: `tests/run_tests.py`
-- Behavioral eval battery (designed, NOT run): `evals/`
+- Behavioral eval battery: design not yet shipped in this package (`evals/`
+  currently ships only the arbitrator-certification battery)
 - Evidence verifier: `scripts/verify_evidence.py`
 - Consensus scholarly-evidence boundary: `reference/consensus-integration.md`
 - Full integration roadmap: `reference/roadmap.md`

--- a/plugins/epistemic-skills/skills/gauntlet/assets/synthesis-template.md
+++ b/plugins/epistemic-skills/skills/gauntlet/assets/synthesis-template.md
@@ -7,15 +7,25 @@
 - **Triage:** [passed | skipped — reason]
 - **DeepReason root:** [path to MCP run directory]
 - **Panel composition:** [lens list]
-- **Depth:** [quick / standard / deep]
+- **Depth:** [quick / standard / deep / max]
+- **Docket mode:** [real-deepreason / mini-deepreason / manual-docket / skipped]
+- **Independence mode:** [independent | degraded — reason]
+- **Role binding:** [native-agent | materialized-role]
 
 ## Executive Verdict
 - **Independence disclosure:** [independent | degraded]
-- **Consensus Result:** [GO / NO-GO / CONDITIONAL]
+- **Computed Verdict:** [GO / NO-GO / CONDITIONAL]
 - **Summary:** [one paragraph]
 - **Verdict gate applied:** [P1/P2 semantics]
 - **Conditions (if CONDITIONAL):** [enumerate]
 - **Epistemic label:** Survivors and scores reflect **best-argued in this review**, not external truth.
+
+## GO Coverage Statement (required for every GO / CONDITIONAL)
+- **Capability families actually exercised:** …
+- **Material assumptions reviewed:** …
+- **Known unknowns / untested behavior:** …
+- **Evidence freshness:** …
+- **Residual uncertainty:** …
 
 ## DeepReason Survivor Map (from MCP frontier)
 - [survivor-id]: [one-line thesis] — falsifier: [what would refute]
@@ -33,7 +43,7 @@ Mechanical criticism struck: [N] findings for missing/ill-formed falsifiers; [N]
 - **Experts in tension:** …
 - **The conflict:** …
 - **Evidence weight:** …
-- **Arbitration ruling:** [UPHELD | OVERRULED | SPLIT]
+- **Arbitration ruling:** [UPHELD | OVERRULED | UPHELD-WITH-QUALIFICATIONS | SPLIT]
 - **Reinstatement round (if any):** [none | attack survived → ruling recomputed]
 
 ## P1–P4 Decision Matrix

--- a/plugins/epistemic-skills/skills/gauntlet/reference/deep-mode-mcp.md
+++ b/plugins/epistemic-skills/skills/gauntlet/reference/deep-mode-mcp.md
@@ -4,8 +4,8 @@ Deep mode uses the `deepreason` MCP server (`python -m deepreason.mcp_server`). 
 
 ## Preconditions
 
-1. `deepreason` package installed (`pip install git+https://github.com/AHepi/DeepReason.git`).
-2. At least one provider API key set in the environment Cursor inherits (`OPENAI_API_KEY` and/or `DEEPSEEK_API_KEY` per `config/operator.yaml`).
+1. `deepreason` package installed (`pip install git+https://github.com/AHepi/DeepReason.git`). Installs MUST pin a commit or tag (e.g. `git+https://github.com/AHepi/DeepReason.git@<commit-sha-or-tag>`) — a mutable reference breaks the replay guarantee.
+2. At least one provider API key set in the environment Cursor inherits (`OPENAI_API_KEY` and/or `DEEPSEEK_API_KEY` per `config/operator.yaml`). The model names in `config/operator.yaml` are examples — verify them against current provider offerings before a run.
 3. Frozen verified dossier from Step 0 exists.
 
 ## Run directory

--- a/plugins/epistemic-skills/skills/gauntlet/reference/lens-registry.md
+++ b/plugins/epistemic-skills/skills/gauntlet/reference/lens-registry.md
@@ -128,8 +128,9 @@ Removed nonexistent pseudo-slugs from SKILL.md: `blast-radius`, `ethnographer`,
 
 ## Expansion frontier bookkeeping
 
-**30 core candidates** are in the registry with complete fingerprints (status=candidate,
-provenance marks the admission gate unrun). See `roster/candidates.md` (generated).
+**Core candidates** are in the registry with complete fingerprints (status=candidate,
+provenance marks the admission gate unrun); the current count lives only in
+`roster/INDEX.md` (generated). See `roster/candidates.md` (generated).
 
 **Audited-candidate QUEUE (named, neighbor-mapped, NOT yet fingerprinted — do not select,
 do not treat as registry entries):**

--- a/plugins/epistemic-skills/skills/gauntlet/reference/roadmap.md
+++ b/plugins/epistemic-skills/skills/gauntlet/reference/roadmap.md
@@ -65,5 +65,5 @@ falsifier check) · compiled mechanical checks / judge-token-free refutation
 - **Phase 3 — Measurement + substrate (Bundles C+D)** — full real-mode parity.
 
 Each later phase = its own spec, gated by measured payoff on the battery. Design
-provenance: the 3-agent bake-off design docs (2026-07-07); the operator's copy
-committed to `docs/superpowers/specs/2026-07-07-gauntlet-staple-deepreason-integration-design.md`.
+provenance: the 3-agent bake-off design docs (2026-07-07); the design doc is
+held in the operator's private repo and is not shipped in this package.


### PR DESCRIPTION
Targeted drift repairs from a documentation audit of the gauntlet skill. Docs/templates only — no code changes. Each fix verified against the code it cites.

- **lens-registry.md**: said "30 core candidates"; the registry holds 24 (generated `roster/INDEX.md`). Removed the hard number and pointed at INDEX.md, as the file itself decrees (counts live only in INDEX.md).
- **roadmap.md**: cited `docs/superpowers/specs/2026-07-07-gauntlet-staple-deepreason-integration-design.md`, which is absent from the public repo. Re-worded: the design doc is held in the operator's private repo and is not shipped.
- **SKILL.md Resources**: "Behavioral eval battery (designed, NOT run): evals/" overstated what ships — `evals/` contains only `arbitrator-certification/`. Honest wording: battery design not yet shipped in this package.
- **assets/synthesis-template.md**: brought up to what SKILL.md Step 8 already mandates — added the GO coverage statement block (capability families exercised / material assumptions / known unknowns / evidence freshness / residual uncertainty), Meta fields for docket_mode / independence_mode / role_binding, `max` in the depth enum, UPHELD-WITH-QUALIFICATIONS in the ruling enum (per lens-registry.md ruling-set@1), and renamed "Consensus Result" → "Computed Verdict".
- **SKILL.md Step 4**: doc said the selector gates on contraindications; `select_lenses.py` applies them as a score penalty. Doc now matches code. Also disclosed that the fit-scoring layer is FROZEN (measurement showed no detectable benefit over random fill under the same hard constraints — recorded in select_lenses.py); panel composition today is constraint-satisfaction + diversity-maximization.
- **reference/deep-mode-mcp.md**: the DeepReason install line used a bare git URL. Added the pin requirement (installs MUST pin a commit or tag; mutable references break the replay guarantee) and noted `config/operator.yaml` model names are examples to verify against current provider offerings.
- **SKILL.md Step 6**: disclosed that `[I]` inference anchors are spot-checked by the arbitrator, not mechanically verified (documented in `verify_evidence.py` but missing from the SKILL).

**Validation:** `python plugins/epistemic-skills/skills/gauntlet/tests/run_tests.py` → ALL PASS. `python scripts/validate_roster.py` → OK, 102 entries validate, views fresh.