### PR TITLE
Add epistemic-product-calibration protocol, schema, verifier, docs, examples, and CI check

### DIFF
--- a/.github/scripts/check_json_artifacts.py
+++ b/.github/scripts/check_json_artifacts.py
@@ -21,6 +21,7 @@ def main() -> int:
         if not row["json_parseable"]
     }
     roots = [
+        REPO_ROOT / "plugins/epistemic-skills/contracts",
         REPO_ROOT / "plugins/epistemic-skills/skills/using-epistemic-skills/evals/epistemic-flexibility",
         REPO_ROOT / "plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality",
         FORMAL_ROOT,

--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -101,6 +101,8 @@ jobs:
         run: python plugins/epistemic-skills/skills/decision-ledger/reference/validate_examples.py
       - name: Existing receipt verifier
         run: python plugins/epistemic-skills/contracts/verify_receipt.py --self-test
+      - name: Cross-product calibration contract
+        run: python plugins/epistemic-skills/contracts/verify_calibration.py --self-test
       - name: Existing UAT judge
         run: python plugins/epistemic-skills/skills/evidence-locked-uat/scripts/judge.py --self-test
       - name: Existing gauntlet tests

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The README is the fast path into the project. The [GitHub Wiki](https://github.c
 - [Eleven-skill catalog](#eleven-skill-catalog)
 - [Installation and compatibility](#installation-and-compatibility)
 - [Architecture and source policy](#architecture-and-source-policy)
+- [Coordination with epistemic-calibration](#coordination-with-epistemic-calibration)
 - [Trust, evidence, and known limits](#trust-evidence-and-known-limits)
 - [Developing and contributing](#developing-and-contributing)
 
@@ -331,6 +332,21 @@ For a stable behavior claim, use this order:
 3. README and Wiki explanations.
 
 `main` is current development and may move. The Wiki is a curated, unversioned handbook and must label current-development links. Historical audits and evaluations retain the status and scope they had at their frozen revision. Stable installation commands always use an immutable tag.
+
+## Coordination with epistemic-calibration
+
+The runtime product and its behavioral measurement counterpart remain separate,
+independently versioned repositories. **epistemic-skills owns intervention
+contracts; epistemic-calibration owns corpora, trial execution, and calibrated
+estimates.** They exchange revision-bound records rather than sharing mutable
+source or creating an installation dependency.
+
+The [coordination charter](docs/coordination/epistemic-calibration.md) records
+the current 3.0.0 status, product boundary, proposed
+`epistemic-product-calibration@1` exchange unit, adoption questions, and phased
+pilot plan. Calibration-side state remains unverified until that repository
+returns an immutable reference; the charter does not turn a proposed bilateral
+contract into an accepted one.
 
 ## Trust, evidence, and known limits
 

--- a/docs/coordination/epistemic-calibration.formal-rigor.json
+++ b/docs/coordination/epistemic-calibration.formal-rigor.json
@@ -1,0 +1,137 @@
+{
+  "record": "formal-rigor-record@2",
+  "subject": {
+    "ref": "docs/coordination/epistemic-calibration.md",
+    "revision": "2d66a276e27b80996a9d0a1851c97cfe77127690"
+  },
+  "valid_while": ["subject-revision-unchanged", "skills-3.0-contract-unchanged", "calibration-side-contract-not-yet-adopted"],
+  "coverage_limits": [
+    "The epistemic-calibration repository was not reachable from this environment.",
+    "The result establishes a unilateral proposal, not bilateral adoption or calibration-side compatibility.",
+    "P8 measurement uncertainty remains unmapped until calibration-side populations and statistical methods are inspected."
+  ],
+  "rigor": {
+    "tier": "standard",
+    "trigger": "A persistent cross-repository product boundary has multiple viable coupling alternatives.",
+    "tier_reason": "The interface bears downstream versioning and evidence load, but this proposal creates no security, safety, public runtime, or irreversible migration boundary."
+  },
+  "decision_frame": {
+    "question": "How should epistemic-skills and epistemic-calibration coordinate without compromising runtime independence or measurement validity?",
+    "system_boundary": "Repository ownership, immutable exchange records, change custody, and release/calibration compatibility; runtime skill behavior and calibration methodology remain owned by their respective repositories.",
+    "actors": ["epistemic-skills maintainers", "epistemic-calibration maintainers", "skill consumers", "calibration result consumers"],
+    "alternatives": [
+      {"id": "null", "kind": "null-option", "description": "Continue with no explicit cross-product coordination."},
+      {"id": "merged", "kind": "option", "description": "Merge calibration machinery and skill runtime contracts into one repository."},
+      {"id": "submodule", "kind": "option", "description": "Couple repositories through a submodule or runtime/install dependency."},
+      {"id": "informal", "kind": "option", "description": "Use prose links without a versioned exchange contract."},
+      {"id": "protocol", "kind": "option", "description": "Keep independent repositories and exchange immutable, validated compatibility records."}
+    ],
+    "hard_constraints": [
+      "Version 3.0.0 remains immutable.",
+      "The runtime package has no calibration repository installation dependency.",
+      "Evidence remains subject-, corpus-, runner-, and result-revision-bound.",
+      "Each repository retains independent release authority."
+    ],
+    "authorized_objectives": [
+      "Coordinate the two products as counterparts.",
+      "Make cross-product claims traceable and correctable.",
+      "Avoid conflating intervention contracts with behavioral measurement."
+    ],
+    "priority_rule": {
+      "kind": "constraint-satisfaction",
+      "authority_ref": "user request 2026-07-29 and docs/coordination/epistemic-calibration.md#executive-position"
+    },
+    "assumptions": ["The named epistemic-calibration repository is intended to be the measurement counterpart."],
+    "empirical_premises": [],
+    "uncertainty_posture": "Fail closed on calibration-side facts until an immutable repository revision is observed."
+  },
+  "coverage": [
+    {"family": "P1", "status": "fired", "modules": ["interface-protocol-evolution"], "reason": "The exchange unit requires stable identity and validity invariants."},
+    {"family": "P2", "status": "not-applicable", "modules": [], "reason": "The proposal does not define a shared mutable datastore or relational decomposition."},
+    {"family": "P3", "status": "not-applicable", "modules": [], "reason": "Repositories land independently; no concurrent shared-write correctness claim is made."},
+    {"family": "P4", "status": "not-applicable", "modules": [], "reason": "The proposal does not replicate state or define distributed consistency."},
+    {"family": "P5", "status": "fired", "modules": ["dependability-fault-models", "interface-protocol-evolution"], "reason": "Missing counterparts, stale subjects, and superseded evidence require fail-closed recovery rules."},
+    {"family": "P6", "status": "not-applicable", "modules": [], "reason": "Only public metadata is proposed; authentication and private evidence transport are outside the boundary."},
+    {"family": "P7", "status": "not-applicable", "modules": [], "reason": "No capacity, complexity, or real-time bound bears on the selection."},
+    {"family": "P8", "status": "unmapped", "modules": [], "reason": "Measurement uncertainty is material, but calibration-side populations and statistical methods are unavailable."},
+    {"family": "P9", "status": "fired", "modules": ["interface-protocol-evolution", "decision-theory-multiobjective"], "reason": "Independent versioning, compatibility, lifecycle, and authorized synthesis determine the product boundary."}
+  ],
+  "derivations": [
+    {
+      "id": "d1",
+      "module": "interface-protocol-evolution",
+      "construct": "versioned protocol compatibility with fail-closed unknown peers",
+      "sources": {"primary_theory": ["plugins/epistemic-skills/skills/applying-formal-rigor/reference/modules/interface-protocol-evolution.md"], "official_product_docs": ["README.md", "docs/release/RELEASE-3.0.0.md"]},
+      "model": "Two independently versioned repositories exchange immutable records; neither reads the other's mutable working tree at runtime.",
+      "preconditions": [
+        {"id": "p1", "statement": "epistemic-skills 3.0.0 is an immutable support point.", "status": "verified"},
+        {"id": "p2", "statement": "Calibration-side adoption is not verified.", "status": "verified"},
+        {"id": "p3", "statement": "Unknown or incompatible records fail closed rather than being treated as current evidence.", "status": "assumed"}
+      ],
+      "fact_mapping": [
+        {"precondition_id": "p1", "claim_class": "observation", "anchor": "README.md:13 and docs/release/RELEASE-3.0.0.md:7"},
+        {"precondition_id": "p2", "claim_class": "observation", "anchor": "network verification failure recorded during 2026-07-29 reconnaissance"},
+        {"precondition_id": "p3", "claim_class": "value", "anchor": "docs/coordination/epistemic-calibration.md#change-protocol"}
+      ],
+      "steps": [
+        "A merge or submodule makes product availability and revision selection depend on the counterpart and violates runtime independence.",
+        "An informal link or status quo cannot bind a result to subject, corpus, runner, and protocol revisions, so compatibility and correction custody remain ambiguous.",
+        "An immutable exchange record names both revisions and can be rejected when unknown, stale, or incompatible.",
+        "Independent landing lets each owner validate inbound claims and release without an unmerged cross-repository branch."
+      ],
+      "result": {"state": "conditional", "statement": "The independent protocol alternative satisfies the declared compatibility and ownership constraints if the counterpart adopts a compatible record."},
+      "counterexample": null,
+      "residual_mismatch": ["No conclusion is established about the calibration repository's current design or willingness to adopt the protocol."]
+    },
+    {
+      "id": "d2",
+      "module": "dependability-fault-models",
+      "construct": "fault containment through immutable evidence pointers and append-only supersession",
+      "sources": {"primary_theory": ["plugins/epistemic-skills/skills/applying-formal-rigor/reference/modules/dependability-fault-models.md"], "official_product_docs": ["docs/release/RELEASE-3.0.0-RISK-ACCEPTANCE.json"]},
+      "model": "Counterpart unavailable, result stale, evidence corrected, or measurement scope narrower than a requested product claim.",
+      "preconditions": [
+        {"id": "p4", "statement": "The receiving repository independently verifies identity and claim scope.", "status": "assumed"},
+        {"id": "p5", "statement": "Corrections supersede rather than rewrite historical evidence.", "status": "assumed"}
+      ],
+      "fact_mapping": [
+        {"precondition_id": "p4", "claim_class": "value", "anchor": "docs/coordination/epistemic-calibration.md#change-protocol"},
+        {"precondition_id": "p5", "claim_class": "value", "anchor": "docs/coordination/epistemic-calibration.md#immutable-exchange-unit"}
+      ],
+      "steps": [
+        "Immutable subject and evidence identities localize a stale or corrected result to records that cite it.",
+        "Independent verification prevents producer declaration alone from becoming a product claim.",
+        "Append-only supersession preserves the audit history while allowing consumers to select the current compatible record.",
+        "An unavailable counterpart leaves status unknown and does not block the runtime package."
+      ],
+      "result": {"state": "conditional", "statement": "The protocol contains counterpart, staleness, and correction faults without coupling runtime availability, provided consumers enforce verification and supersession."},
+      "counterexample": null,
+      "residual_mismatch": ["A future private-data transport would require a separate security analysis."]
+    }
+  ],
+  "empirical_closure": {"state": "not-required", "tests": []},
+  "synthesis": {
+    "outcome": "conditional",
+    "selected_option": "protocol",
+    "basis": [
+      "Only the protocol option satisfies runtime independence while binding subject, corpus, runner, and result identities.",
+      "Independent validation and supersession contain unavailable, stale, or corrected evidence.",
+      "The selection cannot become bilateral until calibration-side adoption is observed."
+    ],
+    "conditions": [
+      "The calibration repository verifies its canonical coordinate and revision.",
+      "Both repositories adopt compatible exchange semantics.",
+      "Consumers reject unknown or stale records."
+    ],
+    "concessions": ["The protocol adds coordination and duplicated validation overhead.", "P8 remains unmapped until calibration-side methods are inspected."],
+    "recovery_moves": ["Counter-propose the protocol after calibration-side reconnaissance.", "Introduce a shared schema package only after real duplication demonstrates the need."]
+  },
+  "never_attests": [
+    "derivation-correctness-by-envelope",
+    "empirical-fact-without-observation",
+    "gauntlet-independence",
+    "calibration-repository-existence-or-state",
+    "bilateral-protocol-adoption",
+    "behavioral-effectiveness",
+    "statistical-validity-without-population-and-method"
+  ]
+}

--- a/docs/coordination/epistemic-calibration.md
+++ b/docs/coordination/epistemic-calibration.md
@@ -1,0 +1,312 @@
+# Epistemic Skills × Epistemic Calibration coordination charter
+
+**Established:** 2026-07-29  
+**Skills subject:** `ZMS-Labs/epistemic-skills` at `2d66a27`  
+**Calibration coordinate:** `https://github.com/ZMS-Labs/epistemic-calibration.git`  
+**Status:** executable consumer-side contract; calibration-side adoption is not yet verified
+
+## Executive position
+
+`epistemic-skills` is at **3.0.0**, its first immutable support point. The
+current branch is post-release documentation/evidence work, not a 3.1 product
+line: the package manifests and public installation contract remain 3.0.0.
+
+The products should be coordinated as a producer/consumer pair without merging
+their responsibilities:
+
+- **epistemic-skills owns the intervention contract**: triggers, procedures,
+  outputs, schemas, deterministic judges, packaging, and honest evidence
+  boundaries.
+- **epistemic-calibration owns measurement**: versioned corpora, trial
+  orchestration, blinded scoring, longitudinal/provider slices, and estimates
+  of how those interventions behave.
+- Neither repository may silently change the other's contract. Shared work
+  crosses through immutable coordinates and an explicit compatibility record.
+
+This is a deliberately loose repository connection. There is no submodule or
+runtime dependency: installing the skill package must not pull in evaluation
+data or calibration infrastructure, and calibration must test immutable skill
+revisions rather than a mutable working tree.
+
+## Where epistemic-skills is now
+
+### Shipped and supported
+
+| Surface | Current state | Authority |
+|---|---|---|
+| Product version | 3.0.0, first stable immutable support point | `README.md`; `docs/release/RELEASE-3.0.0.md` |
+| Package | Eleven skills: router, nine disciplines, and Helix | `README.md` |
+| Core operating model | Routine fast path; positive triggers; silent non-events; proportional process | `README.md`; released skill contracts |
+| Cross-workflow coordination | Helix pairs epistemic methods with workflow stages but does not replace either router | `plugins/epistemic-skills/skills/helix/SKILL.md` |
+| Distribution | Multi-harness package surfaces pinned to v3.0.0 | `README.md`; package manifests |
+| Deterministic evidence | Repository test suites cover contracts, proportionality, formal-rigor fixtures, UAT triage, receipts, DCO, JSON, and Gauntlet mechanics | `.github/workflows/epistemic-flexibility.yml` |
+
+### Supported, with bounded claims
+
+The 3.0.0 support promise is about immutable contracts and deterministic
+repository checks. It is **not** proof of universal behavioral superiority,
+cross-provider generality, human equivalence, or current behavior in every
+harness. The release risk record names the accepted gaps.
+
+The V3 formal-rigor post-hoc report says “3.0.0 remains HOLD,” but that sentence
+is local to the diagnostic's no-release-credit boundary and predates the later
+release authorization/publication sequence. It must not be used as the current
+product status. The README and release record are the current public status;
+the diagnostic remains evidence with its original limitation.
+
+### Open measurement work that belongs in the relationship
+
+1. Native trigger precision and timing across supported harnesses.
+2. False-act and false-hold rates on clean controls and traps.
+3. Cross-model/provider and repeated-run behavior without provider/repetition
+   confounding.
+4. Gauntlet lens and arbitrator calibration on broader seeded corpora.
+5. Evidence-locked UAT's transition from `uncalibrated` to the existing
+   `calibrated:<corpus-ref>@<date>` vocabulary.
+6. Real-world catch rate, correction burden, latency, and token/tool cost.
+7. Version-to-version regression and transfer, while retaining negative and
+   parody controls.
+
+These are calibration questions. A finding may motivate a skill change, but a
+measurement gap alone must not cause evaluation machinery to leak into the
+runtime package.
+
+## Blindspot pass
+
+### Landmines
+
+- “Connect the repositories” could mean a Git submodule, a runtime dependency,
+  shared source, a Git remote, or a governance relationship. Only the last two
+  preserve the package/evidence boundary; a submodule would couple installs to
+  a changing corpus.
+- This checkout initially had no Git remotes, and network access could not
+  verify the calibration repository. The coordinate above is therefore an
+  operator-supplied naming inference, not an observed calibration-side fact.
+- The word *calibration* already has several scopes here: UAT seeded-defect
+  status, Gauntlet telemetry, fixture smoke checks, and broad behavioral
+  measurement. Treating them as one score would erase their populations and
+  validity limits.
+- Green deterministic checks do not estimate behavioral effectiveness. The
+  release documentation explicitly separates immutable support from universal
+  behavior claims.
+- The current README estate header says `maintenance` and portfolio role
+  `none`. Cross-product coordination must not silently override that external
+  lifecycle authority.
+
+### Hidden context
+
+- The collection audit already rejected “calibration reader” as another skill;
+  calibration should be machinery consumed at existing decision points, not
+  runtime ceremony (`docs/audits/2026-07-22-collection-audit/06-gap-analysis.md`).
+- UAT already defines a closed calibration status and transition shape, but
+  intentionally lacks the corpus that would authorize the transition
+  (`plugins/epistemic-skills/skills/evidence-locked-uat/references/schemas.md`).
+- Existing release evidence contains useful trials but also missingness,
+  same-family correlation, and provider/repetition confounding. Calibration
+  must preserve those limitations rather than normalize them away.
+- Helix's core division is useful here: workflow executes work; epistemic
+  skills define what warrants belief. Calibration is a third concern—measuring
+  whether those epistemic interventions work in specified populations—not a
+  replacement strand inside Helix.
+
+### What good looks like
+
+- The 3.0.0 risk-acceptance JSON gives every accepted gap an owner, scope,
+  revisit trigger, and exit criterion rather than a blanket waiver.
+- Formal-rigor evaluation artifacts pin subjects, prompts, judges, attempts,
+  missingness, and no-retry boundaries, allowing later interpretation without
+  rewriting the historical result.
+- UAT's calibration vocabulary requires a corpus reference and date instead of
+  permitting an ungrounded `calibrated` boolean.
+
+### Questions you should be asking
+
+1. **Is epistemic-calibration already public and canonical at the named URL?**
+   Best guess: yes, but this environment could not verify it; adoption remains
+   blocked on a calibration-side immutable reference.
+2. **Which product owns shared schemas?** Best guess: the repository that
+   produces the artifact owns its schema; the consumer pins and validates a
+   version, avoiding a third shared-source package for now.
+3. **Should calibration results gate skill releases immediately?** Best guess:
+   no. Start in observational mode, preregister thresholds, then promote only
+   stable metrics with adequate controls to release gates.
+4. **What is the first joint slice?** Best guess: UAT seeded-defect calibration,
+   because epistemic-skills already exposes an explicit status transition and
+   missing-corpus blocker.
+5. **Does coordination change the maintenance lifecycle?** Best guess: no; it
+   establishes interfaces and evidence intake. Lifecycle changes require the
+   estate authority named in `README.md`.
+
+## Product boundary and compatibility contract
+
+### Ownership
+
+| Concern | epistemic-skills | epistemic-calibration |
+|---|---|---|
+| Runtime trigger/procedure semantics | **owns** | consumes immutable subject |
+| Runtime schemas and judges | **owns** | validates and reports exact versions |
+| Corpus cases, labels, sampling frames | supplies testable contract requirements | **owns** |
+| Trial execution and raw run evidence | supplies adapters where necessary | **owns** |
+| Behavioral estimates and uncertainty | receives; does not inflate | **owns** |
+| Product change decision | **owns** | recommends with evidence |
+| Calibration methodology change | consulted when product meaning is affected | **owns** |
+
+### Immutable exchange unit
+
+Every cross-repository result must validate against
+`plugins/epistemic-skills/contracts/epistemic-product-calibration.schema.json`
+and carry at least:
+
+```json
+{
+  "protocol": "epistemic-product-calibration@1",
+  "producer": {"repo": "ZMS-Labs/epistemic-calibration", "revision": "<full SHA>"},
+  "subject": {
+    "repo": "ZMS-Labs/epistemic-skills",
+    "revision": "<full SHA>",
+    "version": "<semver>",
+    "skill_or_surface": "<stable-slug>"
+  },
+  "contract_revision": "<tested contract>",
+  "corpus": {"ref": "<path>", "revision": "<full SHA>", "sha256": "<hash>"},
+  "runner": {"ref": "<path>", "revision": "<full SHA>", "sha256": "<hash>"},
+  "execution": {"models": ["<pin>"], "harnesses": ["<pin>"], "started_at": "<RFC3339>", "completed_at": "<RFC3339>"},
+  "sampling_frame": {"population": "<scope>", "planned": 1, "observed": 1, "excluded": 0, "missing": 0},
+  "preregistration": {"ref": "<path>", "revision": "<full SHA>", "sha256": "<hash>"},
+  "result": {"ref": "<path>", "revision": "<full SHA>", "sha256": "<hash>"},
+  "status": "observed",
+  "limitations": ["<validity limit>"],
+  "never_attests": ["behavioral-merit-by-envelope", "statistical-validity-by-envelope", "release-readiness-by-envelope"]
+}
+```
+
+The receiving repository records a pointer, interpretation, and disposition;
+it does not copy mutable “latest” results or claim more than the sampling frame
+supports. Corrections append or supersede—they do not rewrite historical
+evidence.
+
+### Change protocol
+
+1. **Propose:** open a paired issue or design record naming both repositories,
+   exact affected contracts, owner, and desired decision.
+2. **Freeze:** pin the skill subject, corpus, runner, preregistration, and
+   scoring contract before empirical execution.
+3. **Run:** calibration retains attempts, failures, missingness, environment,
+   and raw/derived evidence under immutable coordinates.
+4. **Receive:** epistemic-skills independently verifies hashes, schema, subject
+   identity, and claim scope before accepting any conclusion.
+5. **Decide:** classify the result as no change, docs/claim correction,
+   contract change, behavioral candidate, or release-gate candidate.
+6. **Land independently:** each repository merges its own change with reciprocal
+   immutable links. Neither merge depends on an unmerged branch in the other.
+7. **Recalibrate:** contract or behavior changes invalidate only the explicitly
+   affected measurements; the compatibility record states what remains usable.
+
+## Phased coordination plan
+
+### Phase 0 — establish the link (now)
+
+- Treat `ZMS-Labs/epistemic-calibration` as the named measurement counterpart.
+- Add a local `calibration` Git remote when the repository is reachable:
+  `git remote add calibration https://github.com/ZMS-Labs/epistemic-calibration.git`.
+- Obtain and record its default branch, HEAD SHA, lifecycle owner, current
+  schemas, corpora, runners, and claims. Until then, all calibration-side state
+  is **unknown**, not absent.
+- Ask that repository to adopt or counter-propose `epistemic-product-calibration@1`.
+- Give it the schema, valid fixture, negative fixtures, and stdlib verifier in
+  `plugins/epistemic-skills/contracts/`; its first producer record must pass the
+  same verifier in both repositories.
+
+**Exit:** reciprocal immutable references and named owners exist in both repos.
+
+### Phase 1 — inventory and map
+
+- Create a matrix of each skill/surface to available corpus, runner, judge,
+  harness, metric, and validity status.
+- Import no results yet; identify duplicates, gaps, incompatible vocabularies,
+  and hidden shared dependencies.
+- Reconcile the calibration repo's roadmap with the accepted 3.0.0 risks and
+  open audit findings.
+
+**Exit:** every claimed measurement has a subject revision and sampling frame;
+every high-priority product gap has an owner or explicit hold.
+
+### Phase 2 — one end-to-end pilot
+
+- Pilot evidence-locked UAT seeded defects against immutable 3.0.0 and current
+  development HEAD as separate subjects.
+- Preregister expected planted-defect catches, clean-control false holds,
+  thresholds, exclusions, and what would *not* authorize `calibrated`.
+- Return an exchange-unit record and independently verify it here.
+
+**Exit:** reproducible cross-repo result, including at least one positive and
+one negative control; no product claim exceeds the evidence.
+
+### Phase 3 — broaden observational calibration
+
+- Add trigger/skip proportionality, formal-rigor semantic validity, Gauntlet
+  lens/arbitrator behavior, continuity recovery, and outsource receipt
+  behavior.
+- Cross providers, harnesses, repetitions, and judges where claims require it;
+  report missingness and correlated seats.
+- Maintain longitudinal results by immutable product version.
+
+**Exit:** versioned dashboards/reports can distinguish structural conformance,
+semantic merit, availability failure, and population uncertainty.
+
+### Phase 4 — promote selected gates
+
+- Promote only preregistered, stable, independently reproducible measures.
+- Put the threshold, corpus class, validity window, exception authority, and
+  rollback rule in both repositories.
+- Keep exploratory metrics non-governing.
+
+**Exit:** accepted gates fail closed without turning proxy improvement into the
+product objective.
+
+## Formal decision record
+
+- **Question:** How should two separately versioned products coordinate while
+  preserving runtime-package independence and measurement validity?
+- **Tier:** standard; this is a persistent cross-repository interface with
+  multiple viable coupling models.
+- **Alternatives:** merge calibration into skills; Git submodule/runtime
+  dependency; informal links; immutable protocol with independent repos
+  (**selected**); status quo (no coordination).
+- **Hard constraints:** 3.0.0 remains immutable; no runtime dependency on
+  calibration; evidence remains revision-bound; claims retain population and
+  uncertainty; each repository controls its own releases.
+- **Authorized objective:** coordinate the products “as they ought to be” while
+  starting from the user's belief that skills is at 3.0. The priority rule is
+  constraint-satisfaction, then minimize coupling and maximize traceability.
+- **Derivation:** merging or submodules violate independence and versioning;
+  informal links/status quo do not give identity, compatibility, or correction
+  custody; an immutable exchange protocol satisfies the constraints and leaves
+  either repository free to evolve.
+- **Outcome:** `conditional` selection of the independent-repository protocol.
+  It becomes bilateral only when the calibration repository verifies its
+  coordinate and adopts or revises the contract.
+- **Concessions:** more coordination overhead and duplicated validation logic;
+  recovery is a small shared schema package only after two real consumers prove
+  duplication is costlier than another compatibility surface.
+- **Property reconciliation:** P1 fired (exchange invariants); P2 not applicable
+  (no shared mutable datastore); P3 not applicable (no concurrent shared writes);
+  P4 not applicable (no replication protocol); P5 fired (supersession and
+  recovery); P6 not applicable to this public-metadata design; P7 not
+  applicable; P8 unmapped (calibration populations and statistical methods are
+  unobserved); P9 fired (versioning, compatibility, lifecycle).
+
+## Rewritten request and next handoff
+
+> Verify the canonical `ZMS-Labs/epistemic-calibration` repository and freeze
+> its current revision. Compare its actual ownership, schemas, corpora, runners,
+> roadmap, and evidence claims with epistemic-skills 3.0.0's supported contract,
+> accepted risks, and open measurement gaps. Counter-propose or adopt
+> `epistemic-product-calibration@1`, land reciprocal immutable references, then
+> plan one preregistered UAT seeded-defect pilot. Do not merge repositories,
+> introduce a runtime/submodule dependency, change estate lifecycle, or promote
+> a metric to a release gate during the pilot.
+
+Next workflow stage: calibration-side reconnaissance, followed by bilateral
+design review of a frozen revision. If that review changes this interface
+materially, update this charter before implementation.

--- a/plugins/epistemic-skills/contracts/README.md
+++ b/plugins/epistemic-skills/contracts/README.md
@@ -1,4 +1,16 @@
-# Handoff receipts — `handoff-receipt@1`
+# Cross-skill and cross-product contracts
+
+This directory contains two deliberately narrow envelopes:
+
+- [`handoff-receipt@1`](handoff-receipt.schema.json) binds artifacts passed
+  between skills in one workflow.
+- [`epistemic-product-calibration@1`](epistemic-product-calibration.schema.json)
+  binds a calibration result to immutable producer, subject, corpus, runner,
+  preregistration, and result revisions across the two product repositories.
+
+Neither envelope attests that a behavioral judgment is correct.
+
+## Handoff receipts — `handoff-receipt@1`
 
 A **handoff receipt** is a small JSON document a skill emits alongside its
 output so a downstream skill can mechanically verify it received a well-formed
@@ -122,3 +134,29 @@ evaluates judgment content.
 A new predicate, trigger-class, or artifact kind is added only by
 **schema-version bump + verifier update in the same PR** — unknown values fail
 closed by design, so a misfit blocks loudly and is never silently absorbed.
+
+## Product calibration — `epistemic-product-calibration@1`
+
+The calibration envelope is the executable boundary between
+`ZMS-Labs/epistemic-calibration` (measurement producer) and
+`ZMS-Labs/epistemic-skills` (immutable intervention subject). It requires:
+
+- full repository revisions rather than branches or mutable `latest` refs;
+- content hashes for corpus, runner, preregistration, and result artifacts;
+- explicit model, harness, time-window, and sampling-frame identity;
+- exact accounting: `observed + excluded + missing = planned`;
+- a closed lifecycle status and explicit supersession pointer; and
+- non-attestations separating envelope validity from behavioral merit,
+  statistical validity, release readiness, and declared independence.
+
+Validate an inbound record before interpreting its result:
+
+```bash
+python verify_calibration.py RECORD.json
+python verify_calibration.py --self-test
+```
+
+Validation is necessary but insufficient. The consumer still resolves and
+hashes the referenced artifacts, evaluates their methodology, and limits every
+claim to the declared sampling frame. `accepted-gate` records remain subject to
+the receiving repository's release authority; that status is not an approval.

--- a/plugins/epistemic-skills/contracts/epistemic-product-calibration.schema.json
+++ b/plugins/epistemic-skills/contracts/epistemic-product-calibration.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/ZMS-Labs/epistemic-skills/main/plugins/epistemic-skills/contracts/epistemic-product-calibration.schema.json",
+  "title": "epistemic-product-calibration@1",
+  "description": "A revision-bound envelope for calibration results about an immutable epistemic-skills subject. Validity of the envelope does not attest behavioral merit, statistical validity, or release readiness.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "protocol", "producer", "subject", "contract_revision", "corpus",
+    "runner", "execution", "sampling_frame", "preregistration", "result",
+    "status", "limitations", "never_attests"
+  ],
+  "properties": {
+    "protocol": {"const": "epistemic-product-calibration@1"},
+    "synthetic": {"type": "boolean"},
+    "producer": {"$ref": "#/$defs/repositoryRevision"},
+    "subject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "revision", "version", "skill_or_surface"],
+      "properties": {
+        "repo": {"const": "ZMS-Labs/epistemic-skills"},
+        "revision": {"$ref": "#/$defs/gitRevision"},
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"},
+        "skill_or_surface": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"}
+      }
+    },
+    "contract_revision": {"type": "string", "minLength": 1},
+    "corpus": {"$ref": "#/$defs/contentRevision"},
+    "runner": {"$ref": "#/$defs/contentRevision"},
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["models", "harnesses", "started_at", "completed_at"],
+      "properties": {
+        "models": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "harnesses": {"type": "array", "minItems": 1, "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+        "started_at": {"type": "string", "format": "date-time"},
+        "completed_at": {"type": "string", "format": "date-time"}
+      }
+    },
+    "sampling_frame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["population", "planned", "observed", "excluded", "missing"],
+      "properties": {
+        "population": {"type": "string", "minLength": 1},
+        "planned": {"type": "integer", "minimum": 1},
+        "observed": {"type": "integer", "minimum": 0},
+        "excluded": {"type": "integer", "minimum": 0},
+        "missing": {"type": "integer", "minimum": 0}
+      }
+    },
+    "preregistration": {"$ref": "#/$defs/contentRevision"},
+    "result": {"$ref": "#/$defs/contentRevision"},
+    "status": {"enum": ["observed", "candidate-gate", "accepted-gate", "superseded"]},
+    "supersedes": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"},
+    "limitations": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+    "never_attests": {
+      "type": "array",
+      "minItems": 3,
+      "uniqueItems": true,
+      "items": {"enum": ["behavioral-merit-by-envelope", "statistical-validity-by-envelope", "release-readiness-by-envelope", "independence-by-declaration"]}
+    }
+  },
+  "$defs": {
+    "gitRevision": {"type": "string", "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"},
+    "repositoryRevision": {
+      "type": "object", "additionalProperties": false,
+      "required": ["repo", "revision"],
+      "properties": {
+        "repo": {"const": "ZMS-Labs/epistemic-calibration"},
+        "revision": {"$ref": "#/$defs/gitRevision"}
+      }
+    },
+    "contentRevision": {
+      "type": "object", "additionalProperties": false,
+      "required": ["ref", "revision", "sha256"],
+      "properties": {
+        "ref": {"type": "string", "minLength": 1},
+        "revision": {"$ref": "#/$defs/gitRevision"},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    }
+  }
+}

--- a/plugins/epistemic-skills/contracts/examples/calibration/invalid-floating-revision.json
+++ b/plugins/epistemic-skills/contracts/examples/calibration/invalid-floating-revision.json
@@ -1,0 +1,62 @@
+{
+  "protocol": "epistemic-product-calibration@1",
+  "synthetic": true,
+  "producer": {
+    "repo": "ZMS-Labs/epistemic-calibration",
+    "revision": "main"
+  },
+  "subject": {
+    "repo": "ZMS-Labs/epistemic-skills",
+    "revision": "3333333333333333333333333333333333333333",
+    "version": "3.0.0",
+    "skill_or_surface": "evidence-locked-uat"
+  },
+  "contract_revision": "uat-seeded-defect@1",
+  "corpus": {
+    "ref": "corpora/uat-seeded-defects",
+    "revision": "4444444444444444444444444444444444444444",
+    "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+  },
+  "runner": {
+    "ref": "runners/uat-calibration",
+    "revision": "6666666666666666666666666666666666666666",
+    "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+  },
+  "execution": {
+    "models": [
+      "synthetic-model@1"
+    ],
+    "harnesses": [
+      "synthetic-harness@1"
+    ],
+    "started_at": "2026-07-29T00:00:00Z",
+    "completed_at": "2026-07-29T00:05:00Z"
+  },
+  "sampling_frame": {
+    "population": "Synthetic planted-defect and clean-control cases.",
+    "planned": 4,
+    "observed": 3,
+    "excluded": 0,
+    "missing": 1
+  },
+  "preregistration": {
+    "ref": "plans/uat-pilot.json",
+    "revision": "8888888888888888888888888888888888888888",
+    "sha256": "9999999999999999999999999999999999999999999999999999999999999999"
+  },
+  "result": {
+    "ref": "results/uat-pilot.json",
+    "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "status": "observed",
+  "supersedes": null,
+  "limitations": [
+    "Synthetic fixture only; does not establish real-user or cross-provider behavior."
+  ],
+  "never_attests": [
+    "behavioral-merit-by-envelope",
+    "statistical-validity-by-envelope",
+    "release-readiness-by-envelope"
+  ]
+}

--- a/plugins/epistemic-skills/contracts/examples/calibration/invalid-missing-never-attests.json
+++ b/plugins/epistemic-skills/contracts/examples/calibration/invalid-missing-never-attests.json
@@ -1,0 +1,61 @@
+{
+  "protocol": "epistemic-product-calibration@1",
+  "synthetic": true,
+  "producer": {
+    "repo": "ZMS-Labs/epistemic-calibration",
+    "revision": "1111111111111111111111111111111111111111"
+  },
+  "subject": {
+    "repo": "ZMS-Labs/epistemic-skills",
+    "revision": "3333333333333333333333333333333333333333",
+    "version": "3.0.0",
+    "skill_or_surface": "evidence-locked-uat"
+  },
+  "contract_revision": "uat-seeded-defect@1",
+  "corpus": {
+    "ref": "corpora/uat-seeded-defects",
+    "revision": "4444444444444444444444444444444444444444",
+    "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+  },
+  "runner": {
+    "ref": "runners/uat-calibration",
+    "revision": "6666666666666666666666666666666666666666",
+    "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+  },
+  "execution": {
+    "models": [
+      "synthetic-model@1"
+    ],
+    "harnesses": [
+      "synthetic-harness@1"
+    ],
+    "started_at": "2026-07-29T00:00:00Z",
+    "completed_at": "2026-07-29T00:05:00Z"
+  },
+  "sampling_frame": {
+    "population": "Synthetic planted-defect and clean-control cases.",
+    "planned": 4,
+    "observed": 3,
+    "excluded": 0,
+    "missing": 1
+  },
+  "preregistration": {
+    "ref": "plans/uat-pilot.json",
+    "revision": "8888888888888888888888888888888888888888",
+    "sha256": "9999999999999999999999999999999999999999999999999999999999999999"
+  },
+  "result": {
+    "ref": "results/uat-pilot.json",
+    "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "status": "observed",
+  "supersedes": null,
+  "limitations": [
+    "Synthetic fixture only; does not establish real-user or cross-provider behavior."
+  ],
+  "never_attests": [
+    "behavioral-merit-by-envelope",
+    "release-readiness-by-envelope"
+  ]
+}

--- a/plugins/epistemic-skills/contracts/examples/calibration/invalid-population.json
+++ b/plugins/epistemic-skills/contracts/examples/calibration/invalid-population.json
@@ -1,0 +1,62 @@
+{
+  "protocol": "epistemic-product-calibration@1",
+  "synthetic": true,
+  "producer": {
+    "repo": "ZMS-Labs/epistemic-calibration",
+    "revision": "1111111111111111111111111111111111111111"
+  },
+  "subject": {
+    "repo": "ZMS-Labs/epistemic-skills",
+    "revision": "3333333333333333333333333333333333333333",
+    "version": "3.0.0",
+    "skill_or_surface": "evidence-locked-uat"
+  },
+  "contract_revision": "uat-seeded-defect@1",
+  "corpus": {
+    "ref": "corpora/uat-seeded-defects",
+    "revision": "4444444444444444444444444444444444444444",
+    "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+  },
+  "runner": {
+    "ref": "runners/uat-calibration",
+    "revision": "6666666666666666666666666666666666666666",
+    "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+  },
+  "execution": {
+    "models": [
+      "synthetic-model@1"
+    ],
+    "harnesses": [
+      "synthetic-harness@1"
+    ],
+    "started_at": "2026-07-29T00:00:00Z",
+    "completed_at": "2026-07-29T00:05:00Z"
+  },
+  "sampling_frame": {
+    "population": "Synthetic planted-defect and clean-control cases.",
+    "planned": 4,
+    "observed": 2,
+    "excluded": 0,
+    "missing": 1
+  },
+  "preregistration": {
+    "ref": "plans/uat-pilot.json",
+    "revision": "8888888888888888888888888888888888888888",
+    "sha256": "9999999999999999999999999999999999999999999999999999999999999999"
+  },
+  "result": {
+    "ref": "results/uat-pilot.json",
+    "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "status": "observed",
+  "supersedes": null,
+  "limitations": [
+    "Synthetic fixture only; does not establish real-user or cross-provider behavior."
+  ],
+  "never_attests": [
+    "behavioral-merit-by-envelope",
+    "statistical-validity-by-envelope",
+    "release-readiness-by-envelope"
+  ]
+}

--- a/plugins/epistemic-skills/contracts/examples/calibration/valid-observed.json
+++ b/plugins/epistemic-skills/contracts/examples/calibration/valid-observed.json
@@ -1,0 +1,62 @@
+{
+  "protocol": "epistemic-product-calibration@1",
+  "synthetic": true,
+  "producer": {
+    "repo": "ZMS-Labs/epistemic-calibration",
+    "revision": "1111111111111111111111111111111111111111"
+  },
+  "subject": {
+    "repo": "ZMS-Labs/epistemic-skills",
+    "revision": "3333333333333333333333333333333333333333",
+    "version": "3.0.0",
+    "skill_or_surface": "evidence-locked-uat"
+  },
+  "contract_revision": "uat-seeded-defect@1",
+  "corpus": {
+    "ref": "corpora/uat-seeded-defects",
+    "revision": "4444444444444444444444444444444444444444",
+    "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+  },
+  "runner": {
+    "ref": "runners/uat-calibration",
+    "revision": "6666666666666666666666666666666666666666",
+    "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+  },
+  "execution": {
+    "models": [
+      "synthetic-model@1"
+    ],
+    "harnesses": [
+      "synthetic-harness@1"
+    ],
+    "started_at": "2026-07-29T00:00:00Z",
+    "completed_at": "2026-07-29T00:05:00Z"
+  },
+  "sampling_frame": {
+    "population": "Synthetic planted-defect and clean-control cases.",
+    "planned": 4,
+    "observed": 3,
+    "excluded": 0,
+    "missing": 1
+  },
+  "preregistration": {
+    "ref": "plans/uat-pilot.json",
+    "revision": "8888888888888888888888888888888888888888",
+    "sha256": "9999999999999999999999999999999999999999999999999999999999999999"
+  },
+  "result": {
+    "ref": "results/uat-pilot.json",
+    "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "status": "observed",
+  "supersedes": null,
+  "limitations": [
+    "Synthetic fixture only; does not establish real-user or cross-provider behavior."
+  ],
+  "never_attests": [
+    "behavioral-merit-by-envelope",
+    "statistical-validity-by-envelope",
+    "release-readiness-by-envelope"
+  ]
+}

--- a/plugins/epistemic-skills/contracts/verify_calibration.py
+++ b/plugins/epistemic-skills/contracts/verify_calibration.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Validate the epistemic-product-calibration@1 envelope and invariants.
+
+This verifier is intentionally stdlib-only. It validates identity, closed
+vocabularies, revision/hash shapes, and population accounting. It does not
+certify the referenced evidence or its behavioral/statistical conclusions.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import json
+from pathlib import Path
+import re
+import sys
+
+
+PROTOCOL = "epistemic-product-calibration@1"
+GIT_REVISION = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+SLUG = re.compile(r"^[a-z0-9][a-z0-9-]{1,63}$")
+SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$")
+STATUSES = {"observed", "candidate-gate", "accepted-gate", "superseded"}
+REQUIRED_NEVER_ATTESTS = {
+    "behavioral-merit-by-envelope",
+    "statistical-validity-by-envelope",
+    "release-readiness-by-envelope",
+}
+ALLOWED_NEVER_ATTESTS = REQUIRED_NEVER_ATTESTS | {"independence-by-declaration"}
+TOP_LEVEL_FIELDS = {
+    "protocol", "synthetic", "producer", "subject", "contract_revision",
+    "corpus", "runner", "execution", "sampling_frame", "preregistration",
+    "result", "status", "supersedes", "limitations", "never_attests",
+}
+REQUIRED_FIELDS = TOP_LEVEL_FIELDS - {"synthetic", "supersedes"}
+
+
+class ValidationError(ValueError):
+    """A named fail-closed contract violation."""
+
+
+def fail(code: str, detail: str) -> None:
+    raise ValidationError(f"{code}: {detail}")
+
+
+def object_fields(value: object, path: str, required: set[str], allowed: set[str]) -> dict:
+    if not isinstance(value, dict):
+        fail("SCHEMA_VIOLATION", f"{path} must be an object")
+    missing = required - value.keys()
+    extra = value.keys() - allowed
+    if missing:
+        fail("SCHEMA_VIOLATION", f"{path} missing {sorted(missing)}")
+    if extra:
+        fail("SCHEMA_VIOLATION", f"{path} has unknown fields {sorted(extra)}")
+    return value
+
+
+def revision(value: object, path: str) -> None:
+    if not isinstance(value, str) or not GIT_REVISION.fullmatch(value):
+        fail("BAD_REVISION", f"{path} must be a full 40- or 64-hex revision")
+
+
+def content_revision(value: object, path: str) -> None:
+    row = object_fields(value, path, {"ref", "revision", "sha256"}, {"ref", "revision", "sha256"})
+    if not isinstance(row["ref"], str) or not row["ref"]:
+        fail("SCHEMA_VIOLATION", f"{path}.ref must be non-empty")
+    revision(row["revision"], f"{path}.revision")
+    if not isinstance(row["sha256"], str) or not SHA256.fullmatch(row["sha256"]):
+        fail("BAD_HASH", f"{path}.sha256 must be 64 lowercase hex characters")
+
+
+def date_time(value: object, path: str) -> datetime:
+    if not isinstance(value, str):
+        fail("SCHEMA_VIOLATION", f"{path} must be an RFC 3339 date-time")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        fail("SCHEMA_VIOLATION", f"{path} must be an RFC 3339 date-time")
+    if parsed.tzinfo is None:
+        fail("SCHEMA_VIOLATION", f"{path} must include a timezone")
+    return parsed
+
+
+def validate(value: object) -> None:
+    record = object_fields(value, "$", REQUIRED_FIELDS, TOP_LEVEL_FIELDS)
+    if record["protocol"] != PROTOCOL:
+        fail("UNKNOWN_PROTOCOL", f"expected {PROTOCOL}")
+    if "synthetic" in record and not isinstance(record["synthetic"], bool):
+        fail("SCHEMA_VIOLATION", "$.synthetic must be boolean")
+
+    producer = object_fields(record["producer"], "$.producer", {"repo", "revision"}, {"repo", "revision"})
+    if producer["repo"] != "ZMS-Labs/epistemic-calibration":
+        fail("WRONG_PRODUCER", "producer.repo must be ZMS-Labs/epistemic-calibration")
+    revision(producer["revision"], "$.producer.revision")
+
+    subject = object_fields(
+        record["subject"], "$.subject",
+        {"repo", "revision", "version", "skill_or_surface"},
+        {"repo", "revision", "version", "skill_or_surface"},
+    )
+    if subject["repo"] != "ZMS-Labs/epistemic-skills":
+        fail("WRONG_SUBJECT", "subject.repo must be ZMS-Labs/epistemic-skills")
+    revision(subject["revision"], "$.subject.revision")
+    if not isinstance(subject["version"], str) or not SEMVER.fullmatch(subject["version"]):
+        fail("SCHEMA_VIOLATION", "$.subject.version must be semver")
+    if not isinstance(subject["skill_or_surface"], str) or not SLUG.fullmatch(subject["skill_or_surface"]):
+        fail("SCHEMA_VIOLATION", "$.subject.skill_or_surface must be a slug")
+    if not isinstance(record["contract_revision"], str) or not record["contract_revision"]:
+        fail("SCHEMA_VIOLATION", "$.contract_revision must be non-empty")
+
+    for key in ("corpus", "runner", "preregistration", "result"):
+        content_revision(record[key], f"$.{key}")
+
+    execution = object_fields(
+        record["execution"], "$.execution",
+        {"models", "harnesses", "started_at", "completed_at"},
+        {"models", "harnesses", "started_at", "completed_at"},
+    )
+    for key in ("models", "harnesses"):
+        items = execution[key]
+        if not isinstance(items, list) or not items or len(items) != len(set(items)) or not all(isinstance(item, str) and item for item in items):
+            fail("SCHEMA_VIOLATION", f"$.execution.{key} must contain unique non-empty strings")
+    started = date_time(execution["started_at"], "$.execution.started_at")
+    completed = date_time(execution["completed_at"], "$.execution.completed_at")
+    if completed < started:
+        fail("INVALID_TIME_WINDOW", "completed_at precedes started_at")
+
+    frame = object_fields(
+        record["sampling_frame"], "$.sampling_frame",
+        {"population", "planned", "observed", "excluded", "missing"},
+        {"population", "planned", "observed", "excluded", "missing"},
+    )
+    if not isinstance(frame["population"], str) or not frame["population"]:
+        fail("SCHEMA_VIOLATION", "$.sampling_frame.population must be non-empty")
+    for key in ("planned", "observed", "excluded", "missing"):
+        minimum = 1 if key == "planned" else 0
+        if isinstance(frame[key], bool) or not isinstance(frame[key], int) or frame[key] < minimum:
+            fail("SCHEMA_VIOLATION", f"$.sampling_frame.{key} must be an integer >= {minimum}")
+    if frame["observed"] + frame["excluded"] + frame["missing"] != frame["planned"]:
+        fail("POPULATION_MISMATCH", "observed + excluded + missing must equal planned")
+
+    if record["status"] not in STATUSES:
+        fail("UNKNOWN_STATUS", f"status must be one of {sorted(STATUSES)}")
+    supersedes = record.get("supersedes")
+    if supersedes is not None and (not isinstance(supersedes, str) or not SHA256.fullmatch(supersedes)):
+        fail("BAD_HASH", "$.supersedes must be null or a sha256")
+    if record["status"] == "superseded" and supersedes is None:
+        fail("MISSING_SUPERSESSION", "superseded status requires supersedes")
+
+    limitations = record["limitations"]
+    if not isinstance(limitations, list) or not limitations or not all(isinstance(item, str) and item for item in limitations):
+        fail("MISSING_LIMITATIONS", "limitations must contain non-empty strings")
+    never = record["never_attests"]
+    if (
+        not isinstance(never, list)
+        or len(never) != len(set(never))
+        or not REQUIRED_NEVER_ATTESTS <= set(never)
+        or not set(never) <= ALLOWED_NEVER_ATTESTS
+    ):
+        fail("MISSING_NEVER_ATTESTS", f"never_attests must include {sorted(REQUIRED_NEVER_ATTESTS)}")
+
+
+def load(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail("INVALID_JSON", str(exc))
+
+
+def self_test() -> None:
+    root = Path(__file__).parent / "examples" / "calibration"
+    cases = {
+        "valid-observed.json": None,
+        "invalid-population.json": "POPULATION_MISMATCH",
+        "invalid-missing-never-attests.json": "MISSING_NEVER_ATTESTS",
+        "invalid-floating-revision.json": "BAD_REVISION",
+    }
+    for name, expected in cases.items():
+        try:
+            validate(load(root / name))
+        except ValidationError as exc:
+            actual = str(exc).split(":", 1)[0]
+            if expected != actual:
+                raise AssertionError(f"{name}: expected {expected}, got {actual}: {exc}") from exc
+        else:
+            if expected is not None:
+                raise AssertionError(f"{name}: expected {expected}, got pass")
+    print(f"calibration contract self-test: PASS ({len(cases)}/{len(cases)})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("record", nargs="?", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    try:
+        if args.self_test:
+            self_test()
+        elif args.record:
+            validate(load(args.record))
+            print(f"ok {args.record}: envelope valid")
+        else:
+            parser.error("provide RECORD or --self-test")
+    except ValidationError as exc:
+        print(f"error {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Establish a clear, revision-bound exchange protocol between `epistemic-skills` and an external measurement repository (`epistemic-calibration`) without introducing runtime/install coupling.
- Provide a machine-verifiable envelope that pins producer/subject/corpus/runner/preregistration/result revisions and enforces fail-closed invariants for cross-repo calibration records.
- Surface the coordination charter and runnable verification tooling so consumers can validate incoming calibration records before interpreting or accepting them.

### Description

- Add a coordination charter and a formal-rigor coordination record at `docs/coordination/epistemic-calibration.md` and `docs/coordination/epistemic-calibration.formal-rigor.json` describing the proposed product boundary and protocol.
- Introduce the `epistemic-product-calibration@1` JSON Schema at `plugins/epistemic-skills/contracts/epistemic-product-calibration.schema.json` and document it in `plugins/epistemic-skills/contracts/README.md` alongside the existing receipt contract.
- Implement a stdlib-only verifier `plugins/epistemic-skills/contracts/verify_calibration.py` that validates the envelope, invariants (including population accounting), and a small suite of example records, and add example records (one valid, several invalid) under `plugins/epistemic-skills/contracts/examples/calibration/`.
- Wire the verifier into CI by adding a step to `.github/workflows/epistemic-flexibility.yml` to run `verify_calibration.py --self-test`, and update `.github/scripts/check_json_artifacts.py` to include the `plugins/epistemic-skills/contracts` root when scanning JSON artifacts.

### Testing

- Ran `python plugins/epistemic-skills/contracts/verify_calibration.py --self-test`, which exercised the valid and invalid example cases and reported PASS. 
- The repository JSON artifact checker `python .github/scripts/check_json_artifacts.py` was updated to include contract artifacts and was exercised in CI as part of the workflow update (no failures reported). 
- Existing receipt verifier CI step (`verify_receipt.py --self-test`) remains present and unchanged; CI continues to run the suite that validates integration surfaces.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a697c0e5fa4833298cc76ea69afafa9)