### PR TITLE
feat: add epistemic event collection contract

### DIFF
--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -26,6 +26,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Epistemic event contract tests
+        run: python plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
+      - name: Compile epistemic event verifier
+        run: python -m py_compile plugins/epistemic-skills/contracts/epistemic-events/verify_epistemic_event.py
       - name: Epistemic-flexibility protocol fixtures
         run: python plugins/epistemic-skills/skills/using-epistemic-skills/evals/epistemic-flexibility/run_tests.py
       - name: Behavioral fixture scorer self-test

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 # plugins/epistemic-skills/contracts/README.md).
 outputs/
 artifacts/uat/**/screenshots/
+.epistemic-events/
+outputs/epistemic-events/
+pilot/runs/

--- a/plugins/epistemic-skills/contracts/README.md
+++ b/plugins/epistemic-skills/contracts/README.md
@@ -12,6 +12,15 @@ self-reported fields**. **"Trust" in this contract means exactly that envelope
 and nothing more.** No field and no rule raises a consumer's confidence in a
 judgment it did not make or re-verify.
 
+## Epistemic event collection
+
+`epistemic-events/` contains a separate, minimized event/outcome contract and
+the closed eleven-surface eligibility map. It is collection machinery, not a
+twelfth discipline: skill results are produced first, absent eligibility is
+silent, and a missing or failed collector cannot change the primary result.
+These records never include raw skill output. Like receipts, collection
+receipts prove envelope facts only and do not upgrade outcome truth.
+
 ## What a receipt never attests
 
 Every receipt carries a non-empty `never_attests` array. The standard entries:

--- a/plugins/epistemic-skills/contracts/epistemic-events/epistemic-event.schema.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/epistemic-event.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Epistemic Event v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["record", "variant", "event_id", "idempotency_key", "producer", "event_kind", "subject_ref", "correlation_ref", "occurred_on", "model_family", "harness_class", "provenance_mode", "privacy_class", "evidence_refs"],
+  "properties": {
+    "record": {"const": "epistemic-event@1"},
+    "variant": {"enum": ["calibratable", "observational"]},
+    "event_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "idempotency_key": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["skill", "skill_version", "producer_sha256"],
+      "properties": {
+        "skill": {"enum": ["using-epistemic-skills", "helix", "blindspot-pass", "applying-formal-rigor", "evidence-research", "write-goal", "outsource", "gauntlet", "evidence-locked-uat", "decision-ledger", "continuity-verify"]},
+        "skill_version": {"type": "string", "minLength": 1},
+        "producer_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "event_kind": {"enum": ["routing-decision", "pairing-decision", "landmine-prediction", "formal-prediction", "evidence-claim", "goal-proof", "handoff-verification", "review-forecast", "uat-verdict", "ledger-revisit", "continuity-reanchor"]},
+    "subject_ref": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "correlation_ref": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "occurred_on": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+    "model_family": {"type": ["string", "null"], "minLength": 1},
+    "harness_class": {"type": ["string", "null"], "minLength": 1},
+    "provenance_mode": {"enum": ["preregistered", "contemporaneous", "post_hoc"]},
+    "privacy_class": {"const": "portable-minimized"},
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "sha256"],
+        "properties": {
+          "kind": {"enum": ["artifact-hash", "receipt-hash", "oracle-hash", "ledger-entry-hash", "run-record-hash"]},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+        }
+      }
+    },
+    "forecast": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome_class", "probability", "resolution_rule"],
+      "properties": {
+        "outcome_class": {"enum": ["correct", "incorrect", "partial", "unresolved", "over-escalated", "under-escalated", "regressed"]},
+        "probability": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        "resolution_rule": {"enum": ["deterministic-fixture", "independent-adjudication", "field-observation", "supersession-chain"]}
+      }
+    },
+    "observation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["class"],
+      "properties": {
+        "class": {"enum": ["verified", "contradicted", "unverified", "superseded", "accepted", "rejected", "recurred", "avoided"]}
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"variant": {"const": "calibratable"}}, "required": ["variant"]},
+      "then": {"required": ["forecast"], "not": {"required": ["observation"]}}
+    },
+    {
+      "if": {"properties": {"variant": {"const": "observational"}}, "required": ["variant"]},
+      "then": {"required": ["observation"], "not": {"required": ["forecast"]}}
+    }
+  ]
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/epistemic-outcome.schema.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/epistemic-outcome.schema.json
@@ -24,5 +24,20 @@
     "observed_on": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
     "producer": {"type": "string", "minLength": 1},
     "supersedes": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"}
-  }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"resolution_status": {"const": "resolved"}}, "required": ["resolution_status"]},
+      "then": {
+        "properties": {
+          "evidence_ref": {"type": "object"},
+          "independence_class": {"not": {"const": "self-reported"}}
+        }
+      }
+    },
+    {
+      "if": {"properties": {"resolution_status": {"const": "superseded"}}, "required": ["resolution_status"]},
+      "then": {"properties": {"supersedes": {"type": "string", "pattern": "^[0-9a-f]{64}$"}}}
+    }
+  ]
 }

