### PR TITLE
release: 2.7.0 — trust contracts, arc timing layer, verification sets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding — how an agent knows things before, during, and after work. One package, eight self-triggering skills. Composes with the superpowers workflow layer via the helix tandem entry point.",
-    "version": "2.6.0"
+    "version": "2.7.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding — how an agent knows things before, during, and after work. One package, eight self-triggering skills. Composes with the superpowers workflow layer via the helix tandem entry point.",
-    "version": "2.6.0"
+    "version": "2.7.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-bound goal authoring, evidence-locked UAT, and multi-lens adversarial review, with the helix tandem layer for pairing them with a workflow-skill collection. Each skill self-triggers by relevance.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "2.3.1",
+  "version": "2.7.0",
   "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-locked UAT, and multi-lens adversarial review.",
   "author": {
     "name": "ZMS Labs",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Epistemic-discipline skills for agentic coding — how an agent **knows** things before, during, and after work.
 
-**Version 2.6.0.** **License: [GPL-3.0-or-later](LICENSE).**
+**Version 2.7.0.** **License: [GPL-3.0-or-later](LICENSE).**
 
 **Harness-agnostic.** The skills are plain [Agent Skills](https://agentskills.io/specification) (`SKILL.md` + supporting files) describing *methods*, not any one tool's mechanics. They run in any harness that can load a skill or a context file — Claude Code, Codex, Cursor, Gemini CLI, Antigravity, Kimi Code, or your own agent loop. Where a step needs a runtime primitive (concurrent sub-agents, a structured-output schema, an MCP tool), the skill states the **contract** and points at a labeled *reference implementation* for one harness; other harnesses meet the same contract with their own primitives. See [Using these in any harness](#using-these-in-any-harness).
 
@@ -78,7 +78,7 @@ Install with **exactly one** mechanism per harness. A second copy of the same sk
 codex plugin marketplace add ZMS-Labs/epistemic-skills --ref main
 codex plugin add epistemic-skills@epistemic-skills
 # Register the five gauntlet roles in Codex's user-agent registry:
-python "$HOME/.codex/plugins/cache/epistemic-skills/epistemic-skills/2.6.0/skills/gauntlet/scripts/render_codex_agents.py" --out "$HOME/.codex/agents"
+python "$HOME/.codex/plugins/cache/epistemic-skills/epistemic-skills/2.7.0/skills/gauntlet/scripts/render_codex_agents.py" --out "$HOME/.codex/agents"
 ```
 
 Start a new Codex task after rendering the roles. Codex plugin manifests do not
@@ -89,7 +89,7 @@ fallback for a task started before registration.
 
 ### Cursor
 
-**Status:** packaging is ready (`.cursor-plugin/` manifests, version 2.6.0). The plugin is **not yet listed** on the public [Cursor Marketplace](https://cursor.com/marketplace); `/add-plugin epistemic-skills` works only after Cursor lists it or you import the repo as a [team marketplace](https://cursor.com/docs/plugins). Publisher application: [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish).
+**Status:** packaging is ready (`.cursor-plugin/` manifests, version 2.7.0). The plugin is **not yet listed** on the public [Cursor Marketplace](https://cursor.com/marketplace); `/add-plugin epistemic-skills` works only after Cursor lists it or you import the repo as a [team marketplace](https://cursor.com/docs/plugins). Publisher application: [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish).
 
 | Path | When to use |
 |---|---|

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-bound goal authoring, evidence-locked UAT, and multi-lens adversarial review, with the helix tandem layer for pairing them with a workflow-skill collection.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "contextFileName": "GEMINI.md"
 }

--- a/plugins/epistemic-skills/.claude-plugin/plugin.json
+++ b/plugins/epistemic-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-bound goal authoring, evidence-locked UAT, and multi-lens adversarial review, with the helix tandem layer for pairing them with a workflow-skill collection. Each skill self-triggers by relevance.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/epistemic-skills/.codex-plugin/plugin.json
+++ b/plugins/epistemic-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-bound goal authoring, evidence-locked UAT, and multi-lens adversarial review, with the helix tandem layer for pairing them with a workflow-skill collection.",
   "author": {
     "name": "ZMS Labs",

--- a/plugins/epistemic-skills/.cursor-plugin/plugin.json
+++ b/plugins/epistemic-skills/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-bound goal authoring, evidence-locked UAT, and multi-lens adversarial review, with the helix tandem layer for pairing them with a workflow-skill collection. Each skill self-triggers by relevance.",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": {
     "name": "ZMS Labs"
   },

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "2.3.1",
+  "version": "2.7.0",
   "description": "The full epistemic-discipline collection in one package: a router plus formal rigor, blindspot reconnaissance, scholarly evidence, evidence-locked UAT, and multi-lens adversarial review.",
   "author": {
     "name": "ZMS Labs",


### PR DESCRIPTION
Version bump 2.6.0 → 2.7.0 across all manifests + README, closing out the 2026-07-22 program:

- contracts/ — handoff-receipt@1 schema, stdlib verifier, examples (#26)
- Arc timing layer — validity column, research convergence + escalation, rigor↔research ordering, drift-rule invariant 6 (#25)
- Router receipt machinery (#27)
- Gauntlet run-record verification set, ledger v2, domain aliases, synthetic example run (#29)
- UAT normative manifest schema, canonical extracted judge.py, sealed inputs, calibration vocabulary (#28)
- Nine-part audit corpus at docs/audits/2026-07-22-collection-audit/ (#26)
- Hygiene + precision repairs (#20, #21, #22, #23)
- Design spec (#24, gauntlet-gated)

Also unifies the Kimi plugin manifests, which were stale at 2.3.1.