### PR TITLE
evidence-locked-uat: manifest schema, judge honesty fields, sealed inputs, extracted canonical judge (PR-B7)

### DIFF
--- a/plugins/epistemic-skills/skills/evidence-locked-uat/SKILL.md
+++ b/plugins/epistemic-skills/skills/evidence-locked-uat/SKILL.md
@@ -43,6 +43,7 @@ their own subagent primitive. Parameters:
 ```json
 {
   "run_id": "…", "tier": "smoke|standard|release", "target_url": "…",
+  "commit_sha": "<target repo commit SHA under test>",
   "change_summary": "…", "requirement_sources": ["…"],
   "evidence_dir": "<absolute>", "target_repo_dir": "<absolute>"
 }
@@ -53,15 +54,25 @@ prompts — the information-permission boundaries in them are the mechanism.
 
 ## Step 3 — Write the report and land the evidence
 
-1. Write `<evidence_dir>/gate.json` from the Workflow return, adding
-   `coverage_omitted` (journeys/personas not run at this tier) and `known_limitations`
-   (always includes: no pairwise coverage; verifier same-provider; a11y = keyboard-path
-   procedural only; all oracle channels LLM-adjudicated at Level 1 (no deterministic
-   programmatic oracle); feedback visible <~3s is below the harness's reliable detection
-   threshold — ephemeral confirmations yield INCONCLUSIVE/predicted usability risk, not
-   PASS; `calibration_status: uncalibrated`).
-2. Write `<evidence_dir>/manifest.json`: run_id, tier, target, target repo commit SHA,
-   date, model, skill version, calibration_status, sha256 of gate.json and contracts.yaml.
+1. Write `<evidence_dir>/gate.json` from the Workflow return, or by running
+   `scripts/judge.py` directly — it is the canonical deterministic judge and any harness
+   runs it identically. The judge itself emits `coverage_omitted` (full release-tier
+   contract×persona matrix minus the cases this tier runs), `known_limitations` (Level-1
+   constant: no pairwise coverage; verifier same-provider; a11y = keyboard-path procedural
+   only; all oracle channels LLM-adjudicated at Level 1, no deterministic programmatic
+   oracle; feedback visible <~3s is below the harness's reliable detection threshold —
+   ephemeral confirmations yield INCONCLUSIVE/predicted usability risk, not PASS), and
+   `target_commit_sha`. Never add or edit these procedurally — a gate.json missing them is
+   incomplete, not clean. `calibration_status` stays `uncalibrated`: the seeded-defect
+   corpus that would permit a `calibrated:<corpus-ref>@<date>` value (vocabulary in
+   `references/schemas.md`) does not exist yet — that missing corpus is the named blocker,
+   deliberately not built here.
+2. Write `<evidence_dir>/manifest.json` per the normative schema in `references/schemas.md`:
+   run_id, tier, target, target repo commit SHA, date, model, skill version, judge-code
+   content hash (sha256 of `scripts/judge.py`), calibration_status, the directive-required
+   fingerprint fields (environment fingerprint, seed, sampling configuration, tool
+   versions), and sha256 of `gate.json`, `contracts.yaml`, every committed
+   `cases/*/actor-output.json`, and every `verifier/*.json`.
 3. Write `<evidence_dir>/summary.md` in the directive's FINAL REPORT FORMAT: decision
    first, critical failures and inconclusive criteria before passes, criterion table with
    evidence paths, predicted usability risks explicitly labeled "predicted", coverage
@@ -110,8 +121,12 @@ Full 26-row table: `references/standard.md` §61.
   section header or read by offset. The three canonical sections: §47 contracts, §59 evidence
   (aspirational full-standard layout, not this skill's contract — see `schemas.md`), §61
   anti-patterns.
-- `references/schemas.md` — canonical schemas + gate/judge rules.
-- `references/workflow-template.mjs` — the orchestration script.
+- `references/schemas.md` — canonical schemas + gate/judge rules, manifest schema,
+  calibration vocabulary, downstream verification.
+- `references/workflow-template.mjs` — the Claude Code reference orchestration script
+  (its embedded judge is a verified copy of `scripts/judge.py`).
+- `scripts/judge.py` — the canonical deterministic judge (stdlib Python, harness-agnostic;
+  `--self-test` exercises the aggregation semantics the `.mjs` copy must match).
 
 ## Local overlay
 

--- a/plugins/epistemic-skills/skills/evidence-locked-uat/references/schemas.md
+++ b/plugins/epistemic-skills/skills/evidence-locked-uat/references/schemas.md
@@ -2,7 +2,9 @@
 
 Derived from `standard.md` §9 (verdicts), §47 (contracts), §59 (evidence layout), §38.3 (gate).
 The Workflow script in `workflow-template.mjs` embeds these as JSON Schema constants —
-this file is the human-readable contract; keep the two in sync.
+this file is the human-readable contract; keep the two in sync. The deterministic judge
+is `../scripts/judge.py` (canonical, stdlib Python, harness-agnostic); the `.mjs` embeds
+a verified copy of its aggregation for the Workflow tool.
 
 ## Verdict vocabulary (closed set)
 
@@ -91,6 +93,10 @@ The verifier may not emit FLAKY (cross-run aggregate only).
 
 ## Judge aggregation (deterministic, in script — never an agent)
 
+Canonical implementation: `../scripts/judge.py` (stdlib Python; run it in any harness).
+The rules below are its contract; the `.mjs` embedded copy is verified against it by
+`judge.py --self-test`.
+
 - Case status: any criterion FAIL_PRODUCT → FAIL_PRODUCT; else worst non-PASS criterion
   status (severity order: FAIL_TEST_HARNESS > BLOCKED_ENVIRONMENT > FLAKY > INCONCLUSIVE >
   NOT_RUN); else PASS.
@@ -99,6 +105,10 @@ The verifier may not emit FLAKY (cross-run aggregate only).
 - Completeness: every contract criterion must receive a verdict; a contract criterion with
   no verifier row is scored INCONCLUSIVE (never skipped). Unknown verifier ids are flagged,
   and single-orphan pairs are matched positionally with the mismatch noted.
+- Honesty fields are emitted BY the judge, not appended procedurally: `known_limitations`
+  is a Level-1 constant, `coverage_omitted` is computed (full release-tier contract×persona
+  matrix minus the cases this tier runs), and `target_commit_sha` is pinned in the gate.
+  A gate.json missing these fields is incomplete — treat it as suspect, not clean.
 
 ## gate.json
 
@@ -109,11 +119,82 @@ The verifier may not emit FLAKY (cross-run aggregate only).
   "tier": "smoke | standard | release",
   "calibration_status": "uncalibrated",
   "target": "<base URL>",
+  "target_commit_sha": "<target repo commit SHA under test>",
   "cases": [ { "case_id": "…", "criticality": "…", "status": "…", "criteria": [ … ] } ],
-  "coverage_omitted": ["<journeys/personas not run at this tier>"],
-  "known_limitations": ["Level 1: no pairwise coverage; verifier same-provider; a11y = scan + keyboard only"]
+  "coverage_omitted": ["<case-id in the full matrix this tier does not run>"],
+  "known_limitations": ["Level 1 constant — see scripts/judge.py KNOWN_LIMITATIONS"]
 }
 ```
+
+## manifest.json (normative)
+
+The integrity anchor of the packet. `hashes` seals every committed JSON/YAML artifact —
+gate, contracts, and the per-case actor/verifier outputs the gate was aggregated from —
+so a downstream consumer can detect post-hoc tampering with the verdict OR its evidence
+inputs. Screenshots are gitignored and unhashed — outside the integrity chain.
+
+```json
+{
+  "run_id": "uat-YYYYMMDD-HHMMSS-<slug>",
+  "tier": "smoke | standard | release",
+  "target": "<base URL>",
+  "target_commit_sha": "<target repo commit SHA under test>",
+  "date": "<ISO 8601 run date>",
+  "model": "<model/version for the LLM roles>",
+  "skill_version": "<skill version string>",
+  "judge_sha256": "<sha256 of the canonical judge: scripts/judge.py>",
+  "calibration_status": "uncalibrated | calibrated:<corpus-ref>@<date>",
+  "environment_fingerprint": "<build, deployment, feature flags, locale, account identity>",
+  "seed": "<sampling seed, or null>",
+  "sampling": "<temperature/sampling configuration, or null>",
+  "tool_versions": { "<tool>": "<version>" },
+  "hashes": {
+    "gate.json": "<sha256>",
+    "contracts.yaml": "<sha256>",
+    "cases/<case-id>/actor-output.json": "<sha256 — one entry per case>",
+    "verifier/<case-id>.json": "<sha256 — one entry per case>"
+  }
+}
+```
+
+`environment_fingerprint`, `seed`, `sampling`, and `tool_versions` are directive-required
+fingerprint fields (`directive.md`: "Record seed, model/version, temperature or sampling
+configuration, tool versions, and environment fingerprint"). Record them as `null` when
+genuinely inapplicable — present-and-null is honest, omitted is a gap.
+
+## Calibration status vocabulary
+
+`calibration_status` is closed: `uncalibrated | calibrated:<corpus-ref>@<date>`.
+
+- `uncalibrated` — the default and current state of every run. Disclosed, not hidden.
+- `calibrated:<corpus-ref>@<date>` — permitted only after the actor→verifier→judge
+  pipeline has been run against a named seeded-defect corpus (`<corpus-ref>`) and met the
+  standard's pre-publication policy threshold (standard.md: "seeded-defect calibration
+  within policy threshold"); `@<date>` is the date of the qualifying corpus run.
+
+Transition: `uncalibrated` → `calibrated:<corpus-ref>@<date>` happens only via a recorded
+corpus run; there is no other path, and a calibrated status silently reverts to
+`uncalibrated` when the judge, verifier prompt, or contract schema changes materially.
+**The seeded-defect corpus does not exist yet — it is the named blocker.** Building it is
+deliberately out of scope here (a ceiling, not a floor); the vocabulary exists so the gap
+is a path, not a dead end.
+
+## Verifying a packet downstream
+
+A consumer MAY recompute `release_decision` from a committed packet without re-running
+any LLM role — the aggregation over the committed actor/verifier outputs is deterministic:
+
+1. Convert `contracts.yaml` to JSON (stdlib Python ships no YAML parser by design; e.g.
+   `python -c "import yaml,json,sys; json.dump(yaml.safe_load(open('contracts.yaml')), sys.stdout)" > contracts.json`).
+2. Run the canonical judge against the packet:
+   `python <skill>/scripts/judge.py --contracts contracts.json --tier <tier> --run-id <run_id> --target <target> --commit-sha <sha> --evidence-dir <packet dir> --output -`
+3. Compare `release_decision` and per-case statuses against the committed `gate.json`;
+   verify the manifest's `hashes` over the committed files first if tamper-evidence matters.
+
+What this proves: the committed gate is the faithful deterministic aggregation of the
+committed actor/verifier outputs. What it does NOT prove: that the verifier's judgments
+were correct (they are LLM adjudications), that blinding held at run time, or anything
+about the screenshots, which are gitignored and unhashed — outside the integrity chain.
 
 ## Evidence directory (`<target-repo>/artifacts/uat/<run-id>/`)
 
@@ -121,12 +202,14 @@ This is the Level-1 evidence layout; standard.md §59 describes the aspirational
 layout for higher maturity levels — do not treat §59 as this skill's contract.
 
 ```
-manifest.json          # run-id, tier, target, commit, model, calibration_status, hashes — committed
+manifest.json          # normative schema above — run-id, tier, target, target_commit_sha,
+                       # date, model, skill_version, judge_sha256, calibration_status,
+                       # fingerprint fields, hashes of all committed artifacts — committed
 contracts.yaml         # committed
 cases/<case-id>/
-  actor-output.json    # committed
-  screenshots/*.png    # gitignored
-verifier/<case-id>.json # committed (one per case, criterion-level decisions)
+  actor-output.json    # committed (hashed in manifest.json)
+  screenshots/*.png    # gitignored and unhashed — outside the integrity chain
+verifier/<case-id>.json # committed (hashed in manifest.json; one per case, criterion-level decisions)
 gate.json              # committed
 summary.md             # committed; final-report format per directive (critical failures first,
                        # predicted usability risks labeled as predicted, coverage omitted, assumptions)

--- a/plugins/epistemic-skills/skills/evidence-locked-uat/references/workflow-template.mjs
+++ b/plugins/epistemic-skills/skills/evidence-locked-uat/references/workflow-template.mjs
@@ -1,6 +1,13 @@
 // CLAUDE CODE REFERENCE IMPLEMENTATION of the evidence-locked-UAT role separation
 // (actor / blinded verifier / deterministic judge as concurrent isolated sub-agents).
 // Other harnesses meet the same contract with their own subagent primitive.
+//
+// CANONICAL JUDGE: the deterministic aggregation in the Judge phase below is an
+// embedded copy of scripts/judge.py, which is canonical — any harness runs that
+// stdlib script identically. The copy exists only because the Workflow tool
+// executes this file standalone; it is verified against scripts/judge.py by that
+// script's `--self-test` fixtures (including the INCONCLUSIVE synthesis paths and
+// id-drift single-orphan positional matching). Change judge.py FIRST, then port.
 export const meta = {
   name: 'evidence-locked-uat',
   description: 'Evidence-locked UAT: compile contracts, human-mode actor executes, blinded verifier judges, deterministic gate',
@@ -12,7 +19,7 @@ export const meta = {
   ],
 }
 
-// args: { run_id, tier, target_url, change_summary, requirement_sources: string[],
+// args: { run_id, tier, target_url, commit_sha, change_summary, requirement_sources: string[],
 //         evidence_dir, target_repo_dir }
 // The runtime's `args` global is not reliably visible inside function closures
 // (verified failure wf_6e9fb422-425: closures saw undefined). Bind it once at
@@ -221,6 +228,22 @@ for (const contract of compiled.contracts) {
 }
 log(cases.length + ' cases planned (tier=' + RUN.tier + ', ' + compiled.contracts.length + ' contracts)')
 
+// coverage_omitted: case ids in the full (release-tier) contract x persona matrix
+// that this tier does not run. Computed here by the judge, never added
+// procedurally by the orchestrator (fail-closed honesty — see schemas.md).
+const coverageOmitted = (() => {
+  const plannedIds = new Set(cases.map((c) => c.case_id))
+  const omitted = []
+  for (const contract of compiled.contracts) {
+    for (const persona of TIER_PERSONAS.release) {
+      if (persona === 'novice-mobile' && contract.criticality === 'low') continue
+      const id = contract.id + '--' + persona
+      if (!plannedIds.has(id)) omitted.push(id)
+    }
+  }
+  return omitted
+})()
+
 const results = await pipeline(
   cases,
   (cs) => agent(actorPrompt(cs, RUN), { schema: ACTOR_SCHEMA, label: 'act:' + cs.case_id, phase: 'Execute' })
@@ -232,6 +255,8 @@ const results = await pipeline(
 )
 
 phase('Judge')
+// Embedded copy of scripts/judge.py (canonical). Keep semantics line-for-line
+// identical; equivalence is exercised by judge.py --self-test.
 const SEVERITY = ['FAIL_PRODUCT', 'FAIL_TEST_HARNESS', 'BLOCKED_ENVIRONMENT', 'FLAKY', 'INCONCLUSIVE', 'NOT_RUN']
 const byCase = new Map(results.filter(Boolean).map((r) => [r.cs.case_id, r]))
 const caseVerdicts = cases.map((cs, i) => {
@@ -307,13 +332,26 @@ const caseVerdicts = cases.map((cs, i) => {
 
 const anyCriticalFail = caseVerdicts.some((v) => v.status === 'FAIL_PRODUCT' && (v.criticality === 'critical' || v.criticality === 'high'))
 const allPass = caseVerdicts.length > 0 && caseVerdicts.every((v) => v.status === 'PASS')
+// Level-1 honesty fields, emitted by the judge (constant/computable), never
+// appended procedurally by the orchestrator. Must equal KNOWN_LIMITATIONS in
+// scripts/judge.py.
+const KNOWN_LIMITATIONS = [
+  'Level 1: no pairwise coverage',
+  'verifier same-provider (independence is context/prompt-level only)',
+  'a11y = keyboard-path procedural only',
+  'all oracle channels LLM-adjudicated at Level 1 (no deterministic programmatic oracle)',
+  'feedback visible <~3s is below the harness\'s reliable detection threshold — ephemeral confirmations yield INCONCLUSIVE/predicted usability risk, not PASS',
+]
 const gate = {
   release_decision: anyCriticalFail ? 'FAIL' : allPass ? 'PASS' : 'INCONCLUSIVE',
   run_id: RUN.run_id,
   tier: RUN.tier,
   calibration_status: 'uncalibrated',
   target: RUN.target_url,
+  target_commit_sha: RUN.commit_sha,
   cases: caseVerdicts,
+  coverage_omitted: coverageOmitted,
+  known_limitations: KNOWN_LIMITATIONS,
 }
 log('Gate: ' + gate.release_decision + ' (' + caseVerdicts.filter((v) => v.status === 'PASS').length + '/' + caseVerdicts.length + ' cases PASS)')
 return gate

--- a/plugins/epistemic-skills/skills/evidence-locked-uat/scripts/judge.py
+++ b/plugins/epistemic-skills/skills/evidence-locked-uat/scripts/judge.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""
+judge.py — canonical deterministic judge for evidence-locked UAT.
+
+This is THE judge. `references/workflow-template.mjs` (the Claude Code reference
+orchestration) embeds a line-for-line equivalent copy of this aggregation for the
+Workflow tool; the copy is verified against this script by the `--self-test`
+fixtures. Any harness runs this script identically — no LLM role is involved in
+the gate decision.
+
+Inputs (all committed artifacts of a run's evidence directory):
+    --contracts      contracts as JSON (the compiler's structured return; JSON is
+                     valid YAML, so a JSON-form contracts.yaml parses directly —
+                     convert hand-written YAML with any YAML tool first)
+    --tier           smoke | standard | release
+    --run-id         uat-<YYYYMMDD-HHMMSS>-<slug>
+    --target         base URL under test
+    --commit-sha     target repo commit SHA under test
+    --evidence-dir   run evidence dir holding cases/<case-id>/actor-output.json
+                     and verifier/<case-id>.json
+
+Output: gate.json conforming to references/schemas.md, including the honesty
+fields (known_limitations, coverage_omitted) and target_commit_sha. Default
+output path is <evidence-dir>/gate.json; use `--output -` for stdout.
+
+    python scripts/judge.py --self-test
+
+Exit codes:
+    0  gate computed (regardless of decision) / self-test passed
+    1  self-test failed
+    2  invalid invocation or missing inputs
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+VERDICTS = ['PASS', 'FAIL_PRODUCT', 'INCONCLUSIVE', 'FAIL_TEST_HARNESS',
+            'BLOCKED_ENVIRONMENT', 'FLAKY', 'NOT_RUN']
+ORACLES = ['rendered-ui', 'accessibility-semantic', 'business-state', 'network',
+           'invariant', 'persistence', 'metamorphic']
+
+# Worst-first severity order for case status (FAIL_PRODUCT short-circuits first).
+SEVERITY = ['FAIL_PRODUCT', 'FAIL_TEST_HARNESS', 'BLOCKED_ENVIRONMENT',
+            'FLAKY', 'INCONCLUSIVE', 'NOT_RUN']
+
+TIER_PERSONAS = {
+    'smoke': ['returning-desktop'],
+    'standard': ['returning-desktop', 'keyboard-only'],
+    'release': ['returning-desktop', 'keyboard-only', 'novice-mobile'],
+}
+
+# Constant at Level 1 — emitted by the judge, never added procedurally, so a
+# forgetful orchestrator cannot produce a clean-looking gate.json (fail-closed).
+KNOWN_LIMITATIONS = [
+    'Level 1: no pairwise coverage',
+    'verifier same-provider (independence is context/prompt-level only)',
+    'a11y = keyboard-path procedural only',
+    'all oracle channels LLM-adjudicated at Level 1 (no deterministic programmatic oracle)',
+    'feedback visible <~3s is below the harness\'s reliable detection threshold — '
+    'ephemeral confirmations yield INCONCLUSIVE/predicted usability risk, not PASS',
+]
+
+CALIBRATION_UNCALIBRATED = 'uncalibrated'
+
+
+def planned_cases(contracts, tier):
+    """The contract x persona case matrix for a tier (mirrors the .mjs exactly)."""
+    cases = []
+    for contract in contracts:
+        if tier == 'smoke' and contract['criticality'] not in ('critical', 'high'):
+            continue
+        for persona in TIER_PERSONAS[tier]:
+            if persona == 'novice-mobile' and contract['criticality'] == 'low':
+                continue
+            cases.append({
+                'case_id': contract['id'] + '--' + persona,
+                'contract': contract,
+                'persona': persona,
+            })
+    return cases
+
+
+def coverage_omitted(contracts, tier):
+    """Case ids in the full (release-tier) matrix that this tier does not run."""
+    planned = {c['case_id'] for c in planned_cases(contracts, tier)}
+    return [c['case_id'] for c in planned_cases(contracts, 'release')
+            if c['case_id'] not in planned]
+
+
+def judge_case(cs, actor_out, verify):
+    """One case verdict. Ported line-for-line from workflow-template.mjs."""
+    if verify is None:
+        return {
+            'case_id': cs['case_id'],
+            'criticality': cs['contract']['criticality'],
+            'status': 'FAIL_TEST_HARNESS' if actor_out is not None else 'NOT_RUN',
+            'criteria': [],
+        }
+
+    # C1: criterion-completeness. Every contract criterion must receive a verdict.
+    contract_criteria = cs['contract']['criteria']
+    verifier_rows = verify['criteria']
+    used_verifier_idx = set()
+    matched_contract_ids = set()
+    completed = []
+
+    # Exact-id pass.
+    for cc in contract_criteria:
+        idx = next((ri for ri, row in enumerate(verifier_rows)
+                    if row['criterion_id'] == cc['id'] and ri not in used_verifier_idx), -1)
+        if idx != -1:
+            used_verifier_idx.add(idx)
+            matched_contract_ids.add(cc['id'])
+            completed.append(verifier_rows[idx])
+
+    # Positional single-orphan pairing pass (tolerates verifier id-drift/shortening).
+    unmatched_contract = [cc for cc in contract_criteria if cc['id'] not in matched_contract_ids]
+    unmatched_verifier_idx = [ri for ri in range(len(verifier_rows)) if ri not in used_verifier_idx]
+    if len(unmatched_contract) == 1 and len(unmatched_verifier_idx) == 1:
+        cc = unmatched_contract[0]
+        ri = unmatched_verifier_idx[0]
+        row = verifier_rows[ri]
+        used_verifier_idx.add(ri)
+        matched_contract_ids.add(cc['id'])
+        completed.append({
+            **row,
+            'evidence_against': list(row.get('evidence_against') or []) + [
+                'criterion id mismatch (' + row['criterion_id'] + ' vs contract ' + cc['id'] +
+                '), matched positionally as the single remaining orphan pair'],
+        })
+
+    # Remaining contract criteria with no verdict at all.
+    for cc in contract_criteria:
+        if cc['id'] in matched_contract_ids:
+            continue
+        completed.append({
+            'criterion_id': cc['id'],
+            'status': 'INCONCLUSIVE',
+            'evidence_for': [],
+            'evidence_against': ['verifier returned no verdict for this contract criterion (completeness check)'],
+            'uncertainty': 'missing verdict',
+        })
+
+    # Verifier rows that matched no contract criterion: keep, flagged.
+    for ri, row in enumerate(verifier_rows):
+        if ri in used_verifier_idx:
+            continue
+        completed.append({
+            **row,
+            'evidence_against': list(row.get('evidence_against') or []) + [
+                'criterion_id does not match the contract (unknown id)'],
+        })
+
+    status = 'PASS'
+    for sev in SEVERITY:
+        if any(c['status'] == sev for c in completed):
+            status = sev
+            break
+    return {
+        'case_id': cs['case_id'],
+        'criticality': cs['contract']['criticality'],
+        'status': status,
+        'criteria': completed,
+        'provisional': bool(cs['contract'].get('provisional')),
+    }
+
+
+def judge(contracts, tier, run_id, target, commit_sha, actor_outputs, verifier_outputs,
+          calibration_status=CALIBRATION_UNCALIBRATED):
+    """Aggregate all case verdicts into the gate object (deterministic, no LLM)."""
+    cases = planned_cases(contracts, tier)
+    case_verdicts = [
+        judge_case(cs, actor_outputs.get(cs['case_id']), verifier_outputs.get(cs['case_id']))
+        for cs in cases
+    ]
+    any_critical_fail = any(
+        v['status'] == 'FAIL_PRODUCT' and v['criticality'] in ('critical', 'high')
+        for v in case_verdicts)
+    all_pass = len(case_verdicts) > 0 and all(v['status'] == 'PASS' for v in case_verdicts)
+    return {
+        'release_decision': 'FAIL' if any_critical_fail else 'PASS' if all_pass else 'INCONCLUSIVE',
+        'run_id': run_id,
+        'tier': tier,
+        'calibration_status': calibration_status,
+        'target': target,
+        'target_commit_sha': commit_sha,
+        'cases': case_verdicts,
+        'coverage_omitted': coverage_omitted(contracts, tier),
+        'known_limitations': list(KNOWN_LIMITATIONS),
+    }
+
+
+def load_evidence(evidence_dir, contracts, tier):
+    """Read committed actor/verifier outputs keyed by planned case_id."""
+    evidence_dir = Path(evidence_dir)
+    actor_outputs, verifier_outputs = {}, {}
+    for cs in planned_cases(contracts, tier):
+        actor_path = evidence_dir / 'cases' / cs['case_id'] / 'actor-output.json'
+        verifier_path = evidence_dir / 'verifier' / (cs['case_id'] + '.json')
+        if actor_path.is_file():
+            actor_outputs[cs['case_id']] = json.loads(actor_path.read_text(encoding='utf-8'))
+        if verifier_path.is_file():
+            verifier_outputs[cs['case_id']] = json.loads(verifier_path.read_text(encoding='utf-8'))
+    return actor_outputs, verifier_outputs
+
+
+# --------------------------------------------------------------------------
+# Self-test: fixture runs demonstrating the aggregation semantics, including
+# the INCONCLUSIVE synthesis paths and id-drift single-orphan positional
+# matching. These are the same semantics the .mjs embedded copy implements.
+# --------------------------------------------------------------------------
+
+def _contract(cid, criticality, criteria, provisional=False):
+    return {
+        'id': cid,
+        'user_goal': 'goal for ' + cid,
+        'criticality': criticality,
+        'provisional': provisional,
+        'preconditions': [],
+        'task_prompt': 'do the thing',
+        'criteria': [
+            {'id': cid + '-C' + str(i + 1), 'statement': 'must be true',
+             'required_oracles': ['rendered-ui'], 'invariants': [], 'timeout_ms': 5000}
+            for i in range(criteria)
+        ],
+        'prohibited_side_effects': [],
+        'ambiguity_notes': [],
+    }
+
+
+def _vrow(criterion_id, status):
+    return {'criterion_id': criterion_id, 'status': status,
+            'evidence_for': ['shot.png: shows it'], 'evidence_against': [],
+            'uncertainty': None}
+
+
+def _actor(case_id):
+    return {'case_id': case_id, 'completed': True,
+            'stop_reason': 'task actions finished', 'knowledge_ledger': [], 'steps': []}
+
+
+def _run_fixture(root, name, contracts, tier, verifier_by_case, actor_by_case=None):
+    """Write a fixture evidence dir, run the file-based judge path, return the gate."""
+    evidence_dir = Path(root) / name
+    case_ids = [cs['case_id'] for cs in planned_cases(contracts, tier)]
+    for cid in case_ids:
+        actor = (actor_by_case or {}).get(cid, _actor(cid))
+        if actor is not None:
+            adir = evidence_dir / 'cases' / cid
+            adir.mkdir(parents=True, exist_ok=True)
+            (adir / 'actor-output.json').write_text(json.dumps(actor), encoding='utf-8')
+        verify = verifier_by_case.get(cid)
+        if verify is not None:
+            vdir = evidence_dir / 'verifier'
+            vdir.mkdir(parents=True, exist_ok=True)
+            (vdir / (cid + '.json')).write_text(json.dumps(verify), encoding='utf-8')
+    actor_outputs, verifier_outputs = load_evidence(evidence_dir, contracts, tier)
+    return judge(contracts, tier, 'uat-20260722-000000-' + name, 'http://localhost:3000',
+                 'deadbeef' * 5, actor_outputs, verifier_outputs)
+
+
+def self_test():
+    failures = []
+
+    def check(label, cond, detail=''):
+        if cond:
+            print('ok   ' + label)
+        else:
+            failures.append(label)
+            print('FAIL ' + label + (' — ' + detail if detail else ''))
+
+    with tempfile.TemporaryDirectory() as root:
+        # F1: clean PASS — one critical contract, one criterion, smoke tier.
+        c = [_contract('REQ-A-001', 'critical', 1)]
+        case = 'REQ-A-001--returning-desktop'
+        gate = _run_fixture(root, 'pass', c, 'smoke', {case: {'criteria': [_vrow('REQ-A-001-C1', 'PASS')]}})
+        check('F1 release_decision PASS', gate['release_decision'] == 'PASS', json.dumps(gate, indent=2))
+        check('F1 case PASS', gate['cases'][0]['status'] == 'PASS')
+        check('F1 commit sha pinned', gate['target_commit_sha'] == 'deadbeef' * 5)
+        check('F1 coverage_omitted lists non-smoke personas',
+              gate['coverage_omitted'] == ['REQ-A-001--keyboard-only', 'REQ-A-001--novice-mobile'],
+              json.dumps(gate['coverage_omitted']))
+        check('F1 known_limitations emitted by judge', gate['known_limitations'] == KNOWN_LIMITATIONS)
+
+        # F2: FAIL_PRODUCT on a high contract -> gate FAIL, even with a second PASS criterion.
+        c = [_contract('REQ-B-001', 'high', 2)]
+        case = 'REQ-B-001--returning-desktop'
+        gate = _run_fixture(root, 'fail', c, 'smoke',
+                            {case: {'criteria': [_vrow('REQ-B-001-C1', 'FAIL_PRODUCT'),
+                                                 _vrow('REQ-B-001-C2', 'PASS')]}})
+        check('F2 case FAIL_PRODUCT', gate['cases'][0]['status'] == 'FAIL_PRODUCT')
+        check('F2 release_decision FAIL', gate['release_decision'] == 'FAIL')
+
+        # F3: missing verdict for a contract criterion -> synthesized INCONCLUSIVE row.
+        c = [_contract('REQ-C-001', 'critical', 2)]
+        case = 'REQ-C-001--returning-desktop'
+        gate = _run_fixture(root, 'inconclusive', c, 'smoke',
+                            {case: {'criteria': [_vrow('REQ-C-001-C1', 'PASS')]}})
+        synth = gate['cases'][0]['criteria'][1]
+        check('F3 case INCONCLUSIVE', gate['cases'][0]['status'] == 'INCONCLUSIVE')
+        check('F3 synthesized row', synth == {
+            'criterion_id': 'REQ-C-001-C2', 'status': 'INCONCLUSIVE',
+            'evidence_for': [],
+            'evidence_against': ['verifier returned no verdict for this contract criterion (completeness check)'],
+            'uncertainty': 'missing verdict'}, json.dumps(synth))
+        check('F3 release_decision INCONCLUSIVE (not rounded up)',
+              gate['release_decision'] == 'INCONCLUSIVE')
+
+        # F4: id-drift single-orphan positional matching, mismatch recorded.
+        c = [_contract('REQ-D-001', 'medium', 2, provisional=True)]
+        case = 'REQ-D-001--returning-desktop'
+        gate = _run_fixture(root, 'drift', c, 'standard',
+                            {case: {'criteria': [_vrow('REQ-D-001-C1', 'PASS'),
+                                                 _vrow('REQ-D-001-C2-short', 'PASS')]}})
+        drift_row = next(r for r in gate['cases'][0]['criteria'] if r['criterion_id'] == 'REQ-D-001-C2-short')
+        check('F4 orphan matched positionally, case PASS', gate['cases'][0]['status'] == 'PASS')
+        check('F4 mismatch recorded in evidence_against',
+              drift_row['evidence_against'] == [
+                  'criterion id mismatch (REQ-D-001-C2-short vs contract REQ-D-001-C2), '
+                  'matched positionally as the single remaining orphan pair'],
+              json.dumps(drift_row))
+        check('F4 provisional marking preserved', gate['cases'][0]['provisional'] is True)
+        check('F4 standard-tier coverage_omitted only novice-mobile',
+              gate['coverage_omitted'] == ['REQ-D-001--novice-mobile'])
+
+        # F5: unknown verifier id kept and flagged.
+        c = [_contract('REQ-E-001', 'critical', 1)]
+        case = 'REQ-E-001--returning-desktop'
+        gate = _run_fixture(root, 'unknown', c, 'smoke',
+                            {case: {'criteria': [_vrow('REQ-E-001-C1', 'PASS'),
+                                                 _vrow('REQ-E-001-C99', 'PASS')]}})
+        unknown = gate['cases'][0]['criteria'][-1]
+        check('F5 unknown id kept, flagged',
+              unknown['criterion_id'] == 'REQ-E-001-C99' and
+              unknown['evidence_against'] == ['criterion_id does not match the contract (unknown id)'])
+
+        # F6: no actor output -> NOT_RUN; actor but no verifier -> FAIL_TEST_HARNESS.
+        c = [_contract('REQ-F-001', 'critical', 1), _contract('REQ-F-002', 'critical', 1)]
+        gate = _run_fixture(root, 'missing', c, 'smoke',
+                            {'REQ-F-001--returning-desktop': None},
+                            actor_by_case={'REQ-F-001--returning-desktop': None})
+        statuses = {v['case_id']: v['status'] for v in gate['cases']}
+        check('F6 NOT_RUN when no actor output',
+              statuses['REQ-F-001--returning-desktop'] == 'NOT_RUN', json.dumps(statuses))
+        check('F6 FAIL_TEST_HARNESS when actor ran but no verifier output',
+              statuses['REQ-F-002--returning-desktop'] == 'FAIL_TEST_HARNESS', json.dumps(statuses))
+        check('F6 NOT_RUN/FAIL_TEST_HARNESS cases carry no provisional key',
+              all('provisional' not in v for v in gate['cases']))
+        check('F6 gate INCONCLUSIVE', gate['release_decision'] == 'INCONCLUSIVE')
+
+    if failures:
+        print('\nself-test FAILED: %d check(s): %s' % (len(failures), ', '.join(failures)))
+        return 1
+    print('\nself-test OK: all fixtures passed')
+    return 0
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Deterministic evidence-locked UAT judge.')
+    parser.add_argument('--self-test', action='store_true', help='run fixture self-test and exit')
+    parser.add_argument('--contracts', help='contracts as JSON (JSON is valid YAML)')
+    parser.add_argument('--tier', choices=list(TIER_PERSONAS))
+    parser.add_argument('--run-id')
+    parser.add_argument('--target')
+    parser.add_argument('--commit-sha')
+    parser.add_argument('--evidence-dir')
+    parser.add_argument('--calibration-status', default=CALIBRATION_UNCALIBRATED)
+    parser.add_argument('--output', help='gate.json path (default <evidence-dir>/gate.json; "-" for stdout)')
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    missing = [n for n in ('contracts', 'tier', 'run_id', 'target', 'commit_sha', 'evidence_dir')
+               if getattr(args, n) is None]
+    if missing:
+        parser.error('missing required arguments: ' + ', '.join('--' + n.replace('_', '-') for n in missing))
+
+    try:
+        contracts_doc = json.loads(Path(args.contracts).read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as e:
+        print('error: cannot read contracts JSON: %s' % e, file=sys.stderr)
+        return 2
+    contracts = contracts_doc['contracts']
+    actor_outputs, verifier_outputs = load_evidence(args.evidence_dir, contracts, args.tier)
+    gate = judge(contracts, args.tier, args.run_id, args.target, args.commit_sha,
+                 actor_outputs, verifier_outputs, args.calibration_status)
+
+    out = json.dumps(gate, indent=2, ensure_ascii=False) + '\n'
+    output = args.output or str(Path(args.evidence_dir) / 'gate.json')
+    if output == '-':
+        sys.stdout.write(out)
+    else:
+        Path(output).write_text(out, encoding='utf-8')
+        print('Gate: %s (%d/%d cases PASS) -> %s' % (
+            gate['release_decision'],
+            sum(1 for v in gate['cases'] if v['status'] == 'PASS'),
+            len(gate['cases']), output), file=sys.stderr)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## PR-B7 — evidence-locked-uat manifest/judge repairs

Implements the **UAT changes** section (6 items) of the operator-approved design spec (spec PR #24, `docs/superpowers/specs/2026-07-22-skill-trust-contract-and-timing-design.md` v2.1), per the **PR-B7** phasing entry: *"evidence-locked-uat (manifest schema, judge honesty fields, sealed inputs, recomputability section, extracted judge, calibration vocabulary)."* Underlying findings: `docs/audits/2026-07-22-collection-audit/05-evidence-locked-uat-audit.md` (proposals P1–P6).

### The 6 items

1. **Normative `manifest.json` schema** in `references/schemas.md` — reconciles SKILL.md Step 3.2; adds `skill_version`, `judge_sha256` (content hash of the canonical judge), and the directive-required fingerprint fields (`environment_fingerprint`, `seed`, `sampling`, `tool_versions`) the audit found dropped.
2. **Honesty fields into the judge** — `gate.json` now emits `known_limitations` (Level-1 constant), `coverage_omitted` (computed: full release-tier contract×persona matrix minus the cases this tier runs), and `target_commit_sha`, from both `scripts/judge.py` and the `.mjs` embedded copy. Converts the forgetful-orchestrator fail-open (clean-looking gate → manifest pins the incomplete artifact) into fail-closed.
3. **Sealed evidence inputs** — manifest `hashes` extended to committed `cases/*/actor-output.json` and `verifier/*.json`; one explicit sentence: screenshots are gitignored and unhashed — outside the integrity chain.
4. **"Verifying a packet downstream"** section in `schemas.md` — a consumer MAY recompute `release_decision` from committed actor/verifier outputs with the deterministic aggregation rules, without re-running any LLM role (docs-only; states what proves what).
5. **Extracted judge** — new `scripts/judge.py` (stdlib Python, canonical, harness-agnostic). `workflow-template.mjs` remains the Claude Code reference orchestration; its header documents that `judge.py` is canonical and its embedded copy is verified against it, exercised by `judge.py --self-test` (fixtures cover the INCONCLUSIVE synthesis paths and id-drift single-orphan positional matching).
6. **Calibration vocabulary** — `uncalibrated | calibrated:<corpus-ref>@<date>` with transition condition in `schemas.md`; SKILL.md names the missing seeded-defect corpus as the blocker. Corpus NOT built (ceiling, not floor).

### Validation

- `python scripts/judge.py --self-test` — 19/19 checks green.
- **Equivalence:** the Judge-phase code textually extracted from the updated `.mjs` and executed under node against 6 hand-built fixtures (PASS, FAIL_PRODUCT, INCONCLUSIVE-via-missing-verdict, id-drift orphan, unknown-id, NOT_RUN/FAIL_TEST_HARNESS) produces parsed-JSON-identical gates to `scripts/judge.py` — including the new honesty fields and `coverage_omitted`.
- CLI end-to-end run on a hand-built evidence dir produces a conformant `gate.json`.
- Repo sanity: `python plugins/epistemic-skills/skills/gauntlet/tests/run_tests.py` — ALL PASS.

### Adjacency note

PR #23 (open) touches the same two files with one-line wording fixes (SKILL.md per-case pipeline wording; schemas.md NOT_RUN narrowing note). This PR branches from current main and edits different hunks of both files; whichever lands second may need a trivial rebase. No semantic conflict — #23's wording changes are orthogonal to these.

### Judgment calls beyond the spec

- `judge.py` consumes contracts as **JSON** (stdlib Python ships no YAML parser; JSON is valid YAML). The downstream-verification docs show a one-line `yaml.safe_load` conversion for hand-written `contracts.yaml`.
- `coverage_omitted` is defined as the full release-tier matrix minus this tier's **planned** cases (planned-but-unexecuted cases are already visible as `NOT_RUN`/`FAIL_TEST_HARNESS` in `cases[]`).
- New gate field named `target_commit_sha`; new Workflow param `commit_sha` (required by judge.py, fail-closed).
- `known_limitations` Level-1 constant consolidates SKILL.md's former long-form list (calibration disclosure removed from the list — it is a dedicated gate field).

🤖 Generated with [Kimi Code](https://www.moonshot.cn/)