--- a/plugins/epistemic-skills/contracts/epistemic-events/epistemic-outcome.schema.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/epistemic-outcome.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Epistemic Outcome v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["record", "observation_id", "event_id", "outcome_class", "resolution_status", "verification_method", "independence_class", "evidence_ref", "observed_on", "producer", "supersedes"],
+  "properties": {
+    "record": {"const": "epistemic-outcome@1"},
+    "observation_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "event_id": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "outcome_class": {"enum": ["correct", "incorrect", "partial", "unresolved", "over-escalated", "under-escalated", "regressed"]},
+    "resolution_status": {"enum": ["resolved", "partial", "unresolved", "superseded"]},
+    "verification_method": {"enum": ["deterministic-oracle", "independent-human", "independent-model", "field-observation"]},
+    "independence_class": {"enum": ["deterministic", "different-family", "same-family", "self-reported"]},
+    "evidence_ref": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["kind", "sha256"],
+      "properties": {
+        "kind": {"enum": ["artifact-hash", "receipt-hash", "oracle-hash", "ledger-entry-hash", "run-record-hash"]},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "observed_on": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+    "producer": {"type": "string", "minLength": 1},
+    "supersedes": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/examples/invalid/observational-with-probability.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/examples/invalid/observational-with-probability.json
@@ -1,0 +1,17 @@
+{
+  "record": "epistemic-event@1",
+  "variant": "observational",
+  "event_id": "1111111111111111111111111111111111111111111111111111111111111111",
+  "idempotency_key": "2222222222222222222222222222222222222222222222222222222222222222",
+  "producer": {"skill": "continuity-verify", "skill_version": "2.9.2", "producer_sha256": "3333333333333333333333333333333333333333333333333333333333333333"},
+  "event_kind": "continuity-reanchor",
+  "subject_ref": "4444444444444444444444444444444444444444444444444444444444444444",
+  "correlation_ref": "5555555555555555555555555555555555555555555555555555555555555555",
+  "occurred_on": "2026-07-27",
+  "model_family": null,
+  "harness_class": null,
+  "provenance_mode": "contemporaneous",
+  "privacy_class": "portable-minimized",
+  "evidence_refs": [],
+  "observation": {"class": "verified", "probability": 0.5}
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/examples/invalid/raw-content.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/examples/invalid/raw-content.json
@@ -1,0 +1,17 @@
+{
+  "record": "epistemic-event@1",
+  "variant": "calibratable",
+  "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "idempotency_key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "producer": {"skill": "evidence-locked-uat", "skill_version": "2.9.2", "producer_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+  "event_kind": "formal-prediction",
+  "subject_ref": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "correlation_ref": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "occurred_on": "2026-07-27",
+  "model_family": null,
+  "harness_class": null,
+  "provenance_mode": "preregistered",
+  "privacy_class": "portable-minimized",
+  "evidence_refs": [{"kind": "artifact-hash", "sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}],
+  "forecast": {"outcome_class": "correct", "probability": 0.75, "resolution_rule": "deterministic-fixture", "raw_content": "not permitted"}
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/examples/invalid/unknown-event-kind.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/examples/invalid/unknown-event-kind.json
@@ -1,0 +1,17 @@
+{
+  "record": "epistemic-event@1",
+  "variant": "calibratable",
+  "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "idempotency_key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "producer": {"skill": "evidence-locked-uat", "skill_version": "2.9.2", "producer_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+  "event_kind": "unbounded-kind",
+  "subject_ref": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "correlation_ref": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "occurred_on": "2026-07-27",
+  "model_family": null,
+  "harness_class": null,
+  "provenance_mode": "preregistered",
+  "privacy_class": "portable-minimized",
+  "evidence_refs": [],
+  "forecast": {"outcome_class": "correct", "probability": 0.75, "resolution_rule": "deterministic-fixture"}
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/examples/valid/calibratable-event.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/examples/valid/calibratable-event.json
@@ -1,0 +1,17 @@
+{
+  "record": "epistemic-event@1",
+  "variant": "calibratable",
+  "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "idempotency_key": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "producer": {"skill": "evidence-locked-uat", "skill_version": "2.9.2", "producer_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},
+  "event_kind": "formal-prediction",
+  "subject_ref": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "correlation_ref": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "occurred_on": "2026-07-27",
+  "model_family": "open-weight",
+  "harness_class": "public-fixture",
+  "provenance_mode": "preregistered",
+  "privacy_class": "portable-minimized",
+  "evidence_refs": [{"kind": "artifact-hash", "sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}],
+  "forecast": {"outcome_class": "correct", "probability": 0.75, "resolution_rule": "deterministic-fixture"}
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/examples/valid/observational-event.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/examples/valid/observational-event.json
@@ -1,0 +1,17 @@
+{
+  "record": "epistemic-event@1",
+  "variant": "observational",
+  "event_id": "1111111111111111111111111111111111111111111111111111111111111111",
+  "idempotency_key": "2222222222222222222222222222222222222222222222222222222222222222",
+  "producer": {"skill": "continuity-verify", "skill_version": "2.9.2", "producer_sha256": "3333333333333333333333333333333333333333333333333333333333333333"},
+  "event_kind": "continuity-reanchor",
+  "subject_ref": "4444444444444444444444444444444444444444444444444444444444444444",
+  "correlation_ref": "5555555555555555555555555555555555555555555555555555555555555555",
+  "occurred_on": "2026-07-27",
+  "model_family": null,
+  "harness_class": null,
+  "provenance_mode": "contemporaneous",
+  "privacy_class": "portable-minimized",
+  "evidence_refs": [{"kind": "receipt-hash", "sha256": "6666666666666666666666666666666666666666666666666666666666666666"}],
+  "observation": {"class": "verified"}
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/examples/valid/outcome.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/examples/valid/outcome.json
@@ -1,0 +1,13 @@
+{
+  "record": "epistemic-outcome@1",
+  "observation_id": "7777777777777777777777777777777777777777777777777777777777777777",
+  "event_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "outcome_class": "correct",
+  "resolution_status": "resolved",
+  "verification_method": "deterministic-oracle",
+  "independence_class": "deterministic",
+  "evidence_ref": {"kind": "oracle-hash", "sha256": "8888888888888888888888888888888888888888888888888888888888888888"},
+  "observed_on": "2026-07-27",
+  "producer": "public-verifier",
+  "supersedes": null
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/skill-event-map.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/skill-event-map.json
@@ -1,0 +1,92 @@
+{
+  "skills": [
+    {
+      "skill": "using-epistemic-skills",
+      "event_kinds": ["routing-decision"],
+      "eligible_when": ["evaluation-case", "sampled-field-incident"],
+      "outcome_sources": ["independent-adjudication"],
+      "collection_mode": "observational",
+      "sentinel_fixture": "router-over-under.json"
+    },
+    {
+      "skill": "helix",
+      "event_kinds": ["pairing-decision"],
+      "eligible_when": ["evaluation-case", "correction-or-supersession"],
+      "outcome_sources": ["independent-adjudication"],
+      "collection_mode": "observational",
+      "sentinel_fixture": "helix-missed-pair.json"
+    },
+    {
+      "skill": "blindspot-pass",
+      "event_kinds": ["landmine-prediction"],
+      "eligible_when": ["preregistered-prediction"],
+      "outcome_sources": ["field-observation"],
+      "collection_mode": "calibratable",
+      "sentinel_fixture": "blindspot-landmine.json"
+    },
+    {
+      "skill": "applying-formal-rigor",
+      "event_kinds": ["formal-prediction"],
+      "eligible_when": ["preregistered-prediction"],
+      "outcome_sources": ["deterministic-fixture", "field-observation"],
+      "collection_mode": "calibratable",
+      "sentinel_fixture": "formal-prediction.json"
+    },
+    {
+      "skill": "evidence-research",
+      "event_kinds": ["evidence-claim"],
+      "eligible_when": ["independently-resolvable-verdict"],
+      "outcome_sources": ["independent-adjudication", "field-observation"],
+      "collection_mode": "conditional",
+      "sentinel_fixture": "evidence-correction.json"
+    },
+    {
+      "skill": "write-goal",
+      "event_kinds": ["goal-proof"],
+      "eligible_when": ["independently-resolvable-verdict"],
+      "outcome_sources": ["field-observation", "supersession-chain"],
+      "collection_mode": "conditional",
+      "sentinel_fixture": "goal-regression.json"
+    },
+    {
+      "skill": "outsource",
+      "event_kinds": ["handoff-verification"],
+      "eligible_when": ["evaluation-case", "sampled-field-incident"],
+      "outcome_sources": ["deterministic-fixture", "independent-adjudication"],
+      "collection_mode": "observational",
+      "sentinel_fixture": "outsource-relay.json"
+    },
+    {
+      "skill": "gauntlet",
+      "event_kinds": ["review-forecast"],
+      "eligible_when": ["preregistered-prediction", "correction-or-supersession"],
+      "outcome_sources": ["field-observation", "supersession-chain"],
+      "collection_mode": "conditional",
+      "sentinel_fixture": "gauntlet-dissent.json"
+    },
+    {
+      "skill": "evidence-locked-uat",
+      "event_kinds": ["uat-verdict"],
+      "eligible_when": ["independently-resolvable-verdict"],
+      "outcome_sources": ["deterministic-fixture", "field-observation"],
+      "collection_mode": "calibratable",
+      "sentinel_fixture": "uat-seeded-defect.json"
+    },
+    {
+      "skill": "decision-ledger",
+      "event_kinds": ["ledger-revisit"],
+      "eligible_when": ["revisit-trigger-fired"],
+      "outcome_sources": ["supersession-chain"],
+      "collection_mode": "observational",
+      "sentinel_fixture": "ledger-revisit.json"
+    },
+    {
+      "skill": "continuity-verify",
+      "event_kinds": ["continuity-reanchor"],
+      "eligible_when": ["evaluation-case", "sampled-field-incident"],
+      "outcome_sources": ["deterministic-fixture", "field-observation"],
+      "collection_mode": "observational",
+      "sentinel_fixture": "continuity-contradiction.json"
+    }
+  ]
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/skill-event-map.schema.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/skill-event-map.schema.json
@@ -11,67 +11,33 @@
       "minItems": 11,
       "maxItems": 11,
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "skill",
-          "event_kinds",
-          "eligible_when",
-          "outcome_sources",
-          "collection_mode",
-          "sentinel_fixture"
-        ],
-        "properties": {
-          "skill": {
-            "enum": [
-              "using-epistemic-skills", "helix", "blindspot-pass",
-              "applying-formal-rigor", "evidence-research", "write-goal",
-              "outsource", "gauntlet", "evidence-locked-uat",
-              "decision-ledger", "continuity-verify"
-            ]
-          },
-          "event_kinds": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "enum": [
-                "routing-decision", "pairing-decision", "landmine-prediction",
-                "formal-prediction", "evidence-claim", "goal-proof",
-                "handoff-verification", "review-forecast", "uat-verdict",
-                "ledger-revisit", "continuity-reanchor"
-              ]
-            }
-          },
-          "eligible_when": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "enum": [
-                "evaluation-case", "sampled-field-incident", "preregistered-prediction",
-                "independently-resolvable-verdict", "correction-or-supersession",
-                "revisit-trigger-fired"
-              ]
-            }
-          },
-          "outcome_sources": {
-            "type": "array",
-            "minItems": 1,
-            "items": {
-              "enum": [
-                "deterministic-fixture", "independent-adjudication",
-                "field-observation", "supersession-chain"
-              ]
-            }
-          },
-          "collection_mode": {
-            "enum": ["calibratable", "observational", "conditional"]
-          },
-          "sentinel_fixture": {
-            "type": "string",
-            "pattern": "^[a-z0-9-]+\\.json$"
-          }
-        }
-      }
+        "oneOf": [
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"using-epistemic-skills"},"event_kinds":{"const":["routing-decision"]},"eligible_when":{"const":["evaluation-case","sampled-field-incident"]},"outcome_sources":{"const":["independent-adjudication"]},"collection_mode":{"const":"observational"},"sentinel_fixture":{"const":"router-over-under.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"helix"},"event_kinds":{"const":["pairing-decision"]},"eligible_when":{"const":["evaluation-case","correction-or-supersession"]},"outcome_sources":{"const":["independent-adjudication"]},"collection_mode":{"const":"observational"},"sentinel_fixture":{"const":"helix-missed-pair.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"blindspot-pass"},"event_kinds":{"const":["landmine-prediction"]},"eligible_when":{"const":["preregistered-prediction"]},"outcome_sources":{"const":["field-observation"]},"collection_mode":{"const":"calibratable"},"sentinel_fixture":{"const":"blindspot-landmine.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"applying-formal-rigor"},"event_kinds":{"const":["formal-prediction"]},"eligible_when":{"const":["preregistered-prediction"]},"outcome_sources":{"const":["deterministic-fixture","field-observation"]},"collection_mode":{"const":"calibratable"},"sentinel_fixture":{"const":"formal-prediction.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"evidence-research"},"event_kinds":{"const":["evidence-claim"]},"eligible_when":{"const":["independently-resolvable-verdict"]},"outcome_sources":{"const":["independent-adjudication","field-observation"]},"collection_mode":{"const":"conditional"},"sentinel_fixture":{"const":"evidence-correction.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"write-goal"},"event_kinds":{"const":["goal-proof"]},"eligible_when":{"const":["independently-resolvable-verdict"]},"outcome_sources":{"const":["field-observation","supersession-chain"]},"collection_mode":{"const":"conditional"},"sentinel_fixture":{"const":"goal-regression.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"outsource"},"event_kinds":{"const":["handoff-verification"]},"eligible_when":{"const":["evaluation-case","sampled-field-incident"]},"outcome_sources":{"const":["deterministic-fixture","independent-adjudication"]},"collection_mode":{"const":"observational"},"sentinel_fixture":{"const":"outsource-relay.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"gauntlet"},"event_kinds":{"const":["review-forecast"]},"eligible_when":{"const":["preregistered-prediction","correction-or-supersession"]},"outcome_sources":{"const":["field-observation","supersession-chain"]},"collection_mode":{"const":"conditional"},"sentinel_fixture":{"const":"gauntlet-dissent.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"evidence-locked-uat"},"event_kinds":{"const":["uat-verdict"]},"eligible_when":{"const":["independently-resolvable-verdict"]},"outcome_sources":{"const":["deterministic-fixture","field-observation"]},"collection_mode":{"const":"calibratable"},"sentinel_fixture":{"const":"uat-seeded-defect.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"decision-ledger"},"event_kinds":{"const":["ledger-revisit"]},"eligible_when":{"const":["revisit-trigger-fired"]},"outcome_sources":{"const":["supersession-chain"]},"collection_mode":{"const":"observational"},"sentinel_fixture":{"const":"ledger-revisit.json"}}},
+          {"type":"object","additionalProperties":false,"required":["skill","event_kinds","eligible_when","outcome_sources","collection_mode","sentinel_fixture"],"properties":{"skill":{"const":"continuity-verify"},"event_kinds":{"const":["continuity-reanchor"]},"eligible_when":{"const":["evaluation-case","sampled-field-incident"]},"outcome_sources":{"const":["deterministic-fixture","field-observation"]},"collection_mode":{"const":"observational"},"sentinel_fixture":{"const":"continuity-contradiction.json"}}}
+        ]
+      },
+      "allOf": [
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"using-epistemic-skills"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"helix"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"blindspot-pass"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"applying-formal-rigor"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"evidence-research"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"write-goal"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"outsource"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"gauntlet"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"evidence-locked-uat"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"decision-ledger"}}},"minContains":1,"maxContains":1},
+        {"contains":{"type":"object","required":["skill"],"properties":{"skill":{"const":"continuity-verify"}}},"minContains":1,"maxContains":1}
+      ]
     }
   }
 }

