### PR TITLE
docs: project estate lifecycle status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # epistemic-skills
 
 <!-- ZMS-ESTATE:BEGIN -->
+
 > **Estate status:** `maintenance` · **Purpose:** `governance_method` · **Portfolio role:** `none`
 > **Canonical for:** epistemic-agent-skill-package
 > Lifecycle authority: `ZMS-Labs/zms-homelab/governance/estate.yaml`.
+
 <!-- ZMS-ESTATE:END -->
 
 Epistemic-discipline skills for agentic coding — how an agent **knows** things before, during, and after work.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # epistemic-skills
 
+<!-- ZMS-ESTATE:BEGIN -->
+> **Estate status:** `maintenance` · **Purpose:** `governance_method` · **Portfolio role:** `none`
+> **Canonical for:** epistemic-agent-skill-package
+> Lifecycle authority: `ZMS-Labs/zms-homelab/governance/estate.yaml`.
+<!-- ZMS-ESTATE:END -->
+
 Epistemic-discipline skills for agentic coding — how an agent **knows** things before, during, and after work.
 
 **Version 2.9.1.** **License: [GPL-3.0-or-later](LICENSE).**


### PR DESCRIPTION
## Summary

- add a generated first-screen ZMS estate status block to the existing README
- show lifecycle, purpose, portfolio role, and canonical scope
- point to the single authoritative estate registry; this README remains a projection

## Verification

- the central estate renderer/checker passed for this repository
- `git diff --check` passed
- README-only change: eight inserted lines and no existing content modified

## Coordination

Part of ZMS estate operating-model Workstream 1. Central inventory and projection enforcement is in [private tracker redacted; issue #1272].


## Operating-model metadata

<!-- final-wave-metadata -->
- **Assurance:** `R0`
- **Affected authority:** README lifecycle projection; the central registry remains authoritative.
- **Operator decision needed:** none for the reversible projection.
- **Runtime verification:** `STATIC` and the PR's stated `TESTED` checks only unless its existing body explicitly records a read-only observation. `LIVE_VERIFIED` and `ACCEPTED` are not claimed.
- **Rollback:** close this draft or revert its commits/merge commit; this PR performs no deployment, migration, archive, or destructive live action.
- **What remains:** stacked parent PRs must land before this projection can become default-branch truth.


> Privacy edit (2026-09-18): personal identifiers and local coordinates in this historical text are redacted. Synthetic example values do not reproduce the original bytes. Findings and outcomes are unchanged.