### PR TITLE
docs: build comprehensive README and GitHub Wiki handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,9 +354,9 @@ Version 3.0.0 is a real release with aligned package surfaces, deterministic che
 | Gauntlet certification | The historical pre-AC-07 result caught 10/10 planted defect classes, but the amended arbitrator-certification battery is **`NOT_RUN`**. No current arbitrator-certification claim is made. |
 | Post-hoc diagnostic | The V3 diagnostic remains exactly **`release_credit: none`**. It informed bounded risk acceptance but did not repair, qualify, or retroactively pass the excluded campaign. |
 
-Operator risk acceptance covered only the named behavioral-confidence gaps. It did **not** waive or satisfy deterministic, DCO, CodeQL, secret-scanning, provenance, independent-review, or publication-identity gates. The machine-readable [v3.0.0 risk record](docs/release/RELEASE-3.0.0-RISK-ACCEPTANCE.json) controls the precise scope.
+Operator risk acceptance covered only the named behavioral-confidence gaps. It did **not** waive or satisfy deterministic, DCO, CodeQL, secret-scanning, provenance, independent-review, or publication-identity gates. The machine-readable [v3.0.0 risk record](https://github.com/ZMS-Labs/epistemic-skills/blob/v3.0.0/docs/release/RELEASE-3.0.0-RISK-ACCEPTANCE.json) controls the precise scope.
 
-Read [Evidence, Status, and Known Limitations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Evidence-Status-and-Known-Limitations), the [release record](docs/release/RELEASE-3.0.0.md), and the [no-credit diagnostic](docs/release/evidence/2026-07-26-formal-rigor-v3-posthoc-diagnostic.md) before making broad behavioral claims.
+Read [Evidence, Status, and Known Limitations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Evidence-Status-and-Known-Limitations), the [release record](https://github.com/ZMS-Labs/epistemic-skills/blob/v3.0.0/docs/release/RELEASE-3.0.0.md), and the [no-credit diagnostic](https://github.com/ZMS-Labs/epistemic-skills/blob/v3.0.0/docs/release/evidence/2026-07-26-formal-rigor-v3-posthoc-diagnostic.md) before making broad behavioral claims.
 
 ## Developing and contributing
 

--- a/README.md
+++ b/README.md
@@ -8,135 +8,197 @@
 
 <!-- ZMS-ESTATE:END -->
 
-Epistemic-discipline skills for agentic coding — how an agent **knows** things before, during, and after work.
+Epistemic disciplines for agentic work: use the least process that can still expose an error capable of changing the action or the completion claim.
 
-**Version 3.0.0.** **License: [GPL-3.0-or-later](LICENSE).**
+**Version 3.0.0.** This is the project's [first immutable support point](https://github.com/ZMS-Labs/epistemic-skills/releases/tag/v3.0.0). The package is harness-agnostic, follows the [Agent Skills specification](https://agentskills.io/specification), and is licensed under [GPL-3.0-or-later](LICENSE).
 
-**Harness-agnostic.** The skills are plain [Agent Skills](https://agentskills.io/specification) (`SKILL.md` + supporting files) describing *methods*, not any one tool's mechanics. They run in any harness that can load a skill or a context file — Claude Code, Codex, Cursor, Gemini CLI, Antigravity, Kimi Code, or your own agent loop. Where a step needs a runtime primitive (concurrent sub-agents, a structured-output schema, an MCP tool), the skill states the **contract** and points at a labeled *reference implementation* for one harness; other harnesses meet the same contract with their own primitives. See [Using these in any harness](#using-these-in-any-harness).
+[![Release](https://img.shields.io/github/v/release/ZMS-Labs/epistemic-skills?display_name=tag)](https://github.com/ZMS-Labs/epistemic-skills/releases/latest)
+[![epistemic-flexibility](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml)
+[![release-security](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/release-security.yml/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/release-security.yml)
+[![CodeQL](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/github-code-scanning/codeql)
+[![License](https://img.shields.io/github/license/ZMS-Labs/epistemic-skills)](LICENSE)
 
-Most skill collections cover the *workflow* layer: test-driven development, systematic debugging, plan writing (see [superpowers](https://github.com/obra/superpowers), which these compose with). This collection covers the layer underneath: the disciplines that keep an agent's claims tethered to evidence and its effort aimed at the real target. The `helix` skill is the pairing map for running the two layers in tandem.
+The README is the fast path into the project. The [GitHub Wiki](https://github.com/ZMS-Labs/epistemic-skills/wiki) is the practical handbook. The immutable released skill files, contracts, schemas, checks, and evidence remain authoritative.
 
-Across the arc, five **epistemic-flexibility controls** separate claims from sources,
-operator-authorized priorities from success proxies, predictions from post-hoc stories,
-recurrent failures from their earliest interruptible links, and unresolved uncertainty from
-forced closure. They are cross-cutting controls inside the existing skills — **not another
-skill or trigger**. Functional definition, evidence limits, and the deterministic conformance
-battery: [`using-epistemic-skills/reference/epistemic-flexibility.md`](plugins/epistemic-skills/skills/using-epistemic-skills/reference/epistemic-flexibility.md).
+## Contents
 
-**Start with `using-epistemic-skills`** — the router. It answers whether the task should leave through the routine path or enter one or more disciplines, in what order, and how each output feeds the next. The package ships **eleven** skills: the router, the **nine** disciplines it routes to, and **helix** — the tandem entry point that pairs those disciplines with a workflow-skill layer such as superpowers. Install once; each skill self-triggers only when its own `description` matches.
+- [What this is—and is not](#what-this-isand-is-not)
+- [Choose your path](#choose-your-path)
+- [Five-minute start](#five-minute-start)
+- [Routine work first](#routine-work-first)
+- [Helix: the central passage](#helix-the-central-passage)
+- [Choose by task](#choose-by-task)
+- [The epistemic arc](#the-epistemic-arc)
+- [Eleven-skill catalog](#eleven-skill-catalog)
+- [Installation and compatibility](#installation-and-compatibility)
+- [Architecture and source policy](#architecture-and-source-policy)
+- [Trust, evidence, and known limits](#trust-evidence-and-known-limits)
+- [Developing and contributing](#developing-and-contributing)
+
+## What this is—and is not
+
+Most agent-skill collections organize **how work proceeds**: brainstorming, planning, implementation, debugging, review, and verification. epistemic-skills sits beneath that workflow layer and asks a different question: **what would make the target, decision, evidence, handoff, or acceptance claim trustworthy enough to bear load?**
+
+The package provides **eleven** skills: one router, **nine** disciplines, and Helix—the passage that pairs those disciplines with a workflow-skill layer such as [superpowers](https://github.com/obra/superpowers). Each method has a positive trigger, an output contract, and a stopping boundary.
+
+It is not:
+
+- a replacement for coding, testing, debugging, planning, or ordinary review;
+- a mandate to run every skill or generate a process artifact for every edit;
+- an automatic truth engine—records, schemas, and receipts have explicit evidentiary limits;
+- proof that one model, provider, or harness is universally superior; or
+- a reason to continue reasoning when the correct boundary is hold, escalation, or a bounded reversible probe.
+
+The governing principle is **floors, not ceilings; proportional cost**. Extra process earns no credit unless it can expose an action-changing error.
+
+## Choose your path
+
+Users and maintainers are equal first-class audiences:
+
+| Use the skills | Develop and maintain |
+|---|---|
+| [Start Here](https://github.com/ZMS-Labs/epistemic-skills/wiki/Start-Here) | [Architecture and Contracts](https://github.com/ZMS-Labs/epistemic-skills/wiki/Architecture-and-Contracts) |
+| [Choosing a Skill](https://github.com/ZMS-Labs/epistemic-skills/wiki/Choosing-a-Skill) | [Cross-Harness Packaging](https://github.com/ZMS-Labs/epistemic-skills/wiki/Cross-Harness-Packaging) |
+| [Routine Work and Proportionality](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) | [Testing and Evaluations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Testing-and-Evaluations) |
+| [Helix: Central Passage](https://github.com/ZMS-Labs/epistemic-skills/wiki/Helix-Central-Passage) | [Evidence, Status, and Known Limitations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Evidence-Status-and-Known-Limitations) |
+| [Workflow Recipes](https://github.com/ZMS-Labs/epistemic-skills/wiki/Workflow-Recipes) | [Contributing](https://github.com/ZMS-Labs/epistemic-skills/wiki/Contributing) |
+| [Installation and Harness Compatibility](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) | [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) |
+| [Skill Catalog](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Catalog) | [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO) |
+
+The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v3.0.0` source controls.
+
+## Five-minute start
+
+1. **Install one immutable copy.** Choose the native path for your harness under [Installation and compatibility](#installation-and-compatibility). Use the generic Agent Skills path only when no native plugin or extension exists.
+2. **Reload the harness or start a fresh task.** Trigger discovery and role registries are commonly session-bound.
+3. **Choose the entry point.** Start with the epistemic router when only this collection is active. If a workflow-skill layer is also active and a positive pairing exists, enter through Helix.
+4. **Verify the inventory and source.** Expect exactly eleven skills from one `3.0.0` package or tagged checkout—not two copies found through different install mechanisms.
+5. **Let routine work leave.** A local, reversible, directly checkable, non-precedential task should finish with its bounded check and no process-only artifact.
+
+For a harness without a native package surface, the complete generic install is:
+
+```bash
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v3.0.0/plugins/epistemic-skills/skills
+```
+
+Do not run that command on top of a native plugin install. The [installation handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) includes verification and recovery details for every packaged harness.
 
 ## Routine work first
 
-The collection is not a requirement to convene a review process for every edit.
-A task stays on the **routine path** when it is all four of:
+Routine work is the default exit, not a lesser form of rigor. A task stays on the routine path only when it is all four of:
 
-1. reversible by an ordinary revert;
-2. local — no security, privacy, authorization, tenancy, billing, legal,
-   infrastructure, network, public-contract, migration, or cross-service boundary;
-3. directly checkable by a targeted test, local preview, deterministic reproduction,
-   or comparably bounded observation; and
-4. non-precedential — no unresolved decision, scholarly premise, authorization, or
-   cross-session judgment must be preserved.
+1. **Reversible** by an ordinary revert.
+2. **Local**—it crosses no security, privacy, authorization, tenancy, billing, legal, infrastructure, network, public-contract, migration, or cross-service boundary.
+3. **Directly checkable** by a targeted test, local preview, deterministic reproduction, or comparably bounded observation.
+4. **Non-precedential**—no unresolved decision, scholarly premise, authorization, or cross-session judgment must be preserved.
 
-For unfamiliar routine-looking territory, open the target artifact and its nearest
-test/example. If they agree with the request and the four conditions still hold, make
-the change and run the bounded check. **Do not emit router or Helix skip inventories,
-a blindspot report, a formal record, a ledger entry, a UAT packet, or another process-
-only artifact.** Escalate only when the first reads expose a positive trigger.
+For unfamiliar but routine-looking work, perform **two-read micro-recon**: inspect the target artifact and its nearest test or example. If they agree with the request and the four conditions still hold, make the smallest change and run the bounded check.
 
-Normative details and examples:
-[`routine-fast-path.md`](plugins/epistemic-skills/skills/using-epistemic-skills/reference/routine-fast-path.md).
-The structural proportionality battery lives at
-[`evals/proportionality/`](plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/).
-Live blinded proportionality results and content-pin provenance are in
-[`blinded/results/RESULTS.md`](plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/blinded/results/RESULTS.md).
-Applying-formal-rigor RED and current fail-closed status are in
-[`formal-rigor-v2-fixtures/results/RESULTS.md`](plugins/epistemic-skills/skills/applying-formal-rigor/evals/formal-rigor-v2-fixtures/results/RESULTS.md).
+Routine work produces no router record, Helix skip inventory, blindspot report, formal record, ledger entry, UAT packet, or proof that other triggers were absent. Escalate only when the reads expose an observed mismatch, hidden coupling, unresolved scope, material fan-out risk, or another positive trigger.
 
-## The arc
+See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v3.0.0/plugins/epistemic-skills/skills/using-epistemic-skills/reference/routine-fast-path.md).
 
-The nine disciplines are one system — *how an agent knows things* before, during, and after work — with each ending at a defined boundary and handing off to the next:
+## Helix: the central passage
 
-```
-routine: reversible + local + directly checkable + non-precedential
-         → change + bounded check; no process-only artifact
+Helix is intentionally a centralized passage between the workflow layer and the epistemic router and disciplines:
 
-resume (pre-arc):  continuity-verify  (the summary is a claim, not a state — re-anchor or stamp)
-        │
- recon              decide                  contract          gate             prove
- blindspot-pass  →  applying-formal-rigor → write-goal     → gauntlet       → evidence-locked-uat
- (rewrites the      (derives the design;     (binds intent    (computed         (blinded verdict on
-  request)           evidence-research        to proof and     GO/NO-GO on        a material finished
-                     grounds any premise)     stop rules)      a frozen subject)  UI change)
-
-persist (cross-cutting): decision-ledger records a consequential moment only when an
-   existing durable plan/ADR/issue/PR/goal/derivation does not already satisfy the consumer
-
-delegate (cross-cutting): outsource commits a context-complete repo packet + short prompt,
-   then records every external response in the repo before the next turn
+```mermaid
+flowchart LR
+    W["Workflow-skill layer<br/>how work gets done"] <--> H["Helix<br/>central passage"]
+    H <--> E["using-epistemic-skills<br/>router and nine disciplines"]
 ```
 
-Most tasks clear the routine gate or fire zero or one discipline. The router's value is the case where more than one applies.
+- `using-epistemic-skills` remains the router **inside** this collection: it applies the routine gate, identifies positive triggers, sequences disciplines, and defines handoffs.
+- Helix never routes within either collection. It maps a positively triggered epistemic member to the workflow stage that consumes it and preserves the required ordering.
+- Once a positive pair exists, the epistemic member runs first and the workflow stage carries its output forward. Recon after design is archaeology; evidence after a verdict is rationalization.
+- Helix is not mandatory ceremony, a twelfth discipline, or a replacement for the routine exit.
+- Routine work, absent pairings, and `(none mandatory)` stages are silent. A fired pair or explicit authorized override gets the compact custody record; non-events do not.
 
-## Skills
+Read [Helix: Central Passage](https://github.com/ZMS-Labs/epistemic-skills/wiki/Helix-Central-Passage) for the released pairing semantics. The paired member's own `SKILL.md`—not the map—governs its trigger and output.
 
-| Skill | Role |
-|---|---|
-| **using-epistemic-skills** | **Router** (not a discipline). Applies the routine gate, then routes positive triggers to the right discipline(s), sequences them (recon → decide → [evidence] → contract → gate → prove), and defines handoff contracts. Read it first; it never does the work itself. |
-| **helix** | **Tandem entry point** (not a discipline). When a workflow-skill layer (such as superpowers) runs alongside this collection, helix pairs workflow stages with positively triggered epistemic disciplines. Routine and absent pairs are silent. |
-| **applying-formal-rigor** | Software-and-systems property analysis and decision synthesis. Focused questions stay within six bullets/250 words; material forks use an open-world P1-P9 inventory, specialist modules, applicability proofs, and revision-bound `formal-rigor-record@2` output. |
-| **blindspot-pass** | Full read-only reconnaissance after micro-recon exposes a material map/territory mismatch, hidden coupling, unresolved scope, or fan-out risk. It surfaces landmines, context, examples, and expert questions, then rewrites the request. Unfamiliarity alone is not the full-pass trigger. |
-| **evidence-research** | Claims about *the literature*. **Consensus** discovers; **Scite** interrogates *reception* (supporting/contrasting citations, retractions); **Zotero** (durable library) does holdings-check + deposit so the org keeps a curated shelf. Prevents citing a refuted/retracted paper as support **and** rediscovering what the library already holds. Requires the triad in tandem; degrades explicitly when a layer is absent. |
-| **write-goal** | Explicit requests to author or start a persistent goal. Converts intent into an approved completion contract with goal-type selection, direct proof plus anti-proxy and provenance guards, scope and blocker policy, interruptibility, and opt-in budgets. Adapted from Kimi Code's built-in `write-goal` and strengthened with a documented research basis. |
-| **outsource** | External model/agent/process handoff. Writes the complete workload context and completion contract to `docs/outsource/<work-id>/HANDOFF.md`, commits it at an exact GitHub ref, emits a short copy/paste pointer, and records every return relay in-repo before it bears load. |
-| **evidence-locked-uat** | Claims that material UI-facing work is *done*. Actor drives; a **blinded verifier** judges from evidence alone; the judge is deterministic script code. Strict verdict vocabulary: `INCONCLUSIVE` is never rounded up to PASS. Routine directly checkable presentation changes use their bounded preview/test instead of constructing a full packet. |
-| **gauntlet** | High-stakes decision points. Multi-lens adversarial panel on a *frozen* subject: truth-gated dossier, falsifiers, deterministic selection, mechanical `[V path:line]` evidence checks, Conflict Ledger, and computed GO/CONDITIONAL/NO-GO. It is not ordinary code review. |
-| **decision-ledger** | The arc's **persistence** moment. Reuses an adequate durable ADR/plan/issue/PR/goal/derivation when one exists; otherwise appends `ledger-entry@1` for a consequential decision, load-bearing assumption, or recurrent correction. Never a verdict; readers re-anchor, never trust. |
-| **continuity-verify** | The **resumption** moment — fires first when a session resumes from a compaction summary, handoff note, or prior-session task whose next action depends on remembered state. It re-anchors load-bearing claims and emits a state digest. Its quick mode keeps trivial resumptions small. |
+## Choose by task
 
-## Layout
+| Task shape | Entry point | Expected result |
+|---|---|---|
+| Local, reversible, directly checkable, non-precedential change | Ordinary workflow | Change plus bounded check; no epistemic artifact |
+| Non-routine task with multiple possible disciplines or ordering questions | `using-epistemic-skills` | Triggered route and explicit handoffs; silent if the task clears the routine gate |
+| Workflow layer and epistemic collection must operate together | `helix` | Correctly ordered pair and member artifact; no absent-pair inventory |
+| Resume from a compaction summary, handoff, or remembered state | `continuity-verify` | Re-anchored state digest or visible uncertainty |
+| Micro-recon exposes map/territory mismatch, hidden coupling, fuzzy scope, or fan-out risk | `blindspot-pass` | Read-only territory map and rewritten request |
+| Material software/system fork or correctness/property claim | `applying-formal-rigor` | Inline focused derivation or a revision-bound formal record |
+| Claim depends on scholarly evidence or a research connector | `evidence-research` | Qualified evidence with reception, holdings, and degradation stated |
+| Operator explicitly asks to author or start a persistent goal | `write-goal` | Approved completion contract with proof, scope, blockers, and stop rule |
+| Consequential uncovered decision, assumption, or recurrent correction must survive | `decision-ledger` | Reused adequate artifact or a minimal ledger entry |
+| Work crosses to an external model, agent, or process | **outsource** | Target-readable immutable handoff packet and short pointer, or `BLOCKED` |
+| High-stakes or irreversible decision needs an adversarial gate | `gauntlet` | Conflict Ledger and computed GO / CONDITIONAL / NO-GO |
+| Material UI-facing work needs an acceptance claim | `evidence-locked-uat` | Actor evidence, blinded verification, and deterministic verdict |
 
+The [workflow recipes](https://github.com/ZMS-Labs/epistemic-skills/wiki/Workflow-Recipes) show how these boundaries compose without turning the table into a checklist.
+
+## The epistemic arc
+
+The arc is a set of trigger-dependent handoffs, not a conveyor belt every task must traverse:
+
+```mermaid
+flowchart LR
+    T["Task or resumed work"] --> Q{"Prior-state claim<br/>bears load?"}
+    Q -- yes --> CV["Continuity Verify<br/>re-anchor state"]
+    Q -- no --> R{"Routine?<br/>all four tests"}
+    CV --> R
+    R -- yes --> B["Change + bounded check<br/>record-free exit"]
+    R -- no --> U["Epistemic router"]
+
+    U -. "mismatch / coupling / fan-out" .-> BP["Blindspot Pass<br/>recon"]
+    BP -. "material design fork" .-> FR["Applying Formal Rigor<br/>derive"]
+    U -. "material design fork" .-> FR
+    ER["Evidence Research<br/>qualify scholarly premise"] -. "grounds" .-> FR
+    FR -. "explicit persistent goal" .-> WG["Write Goal<br/>completion contract"]
+    WG -. "high-stakes gate" .-> G["Gauntlet<br/>adversarial verdict"]
+    G -. "material UI acceptance" .-> UAT["Evidence-Locked UAT<br/>blinded proof"]
+
+    U -. "external boundary" .-> O["Outsource<br/>immutable handoff"]
+    D["Decision Ledger<br/>persist uncovered consequential moment"] -. "cross-cutting reuse" .-> U
 ```
-epistemic-skills/                         # repo root
-├── plugins/epistemic-skills/
-│   ├── skills/<name>/SKILL.md            # canonical skill cores (eleven)
-│   ├── contracts/                        # handoff-receipt contract: schema, stdlib verifier, synthetic examples
-│   ├── agents/                           # gauntlet role-agents (five)
-│   ├── .claude-plugin/plugin.json
-│   ├── .codex-plugin/plugin.json
-│   └── .cursor-plugin/plugin.json
-├── skills/  → plugins/epistemic-skills/skills/    # symlink (Gemini / root scanners)
-├── agents/  → plugins/epistemic-skills/agents/    # symlink
-├── .claude-plugin/marketplace.json
-├── .agents/plugins/marketplace.json      # Codex marketplace index
-├── .cursor-plugin/plugin.json            # Cursor whole-repo plugin
-├── .cursor-plugin/marketplace.json       # Cursor team-marketplace index
-├── gemini-extension.json + GEMINI.md     # Gemini CLI extension
-├── .kimi-plugin/plugin.json              # Kimi Code plugin (points at the same skills tree)
-└── plugin.json                           # Antigravity native plugin
-```
 
-One tree of method files; harness-specific manifests only. Do not fork the skills per harness.
+Evidence Research, Decision Ledger, and Outsource are cross-cutting. Continuity Verify is pre-arc. Most tasks clear the routine gate or fire one discipline. See [The Epistemic Arc](https://github.com/ZMS-Labs/epistemic-skills/wiki/The-Epistemic-Arc) for handoff details and [Core Concepts](https://github.com/ZMS-Labs/epistemic-skills/wiki/Core-Concepts) for the five epistemic-flexibility controls.
 
-## Install
+## Eleven-skill catalog
 
-Install with **exactly one** mechanism per harness. A second copy of the same skills (for example `npx skills add` on top of a plugin install) produces duplicate triggers.
+The package contains exactly one router, Helix, and nine disciplines. Each name appears once in this catalog; the linked guide and immutable source define the full contract.
 
-### 3.0.0 migration
+| Skill | Positive trigger | Purpose | Output |
+|---|---|---|---|
+| [`using-epistemic-skills`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Using-Epistemic-Skills) | Non-routine work may need multiple disciplines, ordering, external crossing, or resumption | Apply the routine gate and route epistemic members | Triggered route and handoff path; routine exit is record-free |
+| [`helix`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Helix-Central-Passage) | Workflow and epistemic layers coexist and a positive pairing exists, or sequencing/crossing is ambiguous | Pair stages across the central passage | Member artifact plus compact fired/overridden custody record where applicable |
+| [`blindspot-pass`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Blindspot-Pass) | Micro-recon reveals mismatch, hidden coupling, fuzzy scope, or material fan-out risk | Read-only reconnaissance before effort multiplies | Territory map, landmines, questions, and rewritten request |
+| [`applying-formal-rigor`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Applying-Formal-Rigor) | Explicit formal request or material multi-option systems/property decision | Derive rather than assert software and systems claims | ≤6 bullets/250-word focused answer, or `formal-rigor-record@2` at higher tiers |
+| [`evidence-research`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Evidence-Research) | Scholarly evidence claim or any Consensus, Scite, or durable-library call | Check holdings, discover, reception-check, cross-validate, and preserve evidence | Source matrix with reception/holdings provenance and explicit degradation |
+| [`write-goal`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Write-Goal) | Explicit intent to author, refine, or start a durable goal | Bind operator intent to proof, scope, blockers, and stop rules | Approved goal contract; execution/certification remains downstream |
+| [`continuity-verify`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Continuity-Verify) | Resumption depends on summary, handoff, or remembered state | Re-anchor load-bearing state before acting | Verified state digest or bounded unresolved uncertainty |
+| [`decision-ledger`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Decision-Ledger) | Uncovered consequential decision, assumption, or recurrent correction will bear future load | Reuse adequate durable records and persist only the gap | Existing artifact reference or `ledger-entry@1`; never a verdict |
+| [`outsource`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Outsource) | Durable handoff to an external model, agent, or process | Make the repository carry complete context and provenance | Committed, pushed, target-readable packet plus short pointer, or `BLOCKED` |
+| [`gauntlet`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Gauntlet) | High-stakes, one-way-door, high-blast-radius, risky pre-merge, or explicit adversarial gate | Multi-lens review of a frozen, truth-gated subject | Conflict Ledger and computed GO / CONDITIONAL / NO-GO |
+| [`evidence-locked-uat`](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Evidence-Locked-UAT) | Explicit UAT or material interaction/state/accessibility-sensitive UI acceptance | Separate actor, blinded verifier, and deterministic judge | Evidence packet and strict verdict; `INCONCLUSIVE` never becomes PASS |
 
-For 3.0.0, replace the existing plugin or skill copy rather than layering a
-second installation mechanism over it, then reload the harness or start a fresh
-task. Codex users must rerun the Gauntlet role renderer from the
-3.0.0 cache path. Integrations must also accept silent routine/absent-trigger
-paths and the tiered applying-formal-rigor contract: focused work is inline and
-record-free, while standard and high-assurance work emit
-`formal-rigor-record@2`. Full migration details are maintained in
-[`docs/release/RELEASE-3.0.0.md`](docs/release/RELEASE-3.0.0.md).
+## Installation and compatibility
+
+### One copy, one version, one canonical tree
+
+Install with **exactly one mechanism per harness**. Native plugin **or** generic skill install—never both. For 3.0.0, replace an older untagged copy, reload, and verify both the skill count and source path. Duplicate copies create duplicate triggers and can silently mix contract versions.
+
+| Harness | v3.0.0 surface | Required follow-through | Honest support boundary |
+|---|---|---|---|
+| Claude Code | Local marketplace from tagged checkout | Start a fresh task | Package discovery from one immutable checkout |
+| Codex | Tagged plugin marketplace | Render five Gauntlet roles; start a new task | Manifest does not itself register custom collaboration-agent types |
+| Cursor | Tagged local checkout or team marketplace | Reload window; verify eleven skills | Public listing unavailable; recorded behavioral epoch is `BLOCKED_EXTERNAL` |
+| Gemini CLI | Tagged extension | Restart and validate extension | Uses root context and canonical symlinked tree |
+| Antigravity (`agy`) | Tagged native local plugin | Validate with `agy` | Choose native, Gemini link, or import—only one |
+| Kimi Code | Tagged repository plugin | `/reload` or new session | Plugin instructions map isolated-agent primitives |
+| Generic Agent Skills host | Tagged canonical skills URL | Reload host and verify source | Host must supply any runtime primitive the selected skill requires |
+
+Full installation, migration, runtime-degradation, and troubleshooting guidance lives in the [installation handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility).
 
 ### Claude Code
-
-Prepare a dedicated checkout of the immutable tag, then add that local
-marketplace:
 
 ```bash
 git clone --depth 1 --branch v3.0.0 https://github.com/ZMS-Labs/epistemic-skills.git /path/to/epistemic-skills-v3.0.0
@@ -147,50 +209,38 @@ git clone --depth 1 --branch v3.0.0 https://github.com/ZMS-Labs/epistemic-skills
 /plugin install epistemic-skills@epistemic-skills
 ```
 
+Use the dedicated tagged checkout as the single marketplace source, then start a fresh task.
+
 ### Codex
 
 ```powershell
 codex plugin marketplace add ZMS-Labs/epistemic-skills --ref v3.0.0
 codex plugin add epistemic-skills@epistemic-skills
-# Register the five gauntlet roles in Codex's user-agent registry:
 python "$HOME/.codex/plugins/cache/epistemic-skills/epistemic-skills/3.0.0/skills/gauntlet/scripts/render_codex_agents.py" --out "$HOME/.codex/agents"
 ```
 
-Start a new Codex task after rendering the roles. Codex plugin manifests do not
-currently register custom collaboration-agent types themselves; the renderer
-bridges the canonical packaged Markdown roles into Codex's native user-agent
-TOML registry. The gauntlet also retains a hashed exact-role materialization
-fallback for a task started before registration.
+Start a new Codex task after rendering. The renderer converts the five canonical packaged Markdown roles into Codex's user-agent registry. The Gauntlet retains a hashed exact-role materialization fallback for tasks that started before registration.
 
 ### Cursor
 
-**Status:** packaging is ready (`.cursor-plugin/` manifests, version 3.0.0). The plugin is **not yet listed** on the public [Cursor Marketplace](https://cursor.com/marketplace); `/add-plugin epistemic-skills` works only after Cursor lists it or you import the repo as a [team marketplace](https://cursor.com/docs/plugins). Publisher application: [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish).
+Cursor packaging is present in v3.0.0, but the plugin is **not publicly listed**. `/add-plugin epistemic-skills` is not a valid public-install claim until Cursor accepts the listing. Use a tagged local checkout or a Cursor Teams/Enterprise team-marketplace import.
 
-| Path | When to use |
-|---|---|
-| Local install (below) | Personal / fleet / until marketplace listing |
-| Team marketplace import of this GitHub repo | Cursor Teams/Enterprise private distribution |
-| Public marketplace `/add-plugin` | After Cursor accepts the publisher listing |
-
-**Local install:** Use a checkout of tag `v3.0.0` for a stable install; use a
-branch checkout only for development.
+Windows local install:
 
 ```powershell
-# Windows — create and verify a dedicated stable checkout
 git clone --depth 1 --branch v3.0.0 https://github.com/ZMS-Labs/epistemic-skills.git .\epistemic-skills-v3.0.0
 Set-Location .\epistemic-skills-v3.0.0
 if ((git describe --tags --exact-match) -ne 'v3.0.0') { throw 'expected v3.0.0' }
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.cursor\plugins\local" | Out-Null
-$src  = (Resolve-Path .\plugins\epistemic-skills).Path
+$src = (Resolve-Path .\plugins\epistemic-skills).Path
 $dest = Join-Path $env:USERPROFILE '.cursor\plugins\local\epistemic-skills'
-if (Test-Path -LiteralPath $dest) {
-  throw "Cursor plugin destination already exists; move or remove it manually after verifying its contents: $dest"
-}
+if (Test-Path -LiteralPath $dest) { throw "destination already exists; inspect it before replacement: $dest" }
 cmd /c mklink /J "$dest" "$src"
 ```
 
+macOS/Linux local install:
+
 ```bash
-# macOS / Linux — create and verify a dedicated stable checkout
 git clone --depth 1 --branch v3.0.0 https://github.com/ZMS-Labs/epistemic-skills.git ./epistemic-skills-v3.0.0
 cd ./epistemic-skills-v3.0.0
 test "$(git describe --tags --exact-match)" = v3.0.0
@@ -198,23 +248,19 @@ mkdir -p ~/.cursor/plugins/local
 ln -sfn "$(pwd)/plugins/epistemic-skills" ~/.cursor/plugins/local/epistemic-skills
 ```
 
-Then **Developer: Reload Window**. Success check: all eleven skills under Customize → Skills, and auto-trigger on matching prompts (for example an irreversible / stress-test ask should surface the router or `gauntlet`).
-
-Do **not** also install these skills into `~/.cursor/skills/` while the plugin is loaded.
+Run **Developer: Reload Window**, verify all eleven skills under Customize → Skills, and do not also install them into `~/.cursor/skills/`.
 
 ### Gemini CLI
 
 ```bash
 gemini extensions install https://github.com/ZMS-Labs/epistemic-skills --ref v3.0.0 --consent
-# local dev:
+# Local development only:
 gemini extensions link /path/to/epistemic-skills
 ```
 
-Restart the Gemini session after install/link. Entrypoints: `gemini-extension.json`, `GEMINI.md`, root `skills/` symlink. Validated with `gemini extensions validate`.
+Restart the session and run `gemini extensions validate` when validating a checkout. Stable users should use the tagged install, not the mutable development link.
 
 ### Antigravity (`agy`)
-
-Native plugin marker is root [`plugin.json`](plugin.json) (Antigravity schema: `name` + `description`). Same `skills/` / `agents/` tree:
 
 ```bash
 git clone --depth 1 --branch v3.0.0 https://github.com/ZMS-Labs/epistemic-skills.git /path/to/epistemic-skills-v3.0.0
@@ -222,65 +268,146 @@ agy plugin install /path/to/epistemic-skills-v3.0.0
 agy plugin validate /path/to/epistemic-skills-v3.0.0
 ```
 
-Prefer **one** of: native `agy plugin install`, Gemini extension link, or `agy plugin import gemini` — not several copies.
+Use one of native `agy plugin install`, Gemini extension link, or `agy plugin import gemini`; do not combine them.
 
 ### Kimi Code
 
 ```text
 /plugins install https://github.com/ZMS-Labs/epistemic-skills/tree/v3.0.0
-# local dev, from a clone:
+# Local development only, from a clone:
 /plugins install /path/to/epistemic-skills
 ```
 
-Run `/reload` or start a new session after install. Entrypoint: root `.kimi-plugin/plugin.json`, which points at the same canonical `plugins/epistemic-skills/skills/` tree; its `skillInstructions` carries the Kimi tool mapping (gauntlet role agents and the UAT actor/verifier/judge dispatch through the `Agent` tool in isolated contexts). If the plugin manager is unavailable, junction the skills into the user skills directory instead — pick exactly one mechanism:
+Run `/reload` or start a new session. `.kimi-plugin/plugin.json` points to the canonical package tree and supplies the Kimi tool mappings.
 
-```powershell
-Get-ChildItem .\plugins\epistemic-skills\skills -Directory | ForEach-Object {
-  New-Item -ItemType Junction -Path "$env:USERPROFILE\.kimi-code\skills\$($_.Name)" -Target $_.FullName
-}
-```
-
-### Using these in any harness
-
-The skills follow the [Agent Skills spec](https://agentskills.io/specification). Point your agent at `plugins/epistemic-skills/skills/` (or the root `skills/` symlink) or a single `SKILL.md`:
+### Generic harness
 
 ```bash
 npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v3.0.0/plugins/epistemic-skills/skills
 ```
 
-Use this **only** when the harness has no native plugin/extension install.
+Use this only when the host has no native plugin or extension. Frontmatter `description` is the trigger; the body is the method. Compatibility means the host preserves the selected skill's capability, ordering, isolation, persistence, and fail-closed contracts—not merely that it can display Markdown.
 
-- **Frontmatter `description`** is the trigger; the body is the method.
-- **Apply the routine gate before loading a process container.** A missing optional skill does not block reversible, local, directly-checkable work; a missing discipline at a positive high-stakes boundary does.
-- **Meet the contract, not the tool.** Runtime needs:
-  - **gauntlet** Step 5: concurrent, context-isolated exact-role agents behind a barrier (degrade: sequential isolated calls). Definitions in `agents/`; runtimes without plugin-defined custom-agent registration use the replayable materialized-role adapter documented in `skills/gauntlet/reference/runtime-role-binding.md`.
-  - **evidence-locked-uat**: actor / blinded-verifier / deterministic-judge in separate contexts for material acceptance runs.
-  - **evidence-research**: Consensus + Scite MCP + durable library (Zotero or equivalent — identify by server / Web API / LOCAL.md host); degrade explicitly when a layer is absent.
-  - **write-goal**: persistent-goal inspection/creation plus a user-question primitive when the harness provides them; otherwise it returns the approved contract without pretending to start it.
-  - **outsource**: repository read/write plus Git/GitHub publication and verification when available; without a pushed, target-readable packet it returns `BLOCKED`, never a ready-looking prompt.
-  - **applying-formal-rigor** and **blindspot-pass**: pure method — no runtime dependency.
-- **`using-epistemic-skills`** is the router; read it first.
+## Architecture and source policy
 
-Gauntlet scripts (`skills/gauntlet/scripts/*.py`) are stdlib-only Python.
+One canonical tree contains all method files; thin harness manifests expose that tree without forking behavior:
 
-## Design principles
+```text
+epistemic-skills/
+├── plugins/epistemic-skills/
+│   ├── skills/<name>/SKILL.md           canonical skill cores (eleven)
+│   ├── agents/                          five canonical Gauntlet roles
+│   ├── contracts/                       shared receipt schema and verifier
+│   ├── .claude-plugin/plugin.json
+│   ├── .codex-plugin/plugin.json
+│   └── .cursor-plugin/plugin.json
+├── skills  ──symlink──> plugins/epistemic-skills/skills
+├── agents  ──symlink──> plugins/epistemic-skills/agents
+├── .claude-plugin/marketplace.json
+├── .agents/plugins/marketplace.json
+├── .cursor-plugin/{plugin,marketplace}.json
+├── gemini-extension.json + GEMINI.md
+├── .kimi-plugin/plugin.json
+└── plugin.json                           Antigravity marker
+```
 
-- **Floors, not ceilings; proportional cost.** Routine work leaves before the arc. Extra process earns no credit unless it can expose an action-changing error.
-- **Derive, don't assert.** Conclusions are earned from named theory or read evidence.
-- **Language carries claims, not automatic truth or authority.** Separate observation,
-  interpretation, prediction, value, and authorization before a claim bears load.
-- **End at the boundary.** Each skill stops where the next begins.
-- **Absent triggers are silent.** Audit consequential actions and overrides, not non-events.
-- **Fail closed; degrade explicitly.** Missing load-bearing tools yield visible limits — never a silent pass; preserve uncertainty with hold, escalation, or a bounded reversible probe.
+### Contract layers
 
-## Gauntlet status (honest)
+| Layer | What it establishes | What it does not establish |
+|---|---|---|
+| Skill contract | Trigger, method, output, boundary, degradation, and handoff | That a particular run followed the contract correctly |
+| Artifact/schema contract | Shape, vocabulary, required fields, and machine-verifiable invariants | Truth of the conclusion or quality of judgment |
+| `handoff-receipt@1` | Producer-declared identity/provenance fields, hash binding, validity envelope | Authenticated origin, authorship, verdict truth, or independence |
+| Runtime contract | Required isolation, tool, storage, ordering, and failure semantics | Equivalent behavioral quality across providers or harnesses |
 
-Full map: [`skills/gauntlet/reference/roadmap.md`](plugins/epistemic-skills/skills/gauntlet/reference/roadmap.md).
+See [Architecture and Contracts](https://github.com/ZMS-Labs/epistemic-skills/wiki/Architecture-and-Contracts) and [Cross-Harness Packaging](https://github.com/ZMS-Labs/epistemic-skills/wiki/Cross-Harness-Packaging).
 
-**Shipped and validated:** staple, falsifiability contract, mechanical evidence checks, and deterministic selector. The historical pre-AC-07 arbitrator battery caught 10/10 planted defect classes, but the amended battery is `NOT_RUN`; 3.0.0 therefore makes no current arbitrator-certification claim. Battery, scorer, and history: [`evals/arbitrator-certification/`](plugins/epistemic-skills/skills/gauntlet/evals/arbitrator-certification/).
+### Source and version policy
 
-**Still partial:** behavioral regression battery has only a smoke-subset run (non-inferiority, not superiority); the full 24×4 sweep and later measurement bundles remain designs — stated as such, never claimed done. (Smoke-run notes are not published as a standalone file in this repo.)
+For a stable behavior claim, use this order:
 
-## License
+1. immutable released `SKILL.md`, contract, schema, or executable check;
+2. released references, records, and evidence at the same tag;
+3. README and Wiki explanations.
 
-[GPL-3.0-or-later](LICENSE) — GNU General Public License, version 3 or (at your option) any later version.
+`main` is current development and may move. The Wiki is a curated, unversioned handbook and must label current-development links. Historical audits and evaluations retain the status and scope they had at their frozen revision. Stable installation commands always use an immutable tag.
+
+## Trust, evidence, and known limits
+
+Version 3.0.0 is a real release with aligned package surfaces, deterministic checks, a tagged source snapshot, and committed evidence. It is also deliberately honest about what those facts do not prove.
+
+### What the evidence supports
+
+- Deterministic checks protect named routing, proportionality, schema, receipt, UAT-judge, DCO-policy, package-integration, and Gauntlet-mechanics invariants.
+- The blinded proportionality campaign retained 162/162 terminal, schema-valid matched calls; the candidate passed the routine, material, and high-risk contract while corrected full-ceremony and always-routine parodies failed.
+- The tag and GitHub Release provide an immutable support coordinate for the packaged contracts and installation instructions.
+
+### Required limitations
+
+| Boundary | Honest v3.0.0 status |
+|---|---|
+| Behavioral correctness | The post-hoc semantic review found **two genuine P0 failures**, `tm-02` and `tm-03`. Do not claim all observed candidates were correct. |
+| AGY adjudication | Forty-four OpenAI-origin candidates received no valid semantic judgment because all **88 AGY attempts** ended as zero-token quota failures. These are availability failures—not merit judgments, passes, or proof the responses would fail. |
+| Generality | Provider, repetition, and judge assignment are confounded; paired seats are correlated. The release does not establish universal superiority or cross-provider generality. |
+| Cursor | v3.0.0 packaging exists, but public marketplace listing is unavailable and the retained behavioral epoch is **`BLOCKED_EXTERNAL`**. Packaging readiness is not runtime behavioral proof. |
+| Structural polarity | Closed-taxonomy and formal-only parodies outperformed the candidate on available structural scoring, and three AGY parody arms are absent. Structural conformance is not semantic correctness. |
+| Gauntlet certification | The historical pre-AC-07 result caught 10/10 planted defect classes, but the amended arbitrator-certification battery is **`NOT_RUN`**. No current arbitrator-certification claim is made. |
+| Post-hoc diagnostic | The V3 diagnostic remains exactly **`release_credit: none`**. It informed bounded risk acceptance but did not repair, qualify, or retroactively pass the excluded campaign. |
+
+Operator risk acceptance covered only the named behavioral-confidence gaps. It did **not** waive or satisfy deterministic, DCO, CodeQL, secret-scanning, provenance, independent-review, or publication-identity gates. The machine-readable [v3.0.0 risk record](docs/release/RELEASE-3.0.0-RISK-ACCEPTANCE.json) controls the precise scope.
+
+Read [Evidence, Status, and Known Limitations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Evidence-Status-and-Known-Limitations), the [release record](docs/release/RELEASE-3.0.0.md), and the [no-credit diagnostic](docs/release/evidence/2026-07-26-formal-rigor-v3-posthoc-diagnostic.md) before making broad behavioral claims.
+
+## Developing and contributing
+
+Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the maintainer handbook. Contract-bearing edits should change the canonical tree, add the smallest discriminating test, keep adapters thin, and preserve routine exits, silent absent triggers, authority boundaries, and record-free outcomes.
+
+### Verification by claim
+
+Run checks in proportion to the change:
+
+```powershell
+# Routing and proportionality
+python plugins/epistemic-skills/skills/using-epistemic-skills/evals/epistemic-flexibility/run_tests.py
+python plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/run_tests.py
+
+# Formal-rigor and package integration
+python plugins/epistemic-skills/skills/applying-formal-rigor/evals/formal-rigor-v2-fixtures/tests/run_tests.py
+python plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+
+# Shared mechanics
+python .github/scripts/check_json_artifacts.py
+python plugins/epistemic-skills/contracts/verify_receipt.py --self-test
+python plugins/epistemic-skills/skills/evidence-locked-uat/scripts/judge.py --self-test
+python plugins/epistemic-skills/skills/gauntlet/tests/run_tests.py
+```
+
+These are useful local entry points, not the complete release gate. The [testing handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Testing-and-Evaluations) reproduces the full released stdlib command map and distinguishes deterministic, behavioral, diagnostic, and release-credit evidence.
+
+Every pull-request commit must carry an author-matching DCO trailer:
+
+```text
+git commit --signoff
+```
+
+A release additionally requires exact-head CI, DCO, CodeQL, full-history secret scanning with a positive control, provenance review, independent publication review, final Gauntlet, and tag/Release identity checks. See [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) and [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO).
+
+### Maintainer map
+
+- [Architecture and Contracts](https://github.com/ZMS-Labs/epistemic-skills/wiki/Architecture-and-Contracts)
+- [Cross-Harness Packaging](https://github.com/ZMS-Labs/epistemic-skills/wiki/Cross-Harness-Packaging)
+- [Testing and Evaluations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Testing-and-Evaluations)
+- [Evidence, Status, and Known Limitations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Evidence-Status-and-Known-Limitations)
+- [Contributing](https://github.com/ZMS-Labs/epistemic-skills/wiki/Contributing)
+- [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning)
+- [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO)
+- [Design History and Audits](https://github.com/ZMS-Labs/epistemic-skills/wiki/Design-History-and-Audits)
+
+## License and support
+
+[GPL-3.0-or-later](LICENSE)—GNU General Public License, version 3 or, at your option, any later version.
+
+- Handbook: [GitHub Wiki](https://github.com/ZMS-Labs/epistemic-skills/wiki)
+- Stable releases: [Releases](https://github.com/ZMS-Labs/epistemic-skills/releases)
+- Questions and defects: [Issues](https://github.com/ZMS-Labs/epistemic-skills/issues)
+- Canonical repository: [ZMS-Labs/epistemic-skills](https://github.com/ZMS-Labs/epistemic-skills)

--- a/docs/superpowers/plans/2026-07-26-github-wiki-readme-handbook.md
+++ b/docs/superpowers/plans/2026-07-26-github-wiki-readme-handbook.md
@@ -157,7 +157,7 @@ Expected: one GitHub-created initial page commit. Do not amend or rewrite it.
 Use the approved design sections `Helix as the central passage`, `Homepage design`, and `Source and version policy`. Each content page begins:
 
 ```markdown
-> **Applies to:** epistemic-skills v3.0.0  
+> **Applies to:** epistemic-skills v3.0.0
 > **Canonical source:** [released source](https://github.com/ZMS-Labs/epistemic-skills/tree/v3.0.0/plugins/epistemic-skills/skills)
 ```
 

--- a/docs/superpowers/plans/2026-07-26-github-wiki-readme-handbook.md
+++ b/docs/superpowers/plans/2026-07-26-github-wiki-readme-handbook.md
@@ -1,0 +1,688 @@
+# GitHub Wiki and README Handbook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a comprehensive dual-track GitHub Wiki and merge a substantially improved README that make v3.0.0 usable and maintainable while keeping repository contracts authoritative and presenting Helix as the central passage between workflow and epistemic layers.
+
+**Architecture:** The main repository owns the README, approved design, and implementation plan through a normal pull request. GitHub's separate `epistemic-skills.wiki.git` repository owns the curated handbook and its navigation. Stable guidance links to immutable `v3.0.0` sources; maintainer guidance labels `main` links as current development.
+
+**Tech Stack:** GitHub-flavored Markdown, GitHub Wiki Git repository, PowerShell, Git, GitHub CLI, stdlib Python validation, existing repository CI.
+
+## Global Constraints
+
+- Preserve the README estate-governance block byte-for-byte and in its existing top-of-file position.
+- Stable user guidance applies to `v3.0.0` and uses immutable tagged source links.
+- `using-epistemic-skills` remains the epistemic router.
+- Helix is the central passage between a workflow-skill layer and the epistemic router/disciplines; it is not a replacement router or mandatory ceremony.
+- Routine work exits first; absent skill and Helix pairing triggers remain silent.
+- Represent all eleven released skills exactly once in the skill-guide inventory. `Helix-Central-Passage.md` is also the Helix skill guide; do not create a duplicate `Skill-Helix.md`.
+- Preserve the v3.0.0 no-credit boundaries: two genuine P0 failures, AGY quota failures as availability failures, Cursor `BLOCKED_EXTERNAL`, amended arbitrator certification `NOT_RUN`, and post-hoc `release_credit: none`.
+- Do not change skill behavior, triggers, schemas, scripts, evaluations, or the immutable v3.0.0 tag/Release.
+- Use `apply_patch` for main-repository and local wiki file edits.
+- Keep the user's original `Y:\dev\epistemic-skills` checkout and its unrelated local commit untouched.
+- Sign every authored Git commit with an author-matching DCO trailer.
+
+---
+
+## File structure
+
+### Main repository
+
+- Modify: `README.md` — polished project front door, quick start, Helix passage, skill selection, installs, architecture, trust boundaries, and handbook links.
+- Existing: `docs/superpowers/specs/2026-07-26-github-wiki-and-readme-design.md` — approved design contract.
+- Create: `docs/superpowers/plans/2026-07-26-github-wiki-readme-handbook.md` — this executable plan.
+
+### Wiki repository
+
+- Create/replace: `Home.md` — dual-track landing page.
+- Create: `_Sidebar.md` — complete navigation with no orphaned pages.
+- Create: `_Footer.md` — stable release and source-of-truth notice.
+- Create: `Start-Here.md`
+- Create: `Helix-Central-Passage.md`
+- Create: `Choosing-a-Skill.md`
+- Create: `Routine-Work-and-Proportionality.md`
+- Create: `The-Epistemic-Arc.md`
+- Create: `Workflow-Recipes.md`
+- Create: `Installation-and-Harness-Compatibility.md`
+- Create: `Skill-Catalog.md`
+- Create: `Skill-Using-Epistemic-Skills.md`
+- Create: `Skill-Blindspot-Pass.md`
+- Create: `Skill-Applying-Formal-Rigor.md`
+- Create: `Skill-Evidence-Research.md`
+- Create: `Skill-Write-Goal.md`
+- Create: `Skill-Continuity-Verify.md`
+- Create: `Skill-Decision-Ledger.md`
+- Create: `Skill-Outsource.md`
+- Create: `Skill-Gauntlet.md`
+- Create: `Skill-Evidence-Locked-UAT.md`
+- Create: `Architecture-and-Contracts.md`
+- Create: `Cross-Harness-Packaging.md`
+- Create: `Testing-and-Evaluations.md`
+- Create: `Evidence-Status-and-Known-Limitations.md`
+- Create: `Contributing.md`
+- Create: `Release-Process-and-Versioning.md`
+- Create: `Security-Provenance-and-DCO.md`
+- Create: `Design-History-and-Audits.md`
+- Create: `Core-Concepts.md`
+- Create: `Glossary.md`
+- Create: `FAQ-and-Troubleshooting.md`
+- Create: `Version-History.md`
+
+---
+
+## Global failure policy
+
+- If Wiki bootstrap fails, stop before authoring against an unverified remote;
+  repair bootstrap, clone the real Wiki repository, then continue.
+- If a page, sidebar target, local link, stable coordinate, or claim check fails,
+  fix it before pushing the Wiki or merging the README.
+- If GitHub-rendered Markdown differs materially from the intended local
+  content, correct the source and publish a new commit.
+- If a released claim cannot be anchored to v3.0.0, omit it or label the
+  uncertainty; do not infer a guarantee from design intent.
+- Recover through new Git commits. Never rewrite the v3.0.0 tag or its Release.
+
+---
+
+### Task 1: Bootstrap and verify the GitHub Wiki repository
+
+**Files:**
+- Create through GitHub UI: `Home.md` with temporary text `epistemic-skills handbook bootstrap`
+- Clone into: `Y:\dev\epistemic-skills.wiki`
+
+**Interfaces:**
+- Consumes: authenticated GitHub access with Wiki enabled on `ZMS-Labs/epistemic-skills`.
+- Produces: a clean local clone whose `origin` is `https://github.com/ZMS-Labs/epistemic-skills.wiki.git` and whose branch is the remote default.
+
+- [ ] **Step 1: Verify the Wiki is enabled and still uninitialized**
+
+Run:
+
+```powershell
+gh repo view ZMS-Labs/epistemic-skills --json hasWikiEnabled --jq .hasWikiEnabled
+git ls-remote https://github.com/ZMS-Labs/epistemic-skills.wiki.git
+```
+
+Expected: the first command prints `true`; before bootstrap, the second reports that the Wiki Git repository is not found.
+
+- [ ] **Step 2: Create the first page through the authenticated GitHub Wiki interface**
+
+Open `https://github.com/ZMS-Labs/epistemic-skills/wiki/_new`, create page title `Home`, body `epistemic-skills handbook bootstrap`, and save it.
+
+Expected: `https://github.com/ZMS-Labs/epistemic-skills/wiki/Home` renders and the Wiki Git repository becomes cloneable.
+
+- [ ] **Step 3: Clone the newly created Wiki repository under the authoritative development root**
+
+Run:
+
+```powershell
+git clone https://github.com/ZMS-Labs/epistemic-skills.wiki.git Y:\dev\epistemic-skills.wiki
+git -C Y:\dev\epistemic-skills.wiki status --short --branch
+git -C Y:\dev\epistemic-skills.wiki remote -v
+```
+
+Expected: a clean branch, one bootstrap `Home.md`, and the exact Wiki `origin` URL.
+
+- [ ] **Step 4: Record the bootstrap commit without changing it**
+
+Run:
+
+```powershell
+git -C Y:\dev\epistemic-skills.wiki log -1 --oneline
+```
+
+Expected: one GitHub-created initial page commit. Do not amend or rewrite it.
+
+---
+
+### Task 2: Build the Wiki foundation, navigation, and central-passage pages
+
+**Files:**
+- Replace: `Y:\dev\epistemic-skills.wiki\Home.md`
+- Create: `Y:\dev\epistemic-skills.wiki\_Sidebar.md`
+- Create: `Y:\dev\epistemic-skills.wiki\_Footer.md`
+- Create: `Y:\dev\epistemic-skills.wiki\Start-Here.md`
+- Create: `Y:\dev\epistemic-skills.wiki\Helix-Central-Passage.md`
+- Create: `Y:\dev\epistemic-skills.wiki\Choosing-a-Skill.md`
+- Create: `Y:\dev\epistemic-skills.wiki\Routine-Work-and-Proportionality.md`
+- Create: `Y:\dev\epistemic-skills.wiki\The-Epistemic-Arc.md`
+- Create: `Y:\dev\epistemic-skills.wiki\Core-Concepts.md`
+
+**Interfaces:**
+- Consumes: released README; `using-epistemic-skills/SKILL.md`; `helix/SKILL.md`; `routine-fast-path.md`; `epistemic-flexibility.md` at tag `v3.0.0`.
+- Produces: the navigation contract and the canonical Wiki explanation of router-versus-Helix boundaries used by every later page.
+
+- [ ] **Step 1: Write the foundation pages with immutable source links**
+
+Use the approved design sections `Helix as the central passage`, `Homepage design`, and `Source and version policy`. Each content page begins:
+
+```markdown
+> **Applies to:** epistemic-skills v3.0.0  
+> **Canonical source:** [released source](https://github.com/ZMS-Labs/epistemic-skills/tree/v3.0.0/plugins/epistemic-skills/skills)
+```
+
+`Helix-Central-Passage.md` must explicitly include:
+
+```text
+workflow skills  <->  Helix central passage  <->  epistemic router and disciplines
+```
+
+and state that routine work exits before Helix, absent pairs are silent, Helix pairs the layers, and the router decides within the epistemic layer.
+
+- [ ] **Step 2: Write the complete sidebar before later pages exist**
+
+List every filename in the File structure section using GitHub Wiki links, grouped under `Use the skills`, `Develop and maintain`, and `Shared reference`. Place `Helix: Central Passage` immediately after `Start Here`.
+
+Expected: later validation initially fails because the sidebar names not-yet-created pages; this is the planned RED state.
+
+- [ ] **Step 3: Prove the navigation inventory is initially incomplete**
+
+Run this read-only check from the Wiki root:
+
+```powershell
+$targets = Select-String -Path _Sidebar.md -Pattern '\]\(([^)]+)\)' -AllMatches |
+  ForEach-Object { $_.Matches.Groups[1].Value }
+$missing = $targets | Where-Object { -not (Test-Path -LiteralPath (Join-Path $PWD (($_ -replace '/$','') + '.md'))) }
+$missing
+if (-not $missing) { throw 'expected later pages to be missing at this stage' }
+```
+
+Expected: the not-yet-authored skill, workflow, and maintainer pages are listed.
+
+- [ ] **Step 4: Commit the foundation locally without pushing partial Wiki content**
+
+Run:
+
+```powershell
+git add Home.md _Sidebar.md _Footer.md Start-Here.md Helix-Central-Passage.md Choosing-a-Skill.md Routine-Work-and-Proportionality.md The-Epistemic-Arc.md Core-Concepts.md
+git commit -s -m "docs: establish wiki navigation and central passage"
+```
+
+Expected: a signed local Wiki commit; do not push yet.
+
+---
+
+### Task 3: Author all eleven skill guides
+
+**Files:**
+- Existing from Task 2: `Y:\dev\epistemic-skills.wiki\Helix-Central-Passage.md`
+- Create the ten `Skill-*.md` files listed in File structure.
+
+**Interfaces:**
+- Consumes: each released `plugins/epistemic-skills/skills/<name>/SKILL.md` plus directly linked references and tests.
+- Produces: exactly eleven guides using the approved ten-section template; the Skill Catalog and recipes link to these pages.
+
+- [ ] **Step 1: Extract and review the released trigger contracts**
+
+Run from the main-repository worktree:
+
+```powershell
+Get-ChildItem plugins/epistemic-skills/skills -Directory | Sort-Object Name | ForEach-Object {
+  Write-Output "=== $($_.Name)"
+  Get-Content (Join-Path $_.FullName 'SKILL.md') -TotalCount 8
+}
+```
+
+Expected: eleven frontmatter descriptions. Treat them as use/do-not-use authority.
+
+- [ ] **Step 2: Write the ten remaining guides**
+
+Each page contains these exact headings:
+
+```markdown
+## What it does
+## Use it when
+## Do not use it when
+## Inputs and prerequisites
+## Normal workflow
+## Outputs and durable artifacts
+## Boundaries and failure modes
+## Example prompts
+## Related skills and handoffs
+## Canonical sources and evidence
+```
+
+Use realistic examples. Do not describe skill names as mandatory incantations. Include record-free routine/focused outcomes wherever the released skill defines them.
+
+- [ ] **Step 3: Validate exact skill coverage and template parity**
+
+Run from the Wiki root:
+
+```powershell
+$guides = @(
+  'Skill-Using-Epistemic-Skills.md','Helix-Central-Passage.md','Skill-Blindspot-Pass.md',
+  'Skill-Applying-Formal-Rigor.md','Skill-Evidence-Research.md','Skill-Write-Goal.md',
+  'Skill-Continuity-Verify.md','Skill-Decision-Ledger.md','Skill-Outsource.md',
+  'Skill-Gauntlet.md','Skill-Evidence-Locked-UAT.md'
+)
+if ($guides.Count -ne 11) { throw 'expected eleven skill guides' }
+$headings = @('What it does','Use it when','Do not use it when','Inputs and prerequisites','Normal workflow','Outputs and durable artifacts','Boundaries and failure modes','Example prompts','Related skills and handoffs','Canonical sources and evidence')
+foreach ($guide in $guides) {
+  if (-not (Test-Path -LiteralPath $guide)) { throw "missing $guide" }
+  $text = Get-Content $guide -Raw
+  foreach ($heading in $headings) { if ($text -notmatch "(?m)^## $([regex]::Escape($heading))$") { throw "$guide missing $heading" } }
+}
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 4: Commit the skill guides locally**
+
+Run:
+
+```powershell
+git add Skill-*.md Helix-Central-Passage.md
+git commit -s -m "docs: add comprehensive skill guides"
+```
+
+Expected: a signed local Wiki commit; do not push yet.
+
+---
+
+### Task 4: Author user workflows, installation, and shared reference
+
+**Files:**
+- Create: `Workflow-Recipes.md`
+- Create: `Installation-and-Harness-Compatibility.md`
+- Create: `Skill-Catalog.md`
+- Create: `Glossary.md`
+- Create: `FAQ-and-Troubleshooting.md`
+- Create: `Version-History.md`
+
+**Interfaces:**
+- Consumes: released README install commands, release notes, manifest files, skill guides, and compatibility limits.
+- Produces: task-based cross-skill paths, one-copy installation guidance, quick reference, and common recovery instructions.
+
+- [ ] **Step 1: Write workflow recipes**
+
+Include at least these recipes with entry decision, sequence, handoffs, stop condition, and routine alternative:
+
+- reversible local edit;
+- unfamiliar task whose two-read micro-recon exposes coupling;
+- consequential design decision;
+- research-backed design premise;
+- persistent goal contract;
+- high-stakes design or pre-merge gate;
+- material UI acceptance;
+- resumed work from a summary;
+- consequential decision persistence;
+- durable external model handoff;
+- workflow plus epistemic operation through Helix.
+
+- [ ] **Step 2: Write the harness installation and compatibility guide**
+
+Cover Claude Code, Codex, Cursor, Gemini CLI, Antigravity, Kimi Code, and generic Agent Skills. Preserve the one-copy rule, immutable `v3.0.0` coordinates, reload/restart checks, Codex Gauntlet role rendering, Cursor marketplace limitation, and explicit degradation rules.
+
+- [ ] **Step 3: Write the catalog and shared references**
+
+`Skill-Catalog.md` uses columns `Skill`, `Entry trigger`, `Purpose`, `Output`, and `Guide`. `Glossary.md` defines at least routine path, micro-recon, positive trigger, central passage, router, discipline, epistemic arc, load-bearing claim, provenance, no-credit, fail-closed, blinded verifier, Conflict Ledger, and durable artifact. `FAQ-and-Troubleshooting.md` includes duplicate installs, absent triggers, missing subagents, unavailable research substrate, inconclusive UAT, blocked external handoff, and resumption uncertainty.
+
+- [ ] **Step 4: Commit the user and reference pages locally**
+
+Run:
+
+```powershell
+git add Workflow-Recipes.md Installation-and-Harness-Compatibility.md Skill-Catalog.md Glossary.md FAQ-and-Troubleshooting.md Version-History.md
+git commit -s -m "docs: add workflows installation and reference handbook"
+```
+
+Expected: a signed local Wiki commit; do not push yet.
+
+---
+
+### Task 5: Author the maintainer handbook
+
+**Files:**
+- Create all eight maintainer pages listed under `Develop and maintain`.
+
+**Interfaces:**
+- Consumes: `README.md`, `CONTRIBUTING.md`, `RELEASING.md`, package manifests, `.github/workflows`, contracts, evaluations, design specs, audits, release evidence, and the v3.0.0 risk record.
+- Produces: current-development documentation that clearly separates released contracts from mutable maintainer state.
+
+- [ ] **Step 1: Write architecture and packaging pages**
+
+Explain the single canonical skills tree, root symlinks, thin harness manifests, shared Gauntlet agents, contracts, and runtime role binding. Link released behavior to `v3.0.0`; label `main` links as current development.
+
+- [ ] **Step 2: Write testing, evidence, and security pages**
+
+Map the deterministic batteries, continuity polarity, UAT judge, Gauntlet suite, package integration, DCO, CodeQL, and full-history gitleaks positive control. Preserve the exact known limitations and distinguish structural tests, behavioral evidence, diagnostic evidence, and release credit.
+
+- [ ] **Step 3: Write contributing, release, and design-history pages**
+
+Summarize the routine contribution path, DCO, version rules, release gates, partial-publication recovery, major design specs, collection audits, and stress-test records. Never present a historical audit as current certification.
+
+- [ ] **Step 4: Commit the maintainer handbook locally**
+
+Run:
+
+```powershell
+git add Architecture-and-Contracts.md Cross-Harness-Packaging.md Testing-and-Evaluations.md Evidence-Status-and-Known-Limitations.md Contributing.md Release-Process-and-Versioning.md Security-Provenance-and-DCO.md Design-History-and-Audits.md
+git commit -s -m "docs: add maintainer handbook"
+```
+
+Expected: a signed local Wiki commit; do not push yet.
+
+---
+
+### Task 6: Redesign the main README as the project front door
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: approved design, completed Wiki filenames, v3.0.0 release, workflow URLs, released install commands, and skill contracts.
+- Produces: the merged entry point whose deep links target the public Wiki pages.
+
+- [ ] **Step 1: Capture and protect the estate block**
+
+Run:
+
+```powershell
+$before = (Get-Content README.md -Raw) -replace '(?s)^(.*?<!-- ZMS-ESTATE:END -->).*','$1'
+$before | Set-Variable EstateBlock
+```
+
+Do not write `$EstateBlock` to disk. After editing, compare the same prefix byte-for-byte.
+
+- [ ] **Step 2: Rewrite the README using the approved section order**
+
+Add durable badges:
+
+```markdown
+[![Release](https://img.shields.io/github/v/release/ZMS-Labs/epistemic-skills?display_name=tag)](https://github.com/ZMS-Labs/epistemic-skills/releases/latest)
+[![epistemic-flexibility](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml)
+[![release-security](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/release-security.yml/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/release-security.yml)
+[![CodeQL](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/github-code-scanning/codeql)
+[![License](https://img.shields.io/github/license/ZMS-Labs/epistemic-skills)](LICENSE)
+```
+
+Include the dual audience paths, five-minute start, routine gate, Helix central-passage diagram, task-to-skill table, Mermaid arc, all-eleven skill catalog, compatibility matrix and detailed installs, architecture, trust limits, maintainer links, and license.
+
+- [ ] **Step 3: Verify the estate block is unchanged**
+
+Run in the same PowerShell session used in Step 1:
+
+```powershell
+$after = (Get-Content README.md -Raw) -replace '(?s)^(.*?<!-- ZMS-ESTATE:END -->).*','$1'
+if ($after -cne $EstateBlock) { throw 'estate block changed' }
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 4: Verify required README concepts and Wiki links**
+
+Run:
+
+```powershell
+$text = Get-Content README.md -Raw
+@('Version 3.0.0','Routine work','Helix','central passage','using-epistemic-skills','release_credit: none','GitHub Wiki') |
+  ForEach-Object { if ($text -notmatch [regex]::Escape($_)) { throw "README missing $_" } }
+$skills = Get-ChildItem plugins/epistemic-skills/skills -Directory | Select-Object -ExpandProperty Name
+foreach ($skill in $skills) { if ($text -notmatch [regex]::Escape($skill)) { throw "README missing $skill" } }
+```
+
+Expected: PASS with no output.
+
+- [ ] **Step 5: Commit the README locally**
+
+Run:
+
+```powershell
+git add README.md
+git commit -s -m "docs: make README a comprehensive project gateway"
+```
+
+Expected: a signed main-repository commit.
+
+---
+
+### Task 7: Run structural, link, and claim validation
+
+**Files:**
+- Test: all main-repository and Wiki Markdown files created or modified by this plan.
+
+**Interfaces:**
+- Consumes: complete local Wiki and README.
+- Produces: fail-closed evidence that navigation, local links, stable refs, skill coverage, and claim boundaries are coherent before publication.
+
+- [ ] **Step 1: Validate the complete Wiki page inventory and sidebar**
+
+Run from the Wiki root:
+
+```powershell
+$content = Get-ChildItem -File -Filter *.md | Where-Object { $_.Name -notin @('_Sidebar.md','_Footer.md') }
+$sidebar = Get-Content _Sidebar.md -Raw
+foreach ($page in $content) {
+  $slug = $page.BaseName
+  $count = [regex]::Matches($sidebar,[regex]::Escape("($slug)")).Count
+  if ($count -ne 1) { throw "sidebar references $($page.Name) $count times; expected exactly once" }
+}
+$targets = [regex]::Matches($sidebar,'\]\(([^)]+)\)') | ForEach-Object { $_.Groups[1].Value }
+foreach ($target in $targets) {
+  if ($target -match '^https?://') { continue }
+  $path = Join-Path $PWD (($target -replace '/$','') + '.md')
+  if (-not (Test-Path -LiteralPath $path)) { throw "missing sidebar target: $target" }
+}
+if ($content.Count -lt 30) { throw "expected at least 30 content pages, found $($content.Count)" }
+```
+
+Expected: PASS with no output and at least 30 content pages.
+
+- [ ] **Step 2: Validate Markdown links that target local files**
+
+Run from the main-repository worktree:
+
+```powershell
+@'
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+import re
+
+sets = [
+    (Path.cwd(), [Path("README.md")], False),
+    (Path("Y:/dev/epistemic-skills.wiki"), sorted(Path("Y:/dev/epistemic-skills.wiki").glob("*.md")), True),
+]
+link = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+missing = []
+for root, files, wiki_mode in sets:
+    for source in files:
+        source = source if source.is_absolute() else root / source
+        for raw in link.findall(source.read_text(encoding="utf-8")):
+            target = raw.strip().strip("<>").split()[0]
+            parsed = urlparse(target)
+            if parsed.scheme or target.startswith("#") or target.startswith("mailto:"):
+                continue
+            rel = unquote(target.split("#", 1)[0])
+            if not rel:
+                continue
+            candidate = (source.parent / rel)
+            if wiki_mode and not candidate.suffix:
+                candidate = candidate.with_suffix(".md")
+            if not candidate.exists():
+                missing.append(f"{source}: {target} -> {candidate}")
+if missing:
+    raise SystemExit("\n".join(missing))
+print("local Markdown links: PASS")
+'@ | python -
+```
+
+Expected: zero missing local targets.
+
+- [ ] **Step 3: Validate immutable stable coordinates**
+
+Run:
+
+```powershell
+rg -n 'tree/main|blob/main|--ref main|--branch main' README.md Y:\dev\epistemic-skills.wiki
+```
+
+Expected: any matches occur only in explicitly labeled maintainer/current-development prose; stable install commands contain `v3.0.0`.
+
+- [ ] **Step 4: Validate package/version consistency and repository artifacts**
+
+Run:
+
+```powershell
+python plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+python .github/scripts/check_json_artifacts.py
+python plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/blinded/tests/run_tests.py
+python plugins/epistemic-skills/skills/gauntlet/tests/run_tests.py
+git diff --check origin/main...HEAD
+```
+
+Expected: every command passes.
+
+- [ ] **Step 5: Perform a focused claim audit**
+
+Search README and Wiki for `superior`, `certified`, `Cursor`, `P0`, `quota`, `NOT_RUN`, and `release_credit`. Confirm every positive-sounding claim is bounded by the v3.0.0 release record and every required limitation appears on the evidence page and README trust section.
+
+Expected: no unbounded superiority, cross-provider, Cursor-compatibility, or current-certification claim.
+
+---
+
+### Task 8: Publish and verify the complete Wiki
+
+**Files:**
+- Publish: all committed files in `Y:\dev\epistemic-skills.wiki`
+
+**Interfaces:**
+- Consumes: locally committed Wiki history passing Task 7.
+- Produces: public Wiki pages at `https://github.com/ZMS-Labs/epistemic-skills/wiki/...` and a clean local clone aligned with the remote.
+
+- [ ] **Step 1: Run final Wiki pre-push checks**
+
+Run:
+
+```powershell
+git status --short --branch
+git log --format='%h %s%n%b' --reverse
+git diff --check origin/HEAD...HEAD
+```
+
+Expected: clean working tree; every authored commit has an author-matching `Signed-off-by` trailer.
+
+- [ ] **Step 2: Push the complete Wiki history once**
+
+Run:
+
+```powershell
+git push origin HEAD
+```
+
+Expected: the remote Wiki branch advances through all local handbook commits.
+
+- [ ] **Step 3: Verify remote alignment**
+
+Run:
+
+```powershell
+git fetch origin
+$local = (git rev-parse HEAD).Trim()
+$remote = (git rev-parse '@{upstream}').Trim()
+if ($local -ne $remote) { throw 'Wiki remote does not match local HEAD' }
+git status --short --branch
+```
+
+Expected: equal SHAs and a clean aligned branch.
+
+---
+
+### Task 9: Publish the README through a reviewed pull request
+
+**Files:**
+- Publish: `README.md`, approved design spec, and this implementation plan on `codex/wiki-readme-handbook`.
+
+**Interfaces:**
+- Consumes: complete public Wiki URLs and passing Task 7 checks.
+- Produces: a reviewed, CI-green pull request merged to `main`.
+
+- [ ] **Step 1: Update README Wiki links after public Wiki verification**
+
+Confirm every link uses `https://github.com/ZMS-Labs/epistemic-skills/wiki/<Page-Slug>` and resolves publicly. Apply only link corrections; do not change approved content boundaries.
+
+- [ ] **Step 2: Re-run main-repository validation and DCO audit**
+
+Run Task 7 Step 4 again, then check every `origin/main..HEAD` commit for an author-matching sign-off using the repository's DCO policy.
+
+Expected: all checks pass and no unsigned commit exists.
+
+- [ ] **Step 3: Commit any public-link corrections and push the branch**
+
+Run:
+
+```powershell
+git add README.md docs/superpowers/specs/2026-07-26-github-wiki-and-readme-design.md docs/superpowers/plans/2026-07-26-github-wiki-readme-handbook.md
+$staged = git diff --cached --name-only
+if ($staged) { git commit -s -m "docs: finalize public handbook links" }
+git push -u origin codex/wiki-readme-handbook
+```
+
+Expected: branch is durable on GitHub.
+
+- [ ] **Step 4: Open a draft pull request with exact verification and Wiki coordinates**
+
+Create a draft PR titled `docs: build comprehensive README and GitHub Wiki handbook`. The body summarizes the dual audience paths, Helix central passage, Wiki page count and commit, source/version policy, validations, and known limitations.
+
+- [ ] **Step 5: Run independent documentation review**
+
+Review the frozen exact PR head for incorrect trigger boundaries, unsafe install instructions, mutable stable refs, stale certification claims, broken links, duplicated Helix/router roles, and omissions from the approved page map. Fix every actionable P1/P2 finding on the branch and rerun validation.
+
+- [ ] **Step 6: Require exact-head GitHub checks and merge**
+
+Require DCO, stdlib checks, release-security when triggered, and CodeQL checks to pass on the final head. Mark ready and merge only that reviewed head.
+
+Expected: PR state `MERGED`, with `origin/main` containing the README, design, and plan.
+
+---
+
+### Task 10: Verify rendered GitHub documentation and close the work
+
+**Files:**
+- Verify only: merged `README.md` and public Wiki pages.
+
+**Interfaces:**
+- Consumes: merged README and pushed Wiki.
+- Produces: rendered evidence and immutable commit coordinates for the operator.
+
+- [ ] **Step 1: Verify required rendered Wiki pages**
+
+Open and visually inspect:
+
+- `https://github.com/ZMS-Labs/epistemic-skills/wiki/Home`
+- `https://github.com/ZMS-Labs/epistemic-skills/wiki/Helix-Central-Passage`
+- `https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Applying-Formal-Rigor`
+- `https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility`
+- `https://github.com/ZMS-Labs/epistemic-skills/wiki/Architecture-and-Contracts`
+
+Expected: headings, tables, code fences, sidebar, footer, and cross-links render correctly.
+
+- [ ] **Step 2: Verify the merged README rendering**
+
+Open `https://github.com/ZMS-Labs/epistemic-skills#readme`. Confirm badges, Mermaid diagram, dual paths, tables, install commands, Wiki links, and trust limitations render correctly.
+
+- [ ] **Step 3: Verify public reachability and final identities**
+
+Run:
+
+```powershell
+gh api repos/ZMS-Labs/epistemic-skills/commits/main --jq .sha
+git -C Y:\dev\epistemic-skills.wiki rev-parse HEAD
+git -C Y:\dev\epistemic-skills.wiki rev-parse '@{upstream}'
+```
+
+Expected: main and Wiki identities are explicit; Wiki local and upstream SHAs match.
+
+- [ ] **Step 4: Confirm the original checkout was preserved**
+
+Run:
+
+```powershell
+git -C Y:\dev\epistemic-skills branch --show-current
+git -C Y:\dev\epistemic-skills status --short --branch
+```
+
+Expected: the original user branch and its unrelated ahead commit remain unchanged.
+
+- [ ] **Step 5: Report completion**
+
+Return the public Wiki homepage, merged README PR, main commit, Wiki commit, page count, validation results, rendered smoke-test result, and the preserved v3.0.0 limitation summary.

--- a/docs/superpowers/specs/2026-07-26-github-wiki-and-readme-design.md
+++ b/docs/superpowers/specs/2026-07-26-github-wiki-and-readme-design.md
@@ -1,0 +1,315 @@
+# GitHub Wiki and README Handbook Design
+
+**Status:** approved design
+**Repository:** `ZMS-Labs/epistemic-skills`
+**Stable baseline:** `v3.0.0`
+**Audience:** users/adopters and developers/maintainers with equal first-class paths
+
+## Goal
+
+Create a comprehensive GitHub Wiki and a substantially improved repository
+README that together make epistemic-skills understandable, usable, auditable,
+and maintainable without creating a second specification that can silently
+drift away from the released repository.
+
+The README is the polished front door. The wiki is the deeper handbook. The
+versioned repository remains authoritative for skill contracts, schemas,
+scripts, tests, evaluation evidence, release records, and design history.
+
+## Success criteria
+
+The documentation succeeds when a new reader can:
+
+1. understand what problem epistemic-skills solves and what it does not claim;
+2. choose the routine path, the epistemic router, or Helix correctly;
+3. install exactly one copy for their harness using an immutable release;
+4. select and use any of the eleven skills without reading its implementation;
+5. understand outputs, handoffs, failure modes, and degradation boundaries;
+6. find canonical contracts and evidence without confusing summaries for proof;
+7. understand the architecture, packaging, test suites, and release process; and
+8. contribute without introducing duplicated skills, stale claims, or ceremony
+   that defeats the proportionality contract.
+
+## Documentation roles
+
+### README
+
+The README is the project landing page and rapid orientation path. It remains
+detailed enough to install and begin using the project without visiting the
+wiki, but it does not reproduce every skill guide or evaluation record.
+
+### GitHub Wiki
+
+The wiki is the curated handbook. It provides concept explanations, task-based
+guides, skill-by-skill usage, workflow recipes, maintainer documentation,
+glossary material, and troubleshooting. It links into immutable repository
+sources wherever exact behavior matters.
+
+### Repository
+
+The repository is the source of truth. In a disagreement, the following order
+controls:
+
+1. the immutable released `SKILL.md`, contract, schema, or executable check;
+2. released reference files and release records;
+3. the README and wiki summaries.
+
+Wiki language must never promote a design, incomplete evaluation, or historical
+result into a current behavioral guarantee.
+
+## Helix as the central passage
+
+Helix is intentionally presented as a centralized passage between a
+workflow-skill layer and the epistemic layer:
+
+```text
+workflow skills  <->  Helix central passage  <->  epistemic router and disciplines
+```
+
+This prominence must not blur the boundary between Helix and
+`using-epistemic-skills`:
+
+- `using-epistemic-skills` is the router inside the epistemic collection. It
+  applies the routine gate, identifies positive epistemic triggers, sequences
+  disciplines, and defines their handoffs.
+- `helix` is the tandem entry point when a workflow system such as superpowers
+  is also active. It pairs workflow stages with positively triggered epistemic
+  disciplines and passes through the correct contracts.
+- Helix is not a requirement to run every skill, not a new process container,
+  and not a replacement for the routine exit.
+- Routine work and absent pairings remain silent.
+
+Helix receives first-class placement on the README, wiki homepage, sidebar,
+workflow recipes, architecture explanation, glossary, and a dedicated
+`Helix: Central Passage` guide.
+
+## Wiki information architecture
+
+The homepage opens with two equal paths and a prominent Helix crossing between
+them.
+
+### Use the skills
+
+- `Start Here`
+- `Helix: Central Passage`
+- `Choosing a Skill`
+- `Routine Work and Proportionality`
+- `The Epistemic Arc`
+- `Workflow Recipes`
+- `Installation and Harness Compatibility`
+- `Skill Catalog`
+- one practical guide for each released skill:
+  - `using-epistemic-skills`
+  - `helix`
+  - `blindspot-pass`
+  - `applying-formal-rigor`
+  - `evidence-research`
+  - `write-goal`
+  - `continuity-verify`
+  - `decision-ledger`
+  - `outsource`
+  - `gauntlet`
+  - `evidence-locked-uat`
+
+### Develop and maintain
+
+- `Architecture and Contracts`
+- `Cross-Harness Packaging`
+- `Testing and Evaluations`
+- `Evidence, Status, and Known Limitations`
+- `Contributing`
+- `Release Process and Versioning`
+- `Security, Provenance, and DCO`
+- `Design History and Audits`
+
+### Shared reference
+
+- `Core Concepts`
+- `Glossary`
+- `FAQ and Troubleshooting`
+- `Version History`
+
+### Navigation files
+
+- `_Sidebar.md` exposes every content page under the same three groups and
+  places `Helix: Central Passage` near the top.
+- `_Footer.md` identifies the current stable release, links to the canonical
+  repository and release, and states that repository contracts control.
+- No content page is allowed to be orphaned from `_Sidebar.md`.
+
+## Homepage design
+
+`Home.md` contains:
+
+1. the one-paragraph value proposition;
+2. current stable release and honest support boundary;
+3. equal `Use the skills` and `Develop and maintain` entry tables;
+4. the routine path as the default first decision;
+5. Helix as the central passage for paired workflow/epistemic operation;
+6. a compact map of the epistemic arc;
+7. links to installation, the skill catalog, known limitations, and the release;
+8. a clear source-of-truth statement.
+
+The homepage must be useful without assuming prior knowledge of agent skills,
+superpowers, formal methods, UAT, or multi-agent review.
+
+## Standard skill-page template
+
+Every skill page uses the same visible structure:
+
+1. **What it does** — one concise behavioral description.
+2. **Use it when** — positive triggers from released frontmatter and contract.
+3. **Do not use it when** — routine and boundary cases.
+4. **Inputs and prerequisites** — required state, tools, or prior artifacts.
+5. **Normal workflow** — numbered method summary.
+6. **Outputs and durable artifacts** — including record-free outcomes.
+7. **Boundaries and failure modes** — fail-closed and degradation behavior.
+8. **Example prompts** — realistic invocation examples, not magic phrases.
+9. **Related skills and handoffs** — upstream/downstream relationships.
+10. **Canonical sources and evidence** — immutable `v3.0.0` links.
+
+The Helix page additionally explains the central-passage model, pairing rules,
+silent absent triggers, the routine exit, ordering, and how Helix differs from
+the router.
+
+## README redesign
+
+The estate-governance block remains byte-for-byte intact and retains its
+position near the top of the file.
+
+The rest of the README is reorganized into:
+
+1. **Project identity** — concise value proposition, stable release, license,
+   and harness-agnostic contract.
+2. **Status badges** — release, license, stdlib checks, release-security, and
+   CodeQL using durable GitHub workflow URLs.
+3. **What this is and is not** — epistemic discipline beneath workflow skills,
+   not a replacement for ordinary engineering or a mandate for ceremony.
+4. **Choose your path** — equal user and maintainer links into the wiki.
+5. **Five-minute start** — install one immutable copy, begin with the router or
+   Helix as appropriate, and verify the expected skill inventory.
+6. **Routine work first** — the four-part routine test and two-read micro-recon.
+7. **Helix central passage** — a prominent diagram and boundary explanation.
+8. **Task-to-skill decision table** — recognizable task shapes, entry point,
+   and expected output.
+9. **The epistemic arc** — a Mermaid flow showing routine exit, resumption,
+   recon, decision, goal contract, gate, proof, persistence, and delegation.
+10. **Skill catalog** — all eleven skills with trigger, purpose, and output.
+11. **Installation and compatibility** — one-copy rule, harness matrix, pinned
+    v3.0.0 commands, restart/reload requirements, and verification.
+12. **Architecture and repository layout** — one canonical skill tree plus thin
+    harness manifests.
+13. **Trust, evidence, and limits** — deterministic evidence, no-credit
+    diagnostics, accepted limitations, and links to the machine-readable record.
+14. **Developing and contributing** — tests, DCO, design history, release
+    process, and wiki maintainer entry points.
+15. **License and support coordinates**.
+
+The README remains comprehensive, but repeated low-level details move behind
+clear wiki links when duplication would create a maintenance hazard.
+
+## Source and version policy
+
+- Every stable user page begins with `Applies to v3.0.0` and links to tagged
+  source paths.
+- Maintainer pages label links to `main` as current development.
+- The wiki never uses an unlabeled `main` link to define released behavior.
+- Historical audits and evaluations retain their original dates and claims.
+- The release risk record controls the wording of behavioral and provider
+  limitations.
+- The wiki identifies itself as unversioned navigation over versioned sources.
+
+## Required honesty boundaries
+
+Documentation must preserve these v3.0.0 limitations:
+
+- no claim of universal behavioral superiority;
+- no claim of cross-provider generality from the incomplete campaign;
+- the two genuine P0 behavioral failures remain disclosed;
+- AGY quota failures remain availability failures, not merit judgments;
+- Cursor compatibility remains `BLOCKED_EXTERNAL` where recorded;
+- the amended Gauntlet arbitrator-certification battery remains `NOT_RUN`;
+- the post-hoc diagnostic remains `release_credit: none`;
+- risk acceptance does not satisfy or waive deterministic, security,
+  provenance, review, or publication gates.
+
+## Publication architecture
+
+README and design changes use a normal branch and reviewed pull request against
+`main`.
+
+GitHub Wiki content lives in GitHub's separate
+`ZMS-Labs/epistemic-skills.wiki.git` repository. Because GitHub has not created
+that repository yet, the first page is bootstrapped through the authenticated
+GitHub Wiki interface. The wiki repository is then cloned under
+`Y:\dev\epistemic-skills.wiki`, populated as one coherent commit, pushed, and
+verified from the remote.
+
+Wiki commits use the same authorship and DCO discipline as the main repository,
+even though GitHub Wiki does not provide the same pull-request workflow.
+
+## Verification
+
+### Structural checks
+
+- every planned content page exists;
+- `_Sidebar.md` links every content page exactly once;
+- every sidebar target resolves to a local wiki file;
+- wiki-to-wiki links resolve and no content page is orphaned;
+- all eleven released skills have exactly one skill guide;
+- README local links resolve in the main repository;
+- README and wiki contain no mutable stable-install coordinate;
+- version text, skill count, and manifest compatibility agree with v3.0.0;
+- JSON and Markdown source links point to existing tagged files.
+
+### Content checks
+
+- every skill guide's use boundary agrees with its released frontmatter and
+  `SKILL.md`;
+- Helix is consistently the central passage and never mislabeled as the
+  epistemic router;
+- routine work remains the first decision and absent triggers remain silent;
+- current limitations match the release record and receive no accidental pass;
+- no historical design or audit is described as current certification.
+
+### Publication checks
+
+- the README pull request passes repository CI and independent review;
+- the merged README renders correctly on GitHub;
+- the wiki remote contains the intended commit and the local clone is clean;
+- GitHub renders `Home`, `Helix: Central Passage`, one additional skill page,
+  `Installation and Harness Compatibility`, and `Architecture and Contracts`;
+- sidebar and footer navigation render on those pages;
+- public page URLs are reachable without relying on local state.
+
+## Failure handling
+
+- If Wiki bootstrap fails, do not publish a partial navigation set; correct the
+  bootstrap and push the complete wiki from the local source clone.
+- If a page or link check fails, fix it before the wiki push or README merge.
+- If rendered GitHub output differs materially from local Markdown, correct the
+  source and republish rather than documenting the mismatch as acceptable.
+- If a released claim cannot be anchored, omit it or label it as uncertain; do
+  not infer a guarantee from design intent.
+- Git history is the recovery mechanism for both repositories. Published wiki
+  corrections use new commits; stable release tags are never moved.
+
+## Non-goals
+
+- changing any skill's behavior, trigger, schema, test, or evaluation result;
+- moving or recreating the immutable v3.0.0 release;
+- duplicating every design document or evidence packet in the wiki;
+- claiming marketplace availability that has not been verified;
+- turning the wiki into a generated API reference or an independent contract;
+- adding a hosted documentation platform beyond GitHub README and Wiki.
+
+## Completion contract
+
+The work is complete only when:
+
+1. the approved README is merged to `main`;
+2. the complete wiki is committed and pushed to the GitHub Wiki repository;
+3. structural, content, link, version, and rendered-page checks pass;
+4. Helix is visibly and accurately presented as the centralized passage;
+5. the original authoritative checkout and unrelated user work remain intact;
+6. durable GitHub URLs and commit identities are reported to the operator.

--- a/docs/superpowers/specs/2026-07-26-github-wiki-and-readme-design.md
+++ b/docs/superpowers/specs/2026-07-26-github-wiki-and-readme-design.md
@@ -242,8 +242,8 @@ GitHub Wiki content lives in GitHub's separate
 `ZMS-Labs/epistemic-skills.wiki.git` repository. Because GitHub has not created
 that repository yet, the first page is bootstrapped through the authenticated
 GitHub Wiki interface. The wiki repository is then cloned under
-`Y:\dev\epistemic-skills.wiki`, populated as one coherent commit, pushed, and
-verified from the remote.
+`Y:\dev\epistemic-skills.wiki`, populated as one coherent, reviewed commit
+series, pushed once, and verified from the remote.
 
 Wiki commits use the same authorship and DCO discipline as the main repository,
 even though GitHub Wiki does not provide the same pull-request workflow.


### PR DESCRIPTION
## What changed

- Rebuilt the README as an equal-entry gateway for two audiences: people adopting the skills and maintainers extending or evaluating them.
- Published a comprehensive 31-page GitHub Wiki handbook at https://github.com/ZMS-Labs/epistemic-skills/wiki, frozen at Wiki commit `651dcd7b84f4d7b3e3bc204025e5aadd7bca9cb8`.
- Documented Helix as the centralized passage between an outer workflow-skill layer and the epistemic router/disciplines. `using-epistemic-skills` remains the epistemic router; routine-work exits happen before the passage, and absent pairings remain silent.
- Added the approved design and implementation plan for the handbook.

## Source and version policy

Stable installation and source guidance is pinned to immutable `v3.0.0` coordinates. Links to `main` are used only where they are explicitly labeled as current-development references, not stable-release sources.

## Validation

Reviewed exact main-repository head: `e6e565c2c3759916a17e9e5726ffd632058cbdbc`.

- Public README Wiki links: **PASS**, 27/27 returned HTTP 200 without authentication.
- Wiki inventory/sidebar: **PASS**, 31 content pages and 33 sidebar targets; no orphan or duplicate local targets.
- Local Markdown links across README and Wiki: **PASS**.
- `python plugins/epistemic-skills/skills/outsource/tests/run_tests.py`: **PASS** (`outsource integration: PASS`).
- `python .github/scripts/check_json_artifacts.py`: **PASS** (178 JSON artifacts checked; one hash-pinned malformed response intentionally preserved).
- `python plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/blinded/tests/run_tests.py`: **PASS** (10/10 routine, 4/4 material, 4/4 high-risk; 25-word routine visible-process median; blinded packets pass).
- `python plugins/epistemic-skills/skills/gauntlet/tests/run_tests.py`: **PASS** (all 32 named checks).
- `git diff --check origin/main...HEAD`: **PASS**.
- Author-matching DCO audit for `origin/main..HEAD`: **PASS**, 4/4 commits.

## Known limitations retained without overclaim

- The release record contains **two genuine P0 failures**; they remain failures and are not erased by the documentation work.
- The AGY zero-token failures are classified as **quota/availability failures, not merit judgments**. They do not establish whether the affected responses would have passed or failed substantive scoring.
- Cursor remains **`BLOCKED_EXTERNAL`** for the retained behavioral-evaluation epoch; packaging and local-install support are not represented as public-listing or behavioral proof.
- The amended Gauntlet arbitrator battery remains **`NOT_RUN`** and is not represented as current certification.
- The posthoc diagnostic remains exactly **`release_credit: none`**; it receives no retroactive release-gate credit.

This PR documents the v3.0.0 system and its evidence boundaries; it does not claim universal superiority, perfect coverage, or proof beyond the recorded evaluations.