--- a/plugins/epistemic-skills/contracts/epistemic-events/skill-event-map.schema.json
+++ b/plugins/epistemic-skills/contracts/epistemic-events/skill-event-map.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://zms-labs.github.io/epistemic-skills/contracts/skill-event-map.schema.json",
+  "title": "Epistemic Skill Event Eligibility Map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["skills"],
+  "properties": {
+    "skills": {
+      "type": "array",
+      "minItems": 11,
+      "maxItems": 11,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "skill",
+          "event_kinds",
+          "eligible_when",
+          "outcome_sources",
+          "collection_mode",
+          "sentinel_fixture"
+        ],
+        "properties": {
+          "skill": {
+            "enum": [
+              "using-epistemic-skills", "helix", "blindspot-pass",
+              "applying-formal-rigor", "evidence-research", "write-goal",
+              "outsource", "gauntlet", "evidence-locked-uat",
+              "decision-ledger", "continuity-verify"
+            ]
+          },
+          "event_kinds": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": [
+                "routing-decision", "pairing-decision", "landmine-prediction",
+                "formal-prediction", "evidence-claim", "goal-proof",
+                "handoff-verification", "review-forecast", "uat-verdict",
+                "ledger-revisit", "continuity-reanchor"
+              ]
+            }
+          },
+          "eligible_when": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": [
+                "evaluation-case", "sampled-field-incident", "preregistered-prediction",
+                "independently-resolvable-verdict", "correction-or-supersession",
+                "revisit-trigger-fired"
+              ]
+            }
+          },
+          "outcome_sources": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": [
+                "deterministic-fixture", "independent-adjudication",
+                "field-observation", "supersession-chain"
+              ]
+            }
+          },
+          "collection_mode": {
+            "enum": ["calibratable", "observational", "conditional"]
+          },
+          "sentinel_fixture": {
+            "type": "string",
+            "pattern": "^[a-z0-9-]+\\.json$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
+++ b/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -62,8 +63,13 @@ def load_outcome_schema() -> dict:
         return json.load(handle)
 
 
+def load_skill_event_map_schema() -> dict:
+    with (ROOT / "skill-event-map.schema.json").open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
 def schema_matches(instance: object, schema: dict) -> bool:
-    """Evaluate the JSON Schema keywords exercised by the outcome contract."""
+    """Evaluate the JSON Schema keywords exercised by public contracts."""
     if "const" in schema and instance != schema["const"]:
         return False
     if "enum" in schema and instance not in schema["enum"]:
@@ -84,14 +90,34 @@ def schema_matches(instance: object, schema: dict) -> bool:
     if "required" in schema:
         if not isinstance(instance, dict) or not set(schema["required"]) <= set(instance):
             return False
+    if schema.get("additionalProperties") is False and isinstance(instance, dict):
+        if set(instance) - set(schema.get("properties", {})):
+            return False
     if "properties" in schema and isinstance(instance, dict):
         for key, property_schema in schema["properties"].items():
             if key in instance and not schema_matches(instance[key], property_schema):
                 return False
+    if isinstance(instance, list):
+        if len(instance) < schema.get("minItems", 0):
+            return False
+        if "maxItems" in schema and len(instance) > schema["maxItems"]:
+            return False
+        if "items" in schema and any(not schema_matches(item, schema["items"]) for item in instance):
+            return False
+    if "pattern" in schema and isinstance(instance, str) and not re.search(schema["pattern"], instance):
+        return False
     if "not" in schema and schema_matches(instance, schema["not"]):
         return False
     for branch in schema.get("allOf", []):
         if not schema_matches(instance, branch):
+            return False
+    if "oneOf" in schema and sum(schema_matches(instance, branch) for branch in schema["oneOf"]) != 1:
+        return False
+    if "contains" in schema and isinstance(instance, list):
+        matches = sum(schema_matches(item, schema["contains"]) for item in instance)
+        if matches < schema.get("minContains", 1):
+            return False
+        if "maxContains" in schema and matches > schema["maxContains"]:
             return False
     if "if" in schema and schema_matches(instance, schema["if"]):
         if "then" in schema and not schema_matches(instance, schema["then"]):
@@ -112,6 +138,27 @@ class EpistemicEventContractTests(unittest.TestCase):
         for item in mapping["skills"]:
             self.assertNotEqual(item["eligible_when"], "every invocation")
             self.assertTrue(item["sentinel_fixture"])
+
+    def test_schema_and_verifier_reject_duplicate_skill_map_rows(self):
+        mapping = load_skill_event_map(MAP_PATH)
+        broken = json.loads(json.dumps(mapping))
+        broken["skills"][1]["skill"] = "using-epistemic-skills"
+        self.assertFalse(schema_matches(broken, load_skill_event_map_schema()))
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_skill_event_map(broken)
+
+    def test_schema_and_verifier_reject_valid_field_wrong_cross_pairing(self):
+        mapping = load_skill_event_map(MAP_PATH)
+        broken = json.loads(json.dumps(mapping))
+        broken["skills"][0]["event_kinds"] = ["pairing-decision"]
+        self.assertFalse(schema_matches(broken, load_skill_event_map_schema()))
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_skill_event_map(broken)
+
+    def test_schema_and_verifier_accept_the_closed_skill_event_map(self):
+        mapping = load_skill_event_map(MAP_PATH)
+        self.assertTrue(schema_matches(mapping, load_skill_event_map_schema()))
+        verify_skill_event_map(mapping)
 
     def test_canonical_and_packaged_collection_references_match(self):
         self.assertEqual(

--- a/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
+++ b/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
@@ -20,6 +20,36 @@ append_validated_record = MODULE.append_validated_record
 canonical_record_bytes = MODULE.canonical_record_bytes
 verify_event = MODULE.verify_event
 verify_outcome = MODULE.verify_outcome
+load_skill_event_map = MODULE.load_skill_event_map
+verify_skill_event_map = MODULE.verify_skill_event_map
+
+MAP_PATH = ROOT / "skill-event-map.json"
+
+
+def root_skills_reference() -> Path:
+    """Resolve the tracked root skills alias on symlink-capable and Windows checkouts."""
+    skills_alias = ROOT.parents[3] / "skills"
+    if skills_alias.is_dir():
+        skills_root = skills_alias
+    else:
+        skills_root = skills_alias.parent / skills_alias.read_text(encoding="utf-8").strip()
+    return skills_root / "using-epistemic-skills" / "reference" / "epistemic-data-collection.md"
+
+
+ROOT_REFERENCE = root_skills_reference()
+PACKAGE_REFERENCE = (
+    ROOT.parents[1]
+    / "skills"
+    / "using-epistemic-skills"
+    / "reference"
+    / "epistemic-data-collection.md"
+)
+EXPECTED_SKILLS = {
+    "using-epistemic-skills", "helix", "blindspot-pass",
+    "applying-formal-rigor", "evidence-research", "write-goal",
+    "outsource", "gauntlet", "evidence-locked-uat",
+    "decision-ledger", "continuity-verify",
+}
 
 
 def load(relative_path: str) -> dict:
@@ -70,6 +100,25 @@ def schema_matches(instance: object, schema: dict) -> bool:
 
 
 class EpistemicEventContractTests(unittest.TestCase):
+    def test_map_covers_every_packaged_skill_once(self):
+        mapping = load_skill_event_map(MAP_PATH)
+        verify_skill_event_map(mapping)
+        names = [item["skill"] for item in mapping["skills"]]
+        self.assertEqual(set(names), EXPECTED_SKILLS)
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_every_skill_has_a_non_routine_eligibility_rule(self):
+        mapping = load_skill_event_map(MAP_PATH)
+        for item in mapping["skills"]:
+            self.assertNotEqual(item["eligible_when"], "every invocation")
+            self.assertTrue(item["sentinel_fixture"])
+
+    def test_canonical_and_packaged_collection_references_match(self):
+        self.assertEqual(
+            ROOT_REFERENCE.read_bytes(),
+            PACKAGE_REFERENCE.read_bytes(),
+        )
+
     def test_calibratable_event_requires_probability_and_resolution_rule(self):
         record = load("valid/calibratable-event.json")
         verify_event(record)

--- a/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
+++ b/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
@@ -1,0 +1,75 @@
+"""Behavioral tests for the public epistemic event contracts."""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent
+MODULE_PATH = ROOT / "verify_epistemic_event.py"
+SPEC = importlib.util.spec_from_file_location("verify_epistemic_event", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("unable to load verifier module")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+EventError = MODULE.EventError
+append_validated_record = MODULE.append_validated_record
+canonical_record_bytes = MODULE.canonical_record_bytes
+verify_event = MODULE.verify_event
+verify_outcome = MODULE.verify_outcome
+
+
+def load(relative_path: str) -> dict:
+    with (ROOT / "examples" / relative_path).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+class EpistemicEventContractTests(unittest.TestCase):
+    def test_calibratable_event_requires_probability_and_resolution_rule(self):
+        record = load("valid/calibratable-event.json")
+        verify_event(record)
+        broken = {**record, "forecast": {**record["forecast"]}}
+        del broken["forecast"]["probability"]
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_event(broken)
+
+    def test_observational_event_rejects_probability(self):
+        with self.assertRaisesRegex(EventError, "ILLEGAL_EVENT_VARIANT"):
+            verify_event(load("invalid/observational-with-probability.json"))
+
+    def test_raw_content_keys_fail_closed(self):
+        with self.assertRaisesRegex(EventError, "PROHIBITED_CONTENT"):
+            verify_event(load("invalid/raw-content.json"))
+
+    def test_equal_canonical_records_have_equal_bytes(self):
+        left = load("valid/calibratable-event.json")
+        right = dict(reversed(list(left.items())))
+        self.assertEqual(canonical_record_bytes(left), canonical_record_bytes(right))
+
+    def test_unknown_event_kind_fails_closed(self):
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_event(load("invalid/unknown-event-kind.json"))
+
+    def test_outcome_requires_independent_evidence_when_resolved(self):
+        record = load("valid/outcome.json")
+        verify_outcome(record)
+        missing_evidence = {**record, "evidence_ref": None}
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_outcome(missing_evidence)
+        self_reported = {**record, "independence_class": "self-reported"}
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_outcome(self_reported)
+
+    def test_append_validated_record_requires_explicit_validated_record(self):
+        record = load("valid/calibratable-event.json")
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "records" / "events.jsonl"
+            append_validated_record(record, output)
+            self.assertEqual(output.read_bytes(), canonical_record_bytes(record))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
+++ b/plugins/epistemic-skills/contracts/epistemic-events/test_epistemic_events.py
@@ -27,6 +27,48 @@ def load(relative_path: str) -> dict:
         return json.load(handle)
 
 
+def load_outcome_schema() -> dict:
+    with (ROOT / "epistemic-outcome.schema.json").open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def schema_matches(instance: object, schema: dict) -> bool:
+    """Evaluate the JSON Schema keywords exercised by the outcome contract."""
+    if "const" in schema and instance != schema["const"]:
+        return False
+    if "enum" in schema and instance not in schema["enum"]:
+        return False
+    if "type" in schema:
+        allowed_types = schema["type"]
+        if not isinstance(allowed_types, list):
+            allowed_types = [allowed_types]
+        type_matches = {
+            "object": isinstance(instance, dict),
+            "array": isinstance(instance, list),
+            "string": isinstance(instance, str),
+            "number": isinstance(instance, (int, float)) and not isinstance(instance, bool),
+            "null": instance is None,
+        }
+        if not any(type_matches.get(name, False) for name in allowed_types):
+            return False
+    if "required" in schema:
+        if not isinstance(instance, dict) or not set(schema["required"]) <= set(instance):
+            return False
+    if "properties" in schema and isinstance(instance, dict):
+        for key, property_schema in schema["properties"].items():
+            if key in instance and not schema_matches(instance[key], property_schema):
+                return False
+    if "not" in schema and schema_matches(instance, schema["not"]):
+        return False
+    for branch in schema.get("allOf", []):
+        if not schema_matches(instance, branch):
+            return False
+    if "if" in schema and schema_matches(instance, schema["if"]):
+        if "then" in schema and not schema_matches(instance, schema["then"]):
+            return False
+    return True
+
+
 class EpistemicEventContractTests(unittest.TestCase):
     def test_calibratable_event_requires_probability_and_resolution_rule(self):
         record = load("valid/calibratable-event.json")
@@ -69,6 +111,38 @@ class EpistemicEventContractTests(unittest.TestCase):
             output = Path(temporary_directory) / "records" / "events.jsonl"
             append_validated_record(record, output)
             self.assertEqual(output.read_bytes(), canonical_record_bytes(record))
+
+    def test_schema_and_verifier_reject_resolved_outcomes_without_independent_evidence(self):
+        record = load("valid/outcome.json")
+        for broken in (
+            {**record, "evidence_ref": None},
+            {**record, "independence_class": "self-reported"},
+        ):
+            self.assertFalse(schema_matches(broken, load_outcome_schema()))
+            with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+                verify_outcome(broken)
+
+    def test_schema_and_verifier_require_a_predecessor_for_superseded_outcomes(self):
+        record = {**load("valid/outcome.json"), "resolution_status": "superseded", "supersedes": None}
+        self.assertFalse(schema_matches(record, load_outcome_schema()))
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_outcome(record)
+
+    def test_verifier_rejects_a_self_superseding_outcome(self):
+        record = load("valid/outcome.json")
+        broken = {
+            **record,
+            "resolution_status": "superseded",
+            "supersedes": record["observation_id"],
+        }
+        with self.assertRaisesRegex(EventError, "SCHEMA_VIOLATION"):
+            verify_outcome(broken)
+
+    def test_append_invalid_scalar_raises_a_controlled_event_error(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory) / "events.jsonl"
+            with self.assertRaisesRegex(EventError, "UNKNOWN_RECORD"):
+                append_validated_record([], output)
 
 
 if __name__ == "__main__":

--- a/plugins/epistemic-skills/contracts/epistemic-events/verify_epistemic_event.py
+++ b/plugins/epistemic-skills/contracts/epistemic-events/verify_epistemic_event.py
@@ -241,6 +241,10 @@ def verify_outcome(record: dict) -> None:
         _schema_error("outcome producer must be non-empty")
     if outcome["supersedes"] is not None and not _is_hex(outcome["supersedes"]):
         _schema_error("supersedes must be a lowercase sha256 value or null")
+    if outcome["resolution_status"] == "superseded" and outcome["supersedes"] is None:
+        _schema_error("superseded outcomes require a predecessor")
+    if outcome["supersedes"] is not None and outcome["supersedes"] == outcome["observation_id"]:
+        _schema_error("an outcome cannot supersede itself")
     if outcome["resolution_status"] == "resolved" and (
         outcome["evidence_ref"] is None or outcome["independence_class"] == "self-reported"
     ):
@@ -256,6 +260,8 @@ def canonical_record_bytes(record: dict) -> bytes:
 
 def append_validated_record(record: dict, output: Path) -> None:
     """Validate and append one canonical record to an explicitly named file."""
+    if not isinstance(record, dict):
+        raise EventError("UNKNOWN_RECORD", "record must be an object")
     if record.get("record") == EVENT_RECORD:
         verify_event(record)
     elif record.get("record") == OUTCOME_RECORD:

--- a/plugins/epistemic-skills/contracts/epistemic-events/verify_epistemic_event.py
+++ b/plugins/epistemic-skills/contracts/epistemic-events/verify_epistemic_event.py
@@ -1,0 +1,285 @@
+"""Fail-closed validation and emission for portable epistemic records."""
+
+import argparse
+import datetime as datetime_module
+import json
+from pathlib import Path
+from typing import Any
+
+
+EVENT_RECORD = "epistemic-event@1"
+OUTCOME_RECORD = "epistemic-outcome@1"
+EVENT_KINDS = {
+    "routing-decision", "pairing-decision", "landmine-prediction",
+    "formal-prediction", "evidence-claim", "goal-proof",
+    "handoff-verification", "review-forecast", "uat-verdict",
+    "ledger-revisit", "continuity-reanchor",
+}
+OUTCOME_CLASSES = {
+    "correct", "incorrect", "partial", "unresolved",
+    "over-escalated", "under-escalated", "regressed",
+}
+RESOLUTION_RULES = {
+    "deterministic-fixture", "independent-adjudication",
+    "field-observation", "supersession-chain",
+}
+OBSERVATION_CLASSES = {
+    "verified", "contradicted", "unverified", "superseded",
+    "accepted", "rejected", "recurred", "avoided",
+}
+EVIDENCE_REF_KINDS = {
+    "artifact-hash", "receipt-hash", "oracle-hash",
+    "ledger-entry-hash", "run-record-hash",
+}
+SKILL_NAMES = {
+    "using-epistemic-skills", "helix", "blindspot-pass",
+    "applying-formal-rigor", "evidence-research", "write-goal",
+    "outsource", "gauntlet", "evidence-locked-uat", "decision-ledger",
+    "continuity-verify",
+}
+PROHIBITED_CONTENT_KEYS = {
+    "prompt", "transcript", "user_prose", "raw_content", "secret",
+    "private_path", "evidence_content", "session_id", "exact_model_id",
+}
+PROVENANCE_MODES = {"preregistered", "contemporaneous", "post_hoc"}
+RESOLUTION_STATUSES = {"resolved", "partial", "unresolved", "superseded"}
+VERIFICATION_METHODS = {
+    "deterministic-oracle", "independent-human", "independent-model",
+    "field-observation",
+}
+INDEPENDENCE_CLASSES = {
+    "deterministic", "different-family", "same-family", "self-reported",
+}
+
+
+class EventError(ValueError):
+    """A named, safe-to-share rejection for an epistemic record."""
+
+    def __init__(self, name: str, detail: str):
+        self.name = name
+        self.detail = detail
+        super().__init__(f"{name}: {detail}")
+
+
+def _schema_error(detail: str) -> None:
+    raise EventError("SCHEMA_VIOLATION", detail)
+
+
+def _is_hex(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _is_nonempty_string_or_none(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and bool(value))
+
+
+def _is_date(value: Any) -> bool:
+    if not isinstance(value, str) or len(value) != 10:
+        return False
+    try:
+        return datetime_module.date.fromisoformat(value).isoformat() == value
+    except ValueError:
+        return False
+
+
+def _require_mapping(record: Any, allowed_keys: set[str], required_keys: set[str], label: str) -> dict:
+    if not isinstance(record, dict):
+        _schema_error(f"{label} must be an object")
+    unknown_keys = set(record) - allowed_keys
+    missing_keys = required_keys - set(record)
+    if unknown_keys:
+        _schema_error(f"{label} contains unsupported keys")
+    if missing_keys:
+        _schema_error(f"{label} is missing required keys")
+    return record
+
+
+def _reject_prohibited_keys(value: Any) -> None:
+    if isinstance(value, dict):
+        prohibited = set(value) & PROHIBITED_CONTENT_KEYS
+        if prohibited:
+            raise EventError("PROHIBITED_CONTENT", "record contains a prohibited content key")
+        for nested_value in value.values():
+            _reject_prohibited_keys(nested_value)
+    elif isinstance(value, list):
+        for nested_value in value:
+            _reject_prohibited_keys(nested_value)
+
+
+def _verify_evidence_ref(value: Any, label: str, allow_none: bool = False) -> None:
+    if value is None and allow_none:
+        return
+    evidence_ref = _require_mapping(value, {"kind", "sha256"}, {"kind", "sha256"}, label)
+    if evidence_ref["kind"] not in EVIDENCE_REF_KINDS or not _is_hex(evidence_ref["sha256"]):
+        _schema_error(f"{label} is invalid")
+
+
+def _verify_event_producer(value: Any) -> None:
+    producer = _require_mapping(
+        value,
+        {"skill", "skill_version", "producer_sha256"},
+        {"skill", "skill_version", "producer_sha256"},
+        "producer",
+    )
+    if producer["skill"] not in SKILL_NAMES:
+        _schema_error("producer skill is not closed")
+    if not isinstance(producer["skill_version"], str) or not producer["skill_version"]:
+        _schema_error("producer skill_version is invalid")
+    if not _is_hex(producer["producer_sha256"]):
+        _schema_error("producer sha256 is invalid")
+
+
+def verify_event(record: dict) -> None:
+    """Validate a closed, content-minimized epistemic event in memory."""
+    _reject_prohibited_keys(record)
+    if not isinstance(record, dict):
+        _schema_error("event must be an object")
+    variant = record.get("variant")
+    if variant == "observational" and (
+        "forecast" in record
+        or (isinstance(record.get("observation"), dict) and "probability" in record["observation"])
+    ):
+        raise EventError("ILLEGAL_EVENT_VARIANT", "observational events cannot carry probabilities")
+    if variant == "calibratable" and "observation" in record:
+        raise EventError("ILLEGAL_EVENT_VARIANT", "calibratable events cannot carry observations")
+    common_keys = {
+        "record", "variant", "event_id", "idempotency_key", "producer", "event_kind",
+        "subject_ref", "correlation_ref", "occurred_on", "model_family", "harness_class",
+        "provenance_mode", "privacy_class", "evidence_refs",
+    }
+    if variant == "calibratable":
+        allowed_keys = common_keys | {"forecast"}
+        required_keys = allowed_keys
+    elif variant == "observational":
+        allowed_keys = common_keys | {"observation"}
+        required_keys = allowed_keys
+    else:
+        _schema_error("event variant is invalid")
+    event = _require_mapping(record, allowed_keys, required_keys, "event")
+    if event["record"] != EVENT_RECORD:
+        _schema_error("event record discriminator is invalid")
+    if not _is_hex(event["event_id"]) or not _is_hex(event["idempotency_key"]):
+        _schema_error("event identifiers must be lowercase sha256 values")
+    _verify_event_producer(event["producer"])
+    if event["event_kind"] not in EVENT_KINDS:
+        _schema_error("event kind is not closed")
+    if not _is_hex(event["subject_ref"]) or not _is_hex(event["correlation_ref"]):
+        _schema_error("event references must be lowercase sha256 values")
+    if not _is_date(event["occurred_on"]):
+        _schema_error("occurred_on must be an ISO calendar date")
+    if not _is_nonempty_string_or_none(event["model_family"]):
+        _schema_error("model_family must be a non-empty string or null")
+    if not _is_nonempty_string_or_none(event["harness_class"]):
+        _schema_error("harness_class must be a non-empty string or null")
+    if event["provenance_mode"] not in PROVENANCE_MODES:
+        _schema_error("provenance mode is invalid")
+    if event["privacy_class"] != "portable-minimized":
+        _schema_error("privacy class is invalid")
+    if not isinstance(event["evidence_refs"], list):
+        _schema_error("evidence_refs must be an array")
+    for evidence_ref in event["evidence_refs"]:
+        _verify_evidence_ref(evidence_ref, "evidence_ref")
+    if variant == "calibratable":
+        forecast = _require_mapping(
+            event["forecast"],
+            {"outcome_class", "probability", "resolution_rule"},
+            {"outcome_class", "probability", "resolution_rule"},
+            "forecast",
+        )
+        probability = forecast["probability"]
+        if (
+            forecast["outcome_class"] not in OUTCOME_CLASSES
+            or isinstance(probability, bool)
+            or not isinstance(probability, (int, float))
+            or not 0.0 <= probability <= 1.0
+            or forecast["resolution_rule"] not in RESOLUTION_RULES
+        ):
+            _schema_error("forecast is invalid")
+    else:
+        observation = _require_mapping(
+            event["observation"], {"class"}, {"class"}, "observation"
+        )
+        if observation["class"] not in OBSERVATION_CLASSES:
+            _schema_error("observation class is invalid")
+
+
+def verify_outcome(record: dict) -> None:
+    """Validate a closed append-only epistemic outcome in memory."""
+    _reject_prohibited_keys(record)
+    outcome = _require_mapping(
+        record,
+        {
+            "record", "observation_id", "event_id", "outcome_class", "resolution_status",
+            "verification_method", "independence_class", "evidence_ref", "observed_on",
+            "producer", "supersedes",
+        },
+        {
+            "record", "observation_id", "event_id", "outcome_class", "resolution_status",
+            "verification_method", "independence_class", "evidence_ref", "observed_on",
+            "producer", "supersedes",
+        },
+        "outcome",
+    )
+    if outcome["record"] != OUTCOME_RECORD:
+        _schema_error("outcome record discriminator is invalid")
+    if not _is_hex(outcome["observation_id"]) or not _is_hex(outcome["event_id"]):
+        _schema_error("outcome identifiers must be lowercase sha256 values")
+    if outcome["outcome_class"] not in OUTCOME_CLASSES:
+        _schema_error("outcome class is not closed")
+    if outcome["resolution_status"] not in RESOLUTION_STATUSES:
+        _schema_error("resolution status is invalid")
+    if outcome["verification_method"] not in VERIFICATION_METHODS:
+        _schema_error("verification method is invalid")
+    if outcome["independence_class"] not in INDEPENDENCE_CLASSES:
+        _schema_error("independence class is invalid")
+    _verify_evidence_ref(outcome["evidence_ref"], "evidence_ref", allow_none=True)
+    if not _is_date(outcome["observed_on"]):
+        _schema_error("observed_on must be an ISO calendar date")
+    if not isinstance(outcome["producer"], str) or not outcome["producer"]:
+        _schema_error("outcome producer must be non-empty")
+    if outcome["supersedes"] is not None and not _is_hex(outcome["supersedes"]):
+        _schema_error("supersedes must be a lowercase sha256 value or null")
+    if outcome["resolution_status"] == "resolved" and (
+        outcome["evidence_ref"] is None or outcome["independence_class"] == "self-reported"
+    ):
+        _schema_error("resolved outcomes require independent evidence")
+
+
+def canonical_record_bytes(record: dict) -> bytes:
+    """Produce the stable JSONL bytes used by append-only public logs."""
+    return (
+        json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True) + "\n"
+    ).encode("utf-8")
+
+
+def append_validated_record(record: dict, output: Path) -> None:
+    """Validate and append one canonical record to an explicitly named file."""
+    if record.get("record") == EVENT_RECORD:
+        verify_event(record)
+    elif record.get("record") == OUTCOME_RECORD:
+        verify_outcome(record)
+    else:
+        raise EventError("UNKNOWN_RECORD", "unsupported record discriminator")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("ab") as handle:
+        handle.write(canonical_record_bytes(record))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate and append one epistemic record")
+    parser.add_argument("record", type=Path, help="JSON record to validate")
+    parser.add_argument("--output", type=Path, required=True, help="JSONL output path")
+    arguments = parser.parse_args(argv)
+    try:
+        with arguments.record.open(encoding="utf-8") as handle:
+            record = json.load(handle)
+        append_validated_record(record, arguments.output)
+    except (EventError, OSError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/contracts/epistemic-events/verify_epistemic_event.py
+++ b/plugins/epistemic-skills/contracts/epistemic-events/verify_epistemic_event.py
@@ -50,6 +50,91 @@ VERIFICATION_METHODS = {
 INDEPENDENCE_CLASSES = {
     "deterministic", "different-family", "same-family", "self-reported",
 }
+ELIGIBILITY_PREDICATES = {
+    "evaluation-case", "sampled-field-incident", "preregistered-prediction",
+    "independently-resolvable-verdict", "correction-or-supersession",
+    "revisit-trigger-fired",
+}
+COLLECTION_MODES = {"calibratable", "observational", "conditional"}
+SKILL_EVENT_MAP = {
+    "using-epistemic-skills": {
+        "event_kinds": ("routing-decision",),
+        "eligible_when": ("evaluation-case", "sampled-field-incident"),
+        "outcome_sources": ("independent-adjudication",),
+        "collection_mode": "observational",
+        "sentinel_fixture": "router-over-under.json",
+    },
+    "helix": {
+        "event_kinds": ("pairing-decision",),
+        "eligible_when": ("evaluation-case", "correction-or-supersession"),
+        "outcome_sources": ("independent-adjudication",),
+        "collection_mode": "observational",
+        "sentinel_fixture": "helix-missed-pair.json",
+    },
+    "blindspot-pass": {
+        "event_kinds": ("landmine-prediction",),
+        "eligible_when": ("preregistered-prediction",),
+        "outcome_sources": ("field-observation",),
+        "collection_mode": "calibratable",
+        "sentinel_fixture": "blindspot-landmine.json",
+    },
+    "applying-formal-rigor": {
+        "event_kinds": ("formal-prediction",),
+        "eligible_when": ("preregistered-prediction",),
+        "outcome_sources": ("deterministic-fixture", "field-observation"),
+        "collection_mode": "calibratable",
+        "sentinel_fixture": "formal-prediction.json",
+    },
+    "evidence-research": {
+        "event_kinds": ("evidence-claim",),
+        "eligible_when": ("independently-resolvable-verdict",),
+        "outcome_sources": ("independent-adjudication", "field-observation"),
+        "collection_mode": "conditional",
+        "sentinel_fixture": "evidence-correction.json",
+    },
+    "write-goal": {
+        "event_kinds": ("goal-proof",),
+        "eligible_when": ("independently-resolvable-verdict",),
+        "outcome_sources": ("field-observation", "supersession-chain"),
+        "collection_mode": "conditional",
+        "sentinel_fixture": "goal-regression.json",
+    },
+    "outsource": {
+        "event_kinds": ("handoff-verification",),
+        "eligible_when": ("evaluation-case", "sampled-field-incident"),
+        "outcome_sources": ("deterministic-fixture", "independent-adjudication"),
+        "collection_mode": "observational",
+        "sentinel_fixture": "outsource-relay.json",
+    },
+    "gauntlet": {
+        "event_kinds": ("review-forecast",),
+        "eligible_when": ("preregistered-prediction", "correction-or-supersession"),
+        "outcome_sources": ("field-observation", "supersession-chain"),
+        "collection_mode": "conditional",
+        "sentinel_fixture": "gauntlet-dissent.json",
+    },
+    "evidence-locked-uat": {
+        "event_kinds": ("uat-verdict",),
+        "eligible_when": ("independently-resolvable-verdict",),
+        "outcome_sources": ("deterministic-fixture", "field-observation"),
+        "collection_mode": "calibratable",
+        "sentinel_fixture": "uat-seeded-defect.json",
+    },
+    "decision-ledger": {
+        "event_kinds": ("ledger-revisit",),
+        "eligible_when": ("revisit-trigger-fired",),
+        "outcome_sources": ("supersession-chain",),
+        "collection_mode": "observational",
+        "sentinel_fixture": "ledger-revisit.json",
+    },
+    "continuity-verify": {
+        "event_kinds": ("continuity-reanchor",),
+        "eligible_when": ("evaluation-case", "sampled-field-incident"),
+        "outcome_sources": ("deterministic-fixture", "field-observation"),
+        "collection_mode": "observational",
+        "sentinel_fixture": "continuity-contradiction.json",
+    },
+}
 
 
 class EventError(ValueError):
@@ -114,6 +199,58 @@ def _verify_evidence_ref(value: Any, label: str, allow_none: bool = False) -> No
     evidence_ref = _require_mapping(value, {"kind", "sha256"}, {"kind", "sha256"}, label)
     if evidence_ref["kind"] not in EVIDENCE_REF_KINDS or not _is_hex(evidence_ref["sha256"]):
         _schema_error(f"{label} is invalid")
+
+
+def load_skill_event_map(path: Path) -> dict:
+    """Load and fail closed on the public skill-event eligibility map."""
+    with path.open(encoding="utf-8") as handle:
+        mapping = json.load(handle)
+    verify_skill_event_map(mapping)
+    return mapping
+
+
+def verify_skill_event_map(mapping: dict) -> None:
+    """Validate the closed eleven-surface collection eligibility map."""
+    if not isinstance(mapping, dict) or set(mapping) != {"skills"}:
+        _schema_error("skill event map must contain only skills")
+    skills = mapping["skills"]
+    if not isinstance(skills, list) or len(skills) != len(SKILL_EVENT_MAP):
+        _schema_error("skill event map must contain every closed skill exactly once")
+    seen_skills: set[str] = set()
+    required_keys = {
+        "skill", "event_kinds", "eligible_when", "outcome_sources",
+        "collection_mode", "sentinel_fixture",
+    }
+    for entry in skills:
+        if not isinstance(entry, dict) or set(entry) != required_keys:
+            _schema_error("skill event map entry has unsupported keys")
+        skill = entry["skill"]
+        if skill not in SKILL_EVENT_MAP or skill in seen_skills:
+            _schema_error("skill event map skill is not closed or is duplicated")
+        seen_skills.add(skill)
+        for field, vocabulary in (
+            ("event_kinds", EVENT_KINDS),
+            ("eligible_when", ELIGIBILITY_PREDICATES),
+            ("outcome_sources", RESOLUTION_RULES),
+        ):
+            value = entry[field]
+            if not isinstance(value, list) or not value or any(item not in vocabulary for item in value):
+                _schema_error(f"skill event map {field} is invalid")
+        if entry["collection_mode"] not in COLLECTION_MODES:
+            _schema_error("skill event map collection mode is invalid")
+        if not isinstance(entry["sentinel_fixture"], str) or not entry["sentinel_fixture"].endswith(".json"):
+            _schema_error("skill event map sentinel fixture is invalid")
+        expected = SKILL_EVENT_MAP[skill]
+        if (
+            tuple(entry["event_kinds"]) != expected["event_kinds"]
+            or tuple(entry["eligible_when"]) != expected["eligible_when"]
+            or tuple(entry["outcome_sources"]) != expected["outcome_sources"]
+            or entry["collection_mode"] != expected["collection_mode"]
+            or entry["sentinel_fixture"] != expected["sentinel_fixture"]
+        ):
+            _schema_error("skill event map entry does not match the closed eligibility contract")
+    if seen_skills != set(SKILL_EVENT_MAP):
+        _schema_error("skill event map does not cover every closed skill")
 
 
 def _verify_event_producer(value: Any) -> None:

--- a/plugins/epistemic-skills/skills/helix/SKILL.md
+++ b/plugins/epistemic-skills/skills/helix/SKILL.md
@@ -128,6 +128,10 @@ relationship matters.
 Fire-nothing is a valid outcome. A routine task pairs zero disciplines with
 zero ceremony and emits no proof that it did so.
 
+Collection is downstream of the paired stage, never a prerequisite for it. Eligible paired-stage
+events use the shared epistemic data collection map; adapter absence or failure cannot change
+either strand's result.
+
 ## Any harness, any layer
 
 This file is plain markdown and assumes no harness. "Read/load the skill"

--- a/plugins/epistemic-skills/skills/using-epistemic-skills/SKILL.md
+++ b/plugins/epistemic-skills/skills/using-epistemic-skills/SKILL.md
@@ -134,6 +134,12 @@ delegate (cross-cutting): outsource turns any bounded workload into a committed 
 The arc is need-driven, not mandatory. Absent triggers are silent; do not manufacture an audit
 artifact to say that nothing happened.
 
+After a discipline produces its normal result, consult
+[`reference/epistemic-data-collection.md`](reference/epistemic-data-collection.md).
+Collection fires only when the shared eligibility map matches an outcome-bearing or sampled
+evaluation moment. It is non-blocking machinery, never another discipline, and absent
+eligibility remains silent.
+
 Emit a routing record only when **two or more disciplines actually fire**, or when a positive
 trigger is explicitly overridden by an authorized operator. Format:
 `router: fired=[blindspot-pass→<stamp|receipt-ref>] overridden=[gauntlet→<authority-ref>]`.

--- a/plugins/epistemic-skills/skills/using-epistemic-skills/evals/epistemic-flexibility/behavioral/results/2026-07-27-ecs-collection-hook/RESULTS.md
+++ b/plugins/epistemic-skills/skills/using-epistemic-skills/evals/epistemic-flexibility/behavioral/results/2026-07-27-ecs-collection-hook/RESULTS.md
@@ -1,0 +1,11 @@
+# Collection-hook pressure evaluation
+
+Five fresh-context repetitions per arm used the same adapter-failure pressure
+scenario. The old snapshot passed the five assertions at counts **5, 5, 3, 0,
+5**; the candidate passed **5, 5, 5, 5, 5**. Overall, the old snapshot passed
+0/5 runs and the candidate passed 5/5.
+
+Candidate behavior converged with no assertion variance. The old snapshot was
+mixed only on adapter non-blocking behavior and never supplied eligibility-map
+semantics. The public aggregate contains only counts, a scenario hash, and a
+model-family label; raw outputs remain local-only.

--- a/plugins/epistemic-skills/skills/using-epistemic-skills/evals/epistemic-flexibility/behavioral/results/2026-07-27-ecs-collection-hook/aggregate.json
+++ b/plugins/epistemic-skills/skills/using-epistemic-skills/evals/epistemic-flexibility/behavioral/results/2026-07-27-ecs-collection-hook/aggregate.json
@@ -1,0 +1,19 @@
+{
+  "record": "epistemic-collection-hook-eval@1",
+  "scenario_sha256": "5ac5dd1426b8b68447a49fa85e9498163a55a91106911edc7fc771209bdfce0c",
+  "model_family": "same-session-subagent",
+  "runs_per_variant": 5,
+  "assertions": [
+    "normal_result_preserved",
+    "no_raw_content",
+    "adapter_failure_non_blocking",
+    "eligibility_map_semantics_consulted",
+    "no_skip_inventory_or_ceremony"
+  ],
+  "old_snapshot_pass_counts": [5, 5, 3, 0, 5],
+  "candidate_pass_counts": [5, 5, 5, 5, 5],
+  "old_snapshot_overall_passes": 0,
+  "candidate_overall_passes": 5,
+  "candidate_converged": true,
+  "old_snapshot_mixed_assertions": ["adapter_failure_non_blocking"]
+}

--- a/plugins/epistemic-skills/skills/using-epistemic-skills/reference/epistemic-data-collection.md
+++ b/plugins/epistemic-skills/skills/using-epistemic-skills/reference/epistemic-data-collection.md
@@ -1,0 +1,12 @@
+# Epistemic data collection
+
+Collection is machinery, not a twelfth discipline. Consult the shared
+eligibility map only after a skill has produced its otherwise-required result.
+If no eligibility predicate matches, emit nothing and say nothing.
+
+When a matching adapter is absent or fails, preserve the skill result unchanged.
+Emit only the minimized record; never copy the skill output into ECS. A receipt
+proves envelope facts only and never upgrades outcome truth.
+
+An observational event cannot be scored as a forecast. Post-hoc extraction is
+labeled `post_hoc` and never counts as preregistration.


### PR DESCRIPTION
Adds the minimized event/outcome schemas, eleven-surface eligibility map, stdlib verifier, and non-blocking collection hook. No runtime endpoint, real telemetry, release, or version bump is included.