### PR TITLE
Trigger-and-scope eval batteries for all five v3.3/v3.4 disciplines + #72 hygiene

### DIFF
--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -98,6 +98,16 @@ jobs:
             plugins/epistemic-skills/skills/decision-ledger/evals/proportionality/tests/run_tests.py \
             plugins/epistemic-skills/skills/open-questions/evals/trigger-and-scope/score.py \
             plugins/epistemic-skills/skills/open-questions/evals/trigger-and-scope/tests/run_tests.py \
+            plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/score.py \
+            plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/tests/run_tests.py \
+            plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/score.py \
+            plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/tests/run_tests.py \
+            plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/score.py \
+            plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/tests/run_tests.py \
+            plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/score.py \
+            plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/tests/run_tests.py \
+            plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/score.py \
+            plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/tests/run_tests.py \
             plugins/epistemic-skills/skills/decision-ledger/reference/validate_examples.py
       - name: Parse committed JSON in integration surfaces
         run: python .github/scripts/check_json_artifacts.py

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Evidence Research, Decision Ledger, Outsource, and Open Questions are cross-cutt
 
 ## Seventeen-skill catalog
 
-The package contains exactly one router, Helix, and fifteen disciplines. Each name appears once in this catalog; the linked guide and immutable source define the full contract.
+The package contains exactly one router, Helix, and fifteen disciplines. Each name appears once in this catalog; the immutable tagged source defines the full contract, and the linked guide is unversioned navigation over it (per the precedence rule above — where they differ, the tagged source controls).
 
 | Skill | Positive trigger | Purpose | Output |
 |---|---|---|---|

--- a/docs/release/PROVENANCE-3.4.0.md
+++ b/docs/release/PROVENANCE-3.4.0.md
@@ -1,0 +1,16 @@
+# Provenance coordinates — v3.4.0 external-source attributions
+
+Pinned coordinates for the v3.4.0 skills' provenance lines (gauntlet v3.4.0
+publication review, P3 register issue #72 item 2). The "re-derived, not
+copied" claim is checkable against these exact artifacts.
+
+| Source | Coordinate | Used for |
+|---|---|---|
+| ConnorGriffin/skills (MIT, NOTICE retained upstream) | https://github.com/ConnorGriffin/skills @ `04c2630297d3a9b64905c6fe43d5086a3e2ce48d` (main HEAD at evaluation, 2026-07-31) | `wayfinding` (wayfinder pattern), `throwaway-prototyping` (prototype pattern), open-questions frontier clause (grilling), gauntlet revision-loop clause (plan-review) |
+| Matt Pocock agentic-coding framework — community synthesis document (secondary source; self-described as derived from tutorials + community workflow analysis) | operator-held file, sha256 `987e11ccf83ea4f23ccde0f89a8a5c5ebb1a0f21c49b0a19b1160060ba94798a` (not committed here — third-party text of unverified licensing) | `intent-traced-merge` (intent-tracing method; abort posture corrected here), `throwaway-prototyping` disposal contract reinforcement, agent-interface-design vocabulary clause |
+| Thariq Shihipar (Anthropic), "The new rules of context engineering for Claude 5 generation models", 2026-07-24 | announcement: https://x.com/trq212/status/2080710971228918066 (essay linked from it) | v3.3.0's `context-audit`, `agent-interface-design` (coordinates recorded here for completeness) |
+
+Method note: all three sources were evaluated skill-by-skill/claim-by-claim in
+the 2026-07-31 session; every adopted idea was re-derived and re-worded, with
+falsifiable gates added; declined items were declined with recorded reasons.
+No source text was copied into this repository.

--- a/docs/release/RELEASE-3.4.0.md
+++ b/docs/release/RELEASE-3.4.0.md
@@ -66,6 +66,16 @@ Update the install coordinate to `v3.4.0` and reload the harness. No existing
 trigger, contract, schema, or output shape changed; amendments are additive
 clauses inside existing sections.
 
+## Erratum (2026-07-31, post-tag)
+
+The migration section's "No existing trigger, contract, schema, or output
+shape changed" overstates: the evidence-locked-uat oracle-honesty rows
+TIGHTEN the acceptance gate — a non-empty console/error set relevant to the
+exercised surface is now an explicit hard FAIL where the prior text left it
+unstated. Consumers whose UAT runs previously passed with unread error
+channels may now fail; that is the intended behavior change. Provenance
+coordinates for this release's external attributions: PROVENANCE-3.4.0.md.
+
 ## Harness verification tiers
 
 Unchanged from 3.3.0: Claude Code primary (deterministic suite on the release

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/README.md
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/README.md
@@ -1,0 +1,24 @@
+# agent-interface-design trigger-and-scope fixtures
+
+This battery tests the trigger discipline and the scope contract: the skill
+engages when an interface another agent will consume is authored or modified
+(a tool or function-call schema, an MCP server surface, a structured-output
+contract, a subagent dispatch contract, an agent-caller CLI, or a review that
+adds one) and stays silent on human-facing interfaces, throwaway single-caller
+scripts, prose handoffs (routed to write-goal/outsource), and inbound
+instruction audits (routed to context-audit). Two hard negatives — a
+human-caller CLI and a prose subagent brief — discriminate trigger shape from
+trigger substance. Two state fixtures exercise the cold-consumer gate (a gate
+failure demands a structural fix or a *recorded* compatibility concession,
+with the transcript kept) and the example-lint (every usage example is
+justified by a named weaker-consumer audience or converted into a structural
+fix and deleted). Over-firing and under-firing are defects, not extra rigor.
+
+This is a structural, trigger-level battery: it scores structured response
+sets against a deterministic scorer. It is NOT behavioral proof that a live
+agent triggers correctly or designs good interfaces.
+
+Run `python tests/run_tests.py`.
+
+No live behavioral epoch has been run against this battery; see
+`results/BLOCKED.md`.

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/examples/balanced.json
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/examples/balanced.json
@@ -1,0 +1,98 @@
+[
+ {
+  "id": "tool-schema-new-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "mcp-surface-new-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "structured-output-contract-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "subagent-dispatch-contract-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "agent-caller-cli-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 1,
+  "example_justifications": [
+   "small local model integration retained one labeled example for the batch path"
+  ]
+ },
+ {
+  "id": "review-adds-tool-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "human-ui-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "human-docs-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "throwaway-script-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "prose-dispatch-brief-no-fire",
+  "action": "no-fire",
+  "routed_to": "write-goal/outsource"
+ },
+ {
+  "id": "inbound-context-audit-no-fire",
+  "action": "no-fire",
+  "routed_to": "context-audit"
+ },
+ {
+  "id": "human-caller-cli-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "cold-consumer-gate-fail",
+  "action": "consumer-gate",
+  "remedy": "structural-fix",
+  "fixed_parameter": "mode",
+  "transcript_kept": true
+ },
+ {
+  "id": "example-lint-three-examples",
+  "action": "example-lint",
+  "dispositions": {
+   "ex-batch-call": {
+    "outcome": "justified",
+    "audience": "legacy 7B on-device consumer that cannot infer the batch envelope"
+   },
+   "ex-retry-flow": {
+    "outcome": "deleted",
+    "structural_fix": "retry policy moved into a typed retry_budget field with a default"
+   },
+   "ex-dry-run": {
+    "outcome": "deleted",
+    "structural_fix": "dry_run promoted to a required boolean defaulting to false"
+   }
+  }
+ }
+]

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/examples/overfiring.json
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/examples/overfiring.json
@@ -1,0 +1,111 @@
+[
+ {
+  "id": "tool-schema-new-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "mcp-surface-new-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "structured-output-contract-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "subagent-dispatch-contract-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "agent-caller-cli-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "review-adds-tool-engage",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "human-ui-no-fire",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "human-docs-no-fire",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "throwaway-script-no-fire",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "prose-dispatch-brief-no-fire",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "inbound-context-audit-no-fire",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "human-caller-cli-no-fire",
+  "action": "engage",
+  "encodes_in_structure": true,
+  "consumer_test": true,
+  "examples_added": 0
+ },
+ {
+  "id": "cold-consumer-gate-fail",
+  "action": "consumer-gate",
+  "remedy": "structural-fix",
+  "fixed_parameter": "mode",
+  "transcript_kept": true
+ },
+ {
+  "id": "example-lint-three-examples",
+  "action": "example-lint",
+  "dispositions": {
+   "ex-batch-call": {
+    "outcome": "justified",
+    "audience": "legacy 7B on-device consumer that cannot infer the batch envelope"
+   },
+   "ex-retry-flow": {
+    "outcome": "deleted",
+    "structural_fix": "retry policy moved into a typed retry_budget field with a default"
+   },
+   "ex-dry-run": {
+    "outcome": "deleted",
+    "structural_fix": "dry_run promoted to a required boolean defaulting to false"
+   }
+  }
+ }
+]

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/examples/underfiring.json
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/examples/underfiring.json
@@ -1,0 +1,73 @@
+[
+ {
+  "id": "tool-schema-new-engage",
+  "action": "no-fire"
+ },
+ {
+  "id": "mcp-surface-new-engage",
+  "action": "no-fire"
+ },
+ {
+  "id": "structured-output-contract-engage",
+  "action": "no-fire"
+ },
+ {
+  "id": "subagent-dispatch-contract-engage",
+  "action": "no-fire"
+ },
+ {
+  "id": "agent-caller-cli-engage",
+  "action": "no-fire"
+ },
+ {
+  "id": "review-adds-tool-engage",
+  "action": "no-fire"
+ },
+ {
+  "id": "human-ui-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "human-docs-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "throwaway-script-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "prose-dispatch-brief-no-fire",
+  "action": "no-fire",
+  "routed_to": "write-goal/outsource"
+ },
+ {
+  "id": "inbound-context-audit-no-fire",
+  "action": "no-fire",
+  "routed_to": "context-audit"
+ },
+ {
+  "id": "human-caller-cli-no-fire",
+  "action": "no-fire"
+ },
+ {
+  "id": "cold-consumer-gate-fail",
+  "action": "consumer-gate",
+  "remedy": "compatibility-concession",
+  "recorded": false,
+  "transcript_kept": false
+ },
+ {
+  "id": "example-lint-three-examples",
+  "action": "example-lint",
+  "dispositions": {
+   "ex-batch-call": {
+    "outcome": "justified",
+    "audience": ""
+   },
+   "ex-retry-flow": {
+    "outcome": "deleted",
+    "structural_fix": ""
+   }
+  }
+ }
+]

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/fixtures.json
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/fixtures.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "tool-schema-new-engage",
+    "scenario": "Authoring a new function-call tool schema (name, parameters, error shape) that a coding agent will invoke to manage deployments.",
+    "trigger": "positive",
+    "expected_action": "engage"
+  },
+  {
+    "id": "mcp-surface-new-engage",
+    "scenario": "Designing the surface of a new MCP server: which operations to expose, their parameter types, and their structured error responses.",
+    "trigger": "positive",
+    "expected_action": "engage"
+  },
+  {
+    "id": "structured-output-contract-engage",
+    "scenario": "Defining the structured-output JSON contract a summarization agent must emit for a downstream pipeline to parse.",
+    "trigger": "positive",
+    "expected_action": "engage"
+  },
+  {
+    "id": "subagent-dispatch-contract-engage",
+    "scenario": "Writing the typed dispatch payload (task type enum, scope fields, result schema) that a controller sends to worker subagents.",
+    "trigger": "positive",
+    "expected_action": "engage"
+  },
+  {
+    "id": "agent-caller-cli-engage",
+    "scenario": "Building a CLI whose only intended caller is an automation agent that parses its machine-readable output and exit codes.",
+    "trigger": "positive",
+    "expected_action": "engage"
+  },
+  {
+    "id": "review-adds-tool-engage",
+    "scenario": "Reviewing a pull request that adds a new tool definition to an agent's toolbox: new parameters, a status enum, and a usage example block.",
+    "trigger": "positive",
+    "expected_action": "engage"
+  },
+  {
+    "id": "human-ui-no-fire",
+    "scenario": "Designing a settings page and onboarding flow for a web dashboard used by people.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "human-docs-no-fire",
+    "scenario": "Writing a getting-started guide and README aimed at human developers evaluating the project.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "throwaway-script-no-fire",
+    "scenario": "A one-off data-munging script with a single known caller, run once and deleted; its argument handling is ad hoc by design.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "prose-dispatch-brief-no-fire",
+    "scenario": "Drafting the prose brief for a research subagent: goals, constraints, and success criteria written as natural-language instructions, no machine contract involved.",
+    "trigger": "none",
+    "expected_action": "no-fire",
+    "expected_route": "write-goal/outsource"
+  },
+  {
+    "id": "inbound-context-audit-no-fire",
+    "scenario": "Auditing and pruning the system prompt and injected instruction context an agent receives, hunting duplicates and stale directives.",
+    "trigger": "none",
+    "expected_action": "no-fire",
+    "expected_route": "context-audit"
+  },
+  {
+    "id": "human-caller-cli-no-fire",
+    "scenario": "Polishing the flags, colors, and help text of a CLI whose callers are human developers at an interactive terminal; no agent consumes it.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "cold-consumer-gate-fail",
+    "scenario": "The cold-consumer test on a shipped tool schema fails: given only the schema and one-line descriptions, the consumer misfills the 'mode' parameter on its first call.",
+    "trigger": "gate",
+    "expected_action": "consumer-gate",
+    "gate_outcome": "fail",
+    "failing_parameter": "mode"
+  },
+  {
+    "id": "example-lint-three-examples",
+    "scenario": "A tool description carries three usage examples; the example-lint requires each to name the weaker-consumer audience it serves or be converted into a structural fix and deleted.",
+    "trigger": "lint",
+    "expected_action": "example-lint",
+    "examples": [
+      "ex-batch-call",
+      "ex-retry-flow",
+      "ex-dry-run"
+    ]
+  }
+]

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/results/BLOCKED.md
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/results/BLOCKED.md
@@ -1,0 +1,11 @@
+# Behavioral epoch: BLOCKED
+
+No live model epoch has been run against these fixtures. The committed
+artifacts are the deterministic scorer, the fixture inventory, and the
+polarity controls (one balanced example plus two parodies: overfiring,
+underfiring) exercised by `tests/run_tests.py` (authored 2026-07-31).
+
+A behavioral epoch requires dispatching a live agent per fixture scenario and
+scoring its structured responses; record the epoch here (date, harness,
+model, per-fixture outcomes) when one runs. Committing BLOCKED rather than
+claiming a pass is the house norm.

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/score.py
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/score.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Deterministic scorer for agent-interface-design trigger discipline and scope."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+ACTIONS = {"engage", "no-fire", "consumer-gate", "example-lint"}
+GATE_REMEDIES = {"structural-fix", "compatibility-concession"}
+EXAMPLE_OUTCOMES = {"justified", "deleted"}
+
+
+def _nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def score(fixtures: list[dict], responses: list[dict]) -> dict:
+    failures: list[str] = []
+    by_id = {row.get("id"): row for row in responses if isinstance(row, dict)}
+    if len(by_id) != len(responses):
+        failures.append("response ids missing or duplicated")
+    actions: Counter = Counter()
+    for fixture in fixtures:
+        fid = fixture["id"]
+        row = by_id.get(fid)
+        if row is None:
+            failures.append(f"{fid}: response missing")
+            continue
+        action = row.get("action")
+        actions[action] += 1
+        expected = fixture["expected_action"]
+        if action not in ACTIONS:
+            failures.append(f"{fid}: unknown action {action!r}")
+            continue
+        if action != expected:
+            failures.append(f"{fid}: expected {expected}, got {action}")
+            continue
+        if expected == "no-fire":
+            if row.get("schema_edits") or row.get("consumer_test") or row.get("visible_process"):
+                failures.append(f"{fid}: no-fire must be silent — no schema work, no consumer test, no process artifact")
+            route = fixture.get("expected_route")
+            if route and row.get("routed_to") != route:
+                failures.append(f"{fid}: excluded crossing must route to {route}, got {row.get('routed_to')!r}")
+        elif expected == "engage":
+            if not row.get("encodes_in_structure"):
+                failures.append(f"{fid}: engage must encode constraints in structure (types, enums, named fields), not prose")
+            if not row.get("consumer_test"):
+                failures.append(f"{fid}: engage must run the cold-consumer test before shipping")
+            examples_added = row.get("examples_added", 0)
+            justifications = row.get("example_justifications", [])
+            if examples_added and len(justifications) != examples_added:
+                failures.append(f"{fid}: every added example needs a written weaker-consumer justification")
+        elif expected == "consumer-gate":
+            remedy = row.get("remedy")
+            if remedy not in GATE_REMEDIES:
+                failures.append(f"{fid}: gate failure remedy must be structural-fix or a recorded compatibility-concession, got {remedy!r}")
+            elif remedy == "compatibility-concession" and not row.get("recorded"):
+                failures.append(f"{fid}: prose or examples added to pass the gate must be recorded as a compatibility concession")
+            if remedy == "structural-fix" and not _nonempty(row.get("fixed_parameter")):
+                failures.append(f"{fid}: structural fix must name the parameter it tightens")
+            elif remedy == "structural-fix" and row.get("fixed_parameter") != fixture.get("failing_parameter"):
+                failures.append(f"{fid}: structural fix targets {fixture.get('failing_parameter')!r}, got {row.get('fixed_parameter')!r}")
+            if not row.get("transcript_kept"):
+                failures.append(f"{fid}: the consumer-test transcript is the gate evidence and must be kept")
+        elif expected == "example-lint":
+            dispositions = row.get("dispositions", {})
+            if not isinstance(dispositions, dict):
+                failures.append(f"{fid}: dispositions must map each example to an outcome")
+                continue
+            for example in fixture.get("examples", []):
+                entry = dispositions.get(example)
+                if not isinstance(entry, dict):
+                    failures.append(f"{fid}: example {example!r} has no lint disposition")
+                    continue
+                outcome = entry.get("outcome")
+                if outcome not in EXAMPLE_OUTCOMES:
+                    failures.append(f"{fid}: example {example!r} outcome must be justified or deleted, got {outcome!r}")
+                elif outcome == "justified" and not _nonempty(entry.get("audience")):
+                    failures.append(f"{fid}: justified example {example!r} must name the weaker-consumer audience it serves")
+                elif outcome == "deleted" and not _nonempty(entry.get("structural_fix")):
+                    failures.append(f"{fid}: deleted example {example!r} must name the structural fix that replaces it")
+            extras = set(dispositions) - set(fixture.get("examples", []))
+            if extras:
+                failures.append(f"{fid}: dispositions for unknown examples {sorted(extras)}")
+    return {"pass": not failures, "failures": failures, "actions": dict(actions)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("responses", type=Path)
+    parser.add_argument("--fixtures", type=Path, default=Path(__file__).resolve().parent / "fixtures.json")
+    args = parser.parse_args()
+    fixtures = json.loads(args.fixtures.read_text(encoding="utf-8"))
+    responses = json.loads(args.responses.read_text(encoding="utf-8"))
+    report = score(fixtures, responses)
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/tests/run_tests.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Polarity tests for agent-interface-design trigger discipline and scope."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(condition: bool, message: object) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    score_path = ROOT / "score.py"
+    require(score_path.is_file(), f"missing agent-interface-design trigger-and-scope scorer: {score_path}")
+    spec = importlib.util.spec_from_file_location("agent_interface_design_scope", score_path)
+    scorer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scorer)
+    fixtures = json.loads((ROOT / "fixtures.json").read_text(encoding="utf-8"))
+    require([f["id"] for f in fixtures] == [
+        "tool-schema-new-engage", "mcp-surface-new-engage", "structured-output-contract-engage",
+        "subagent-dispatch-contract-engage", "agent-caller-cli-engage", "review-adds-tool-engage",
+        "human-ui-no-fire", "human-docs-no-fire", "throwaway-script-no-fire",
+        "prose-dispatch-brief-no-fire", "inbound-context-audit-no-fire", "human-caller-cli-no-fire",
+        "cold-consumer-gate-fail", "example-lint-three-examples",
+    ], "agent-interface-design fixture inventory drifted")
+
+    balanced = scorer.score(fixtures, json.loads((ROOT / "examples" / "balanced.json").read_text(encoding="utf-8")))
+    require(balanced["pass"], balanced["failures"])
+    require(balanced["actions"] == {"engage": 6, "no-fire": 6, "consumer-gate": 1, "example-lint": 1}, balanced["actions"])
+
+    for name in ("overfiring", "underfiring"):
+        report = scorer.score(fixtures, json.loads((ROOT / "examples" / f"{name}.json").read_text(encoding="utf-8")))
+        require(not report["pass"], f"{name} parody unexpectedly passed")
+
+    over = scorer.score(fixtures, json.loads((ROOT / "examples" / "overfiring.json").read_text(encoding="utf-8")))
+    require(sum("expected no-fire, got engage" in failure for failure in over["failures"]) == 6, over["failures"])
+
+    under = scorer.score(fixtures, json.loads((ROOT / "examples" / "underfiring.json").read_text(encoding="utf-8")))
+    require(sum("expected engage, got no-fire" in failure for failure in under["failures"]) == 6, under["failures"])
+    require(any("recorded as a compatibility concession" in failure for failure in under["failures"]), under["failures"])
+    require(any("transcript" in failure for failure in under["failures"]), under["failures"])
+    require(any("no lint disposition" in failure for failure in under["failures"]), under["failures"])
+    require(any("weaker-consumer audience" in failure for failure in under["failures"]), under["failures"])
+    require(any("structural fix that replaces it" in failure for failure in under["failures"]), under["failures"])
+
+    print("agent-interface-design trigger-and-scope: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/README.md
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/README.md
@@ -1,0 +1,23 @@
+# context-audit trigger-and-scope fixtures
+
+This battery tests the trigger discipline and the audit scope contract:
+explicit invocation ("audit my context/CLAUDE.md/system prompt", "prune my
+instructions"), a detected cross-layer instruction conflict, or a
+model-generation upgrade each fire the full audit; single-document prose
+editing, new-interface design, task-brief recon, and one-task prompt tuning
+never fire — even when they are conflict-shaped or name a system prompt. A
+firing audit inventories every loaded layer, runs the cross-layer merge, and
+reports before applying; an estate without version control stops at the
+report; a gotcha with an incident record is kept only after reading its
+origin; a duplicate's most local copy survives; governance-projection
+conflicts route upstream, never edited in place. Over-firing and under-firing
+are defects, not extra rigor.
+
+The battery is structural and trigger-level only: it scores declared
+fire/no-fire decisions and audit-shape fields against fixtures, not whether a
+live agent's actual audit was any good. Passing it is NOT behavioral proof.
+
+Run `python tests/run_tests.py`.
+
+No live behavioral epoch has been run against this battery; see
+`results/BLOCKED.md`.

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/examples/balanced.json
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/examples/balanced.json
@@ -1,0 +1,98 @@
+[
+ {
+  "id": "explicit-claudemd-audit",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "version_control": true,
+  "applied": true,
+  "apply_order": [
+   "CONFLICT",
+   "DUPLICATE",
+   "OVER-VERIFY",
+   "OBVIOUS",
+   "MODEL-HANDLES-THIS-NOW"
+  ]
+ },
+ {
+  "id": "explicit-prune-instructions",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "midtask-layer-conflict",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "model-upgrade-stale-guardrails",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "single-doc-prose",
+  "action": "no-fire"
+ },
+ {
+  "id": "new-agent-interface",
+  "action": "no-fire"
+ },
+ {
+  "id": "task-brief-recon",
+  "action": "no-fire"
+ },
+ {
+  "id": "single-task-prompt-tuning",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-intradoc-contradictions",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-system-prompt-tuning",
+  "action": "no-fire"
+ },
+ {
+  "id": "keep-gotcha-with-origin",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "classification": "KEEP:GOTCHA",
+  "origin_read": true
+ },
+ {
+  "id": "duplicate-most-local-survives",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "classification": "DUPLICATE",
+  "survivor": "tool-description"
+ },
+ {
+  "id": "no-version-control-report-only",
+  "action": "report-only-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "applied": false
+ },
+ {
+  "id": "governance-projection-conflict",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "routed_upstream": true,
+  "projection_edited": false
+ }
+]

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/examples/overfiring.json
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/examples/overfiring.json
@@ -1,0 +1,116 @@
+[
+ {
+  "id": "explicit-claudemd-audit",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "version_control": true,
+  "applied": true,
+  "apply_order": [
+   "CONFLICT",
+   "DUPLICATE",
+   "OVER-VERIFY",
+   "OBVIOUS",
+   "MODEL-HANDLES-THIS-NOW"
+  ]
+ },
+ {
+  "id": "explicit-prune-instructions",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "midtask-layer-conflict",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "model-upgrade-stale-guardrails",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "single-doc-prose",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "new-agent-interface",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "task-brief-recon",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "single-task-prompt-tuning",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "hard-neg-intradoc-contradictions",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "hard-neg-system-prompt-tuning",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true
+ },
+ {
+  "id": "keep-gotcha-with-origin",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "classification": "KEEP:GOTCHA",
+  "origin_read": true
+ },
+ {
+  "id": "duplicate-most-local-survives",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "classification": "DUPLICATE",
+  "survivor": "tool-description"
+ },
+ {
+  "id": "no-version-control-report-only",
+  "action": "report-only-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "applied": false
+ },
+ {
+  "id": "governance-projection-conflict",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "routed_upstream": true,
+  "projection_edited": false
+ }
+]

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/examples/underfiring.json
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/examples/underfiring.json
@@ -1,0 +1,68 @@
+[
+ {
+  "id": "explicit-claudemd-audit",
+  "action": "no-fire"
+ },
+ {
+  "id": "explicit-prune-instructions",
+  "action": "no-fire"
+ },
+ {
+  "id": "midtask-layer-conflict",
+  "action": "no-fire"
+ },
+ {
+  "id": "model-upgrade-stale-guardrails",
+  "action": "no-fire"
+ },
+ {
+  "id": "single-doc-prose",
+  "action": "no-fire"
+ },
+ {
+  "id": "new-agent-interface",
+  "action": "no-fire"
+ },
+ {
+  "id": "task-brief-recon",
+  "action": "no-fire"
+ },
+ {
+  "id": "single-task-prompt-tuning",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-intradoc-contradictions",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-system-prompt-tuning",
+  "action": "no-fire"
+ },
+ {
+  "id": "keep-gotcha-with-origin",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "classification": "MODEL-HANDLES-THIS-NOW",
+  "origin_read": false
+ },
+ {
+  "id": "duplicate-most-local-survives",
+  "action": "full-audit",
+  "layers_inventoried": true,
+  "cross_layer_merge": true,
+  "report_emitted": true,
+  "classification": "DUPLICATE",
+  "survivor": "system-prompt"
+ },
+ {
+  "id": "no-version-control-report-only",
+  "action": "no-fire"
+ },
+ {
+  "id": "governance-projection-conflict",
+  "action": "no-fire"
+ }
+]

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/fixtures.json
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/fixtures.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "explicit-claudemd-audit",
+    "scenario": "Operator says: audit my CLAUDE.md and system prompt — cut what a strong model no longer needs. The estate is under version control.",
+    "trigger": "explicit",
+    "expected_action": "full-audit",
+    "applies": true
+  },
+  {
+    "id": "explicit-prune-instructions",
+    "scenario": "Operator says: prune my instructions, they have accreted for two years.",
+    "trigger": "explicit",
+    "expected_action": "full-audit"
+  },
+  {
+    "id": "midtask-layer-conflict",
+    "scenario": "Mid-task, the project instruction file directs always-squash-merge while a loaded command definition directs never-squash — two active layers direct incompatible behavior.",
+    "trigger": "auto",
+    "expected_action": "full-audit"
+  },
+  {
+    "id": "model-upgrade-stale-guardrails",
+    "scenario": "The harness just moved to a new model generation; the instruction estate is dense with guardrails written for the prior, weaker generation.",
+    "trigger": "auto",
+    "expected_action": "full-audit"
+  },
+  {
+    "id": "single-doc-prose",
+    "scenario": "Operator asks: tighten the prose of this README — it rambles. No instruction layers involved.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "new-agent-interface",
+    "scenario": "Operator asks for a well-shaped tool description for a NEW MCP server this agent is authoring for other agents to consume.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "task-brief-recon",
+    "scenario": "A fuzzy task brief just arrived; the agent wants to survey the territory's unknowns before planning.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "single-task-prompt-tuning",
+    "scenario": "Operator asks: make the extraction prompt produce better JSON for this one pipeline task.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "hard-neg-intradoc-contradictions",
+    "scenario": "Operator says: this design doc contradicts itself in sections 2 and 5 — fix the contradictions. The doc is not an instruction layer any harness loads; it is one document being edited.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "hard-neg-system-prompt-tuning",
+    "scenario": "Operator says: rewrite the summarizer agent's system prompt so its weekly-digest summaries come out punchier. One task's output is the target, not the assembled context's hygiene.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "keep-gotcha-with-origin",
+    "scenario": "During an explicit audit, a line reads like a stale guardrail, but it cites an incident record documenting the failure it guards. Classification requires reading that record, not remembering it.",
+    "trigger": "explicit",
+    "expected_action": "full-audit",
+    "instruction_under_test": {
+      "text": "Never run the importer twice in one session (see incident record INC-0042)",
+      "has_incident_record": true
+    },
+    "expected_class": "KEEP:GOTCHA"
+  },
+  {
+    "id": "duplicate-most-local-survives",
+    "scenario": "During an explicit audit, the same directive appears verbatim in the always-loaded system prompt and in a load-on-demand tool description. Exactly one authoritative copy survives.",
+    "trigger": "explicit",
+    "expected_action": "full-audit",
+    "duplicate_locations": [
+      "system-prompt",
+      "tool-description"
+    ],
+    "expected_class": "DUPLICATE",
+    "expected_survivor": "tool-description"
+  },
+  {
+    "id": "no-version-control-report-only",
+    "scenario": "Operator asks for a context audit, but the instruction estate lives outside any version control — there is no rollback path for cuts.",
+    "trigger": "explicit",
+    "expected_action": "report-only-audit"
+  },
+  {
+    "id": "governance-projection-conflict",
+    "scenario": "An explicit audit finds a conflict inside a generated governance projection (compiled safety policy). The projection is report-only: the finding routes upstream to its source of truth.",
+    "trigger": "explicit",
+    "expected_action": "full-audit",
+    "governance_conflict": true
+  }
+]

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/results/BLOCKED.md
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/results/BLOCKED.md
@@ -1,0 +1,11 @@
+# Behavioral epoch: BLOCKED
+
+No live model epoch has been run against these fixtures (as of 2026-07-31).
+The committed artifacts are the deterministic scorer, the fixture inventory,
+and the polarity controls (one balanced example plus two parodies: overfiring,
+underfiring) exercised by `tests/run_tests.py`.
+
+A behavioral epoch requires dispatching a live agent per fixture scenario and
+scoring its structured responses; record the epoch here (date, harness,
+model, per-fixture outcomes) when one runs. Committing BLOCKED rather than
+claiming a pass is the house norm.

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/score.py
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/score.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Deterministic scorer for context-audit trigger discipline and audit scope."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+ACTIONS = {"full-audit", "report-only-audit", "no-fire"}
+CUT_CLASSES = {"CONFLICT", "DUPLICATE", "OBVIOUS", "MODEL-HANDLES-THIS-NOW", "OVER-VERIFY"}
+KEEP_CLASSES = {
+    "KEEP:GOTCHA",
+    "KEEP:OPERATOR-PREFERENCE",
+    "KEEP:ROUTING+THRESHOLD",
+    "KEEP:NAMED-INTEGRATION",
+    "KEEP:GOVERNANCE",
+}
+APPLY_ORDER = ["CONFLICT", "DUPLICATE", "OVER-VERIFY", "OBVIOUS", "MODEL-HANDLES-THIS-NOW"]
+AUDIT_ARTIFACT_FIELDS = ("layers_inventoried", "cross_layer_merge", "report_emitted", "cut_list", "applied")
+
+
+def _audit_common(fid: str, row: dict, failures: list[str]) -> None:
+    """Checks shared by every audit that actually runs (full or report-only)."""
+    if not row.get("layers_inventoried"):
+        failures.append(f"{fid}: the unit of audit is the assembled set — inventory every loaded layer")
+    if not row.get("cross_layer_merge"):
+        failures.append(f"{fid}: a per-file audit that skips the cross-layer merge is ordinary editing wearing this skill's name")
+    if not row.get("report_emitted"):
+        failures.append(f"{fid}: report before apply — the durable report is the artifact")
+
+
+def score(fixtures: list[dict], responses: list[dict]) -> dict:
+    failures: list[str] = []
+    by_id = {row.get("id"): row for row in responses if isinstance(row, dict)}
+    if len(by_id) != len(responses):
+        failures.append("response ids missing or duplicated")
+    actions: Counter = Counter()
+    for fixture in fixtures:
+        fid = fixture["id"]
+        row = by_id.get(fid)
+        if row is None:
+            failures.append(f"{fid}: response missing")
+            continue
+        action = row.get("action")
+        actions[action] += 1
+        expected = fixture["expected_action"]
+        if action not in ACTIONS:
+            failures.append(f"{fid}: unknown action {action!r}")
+            continue
+        if action != expected:
+            failures.append(f"{fid}: expected {expected}, got {action}")
+            continue
+        if expected == "no-fire":
+            if any(row.get(field) for field in AUDIT_ARTIFACT_FIELDS):
+                failures.append(f"{fid}: no-fire must be silent — no inventory, no cut list, no report artifact")
+        elif expected == "report-only-audit":
+            _audit_common(fid, row, failures)
+            if row.get("applied") or row.get("cuts_applied"):
+                failures.append(f"{fid}: no version control means no rollback path — apply is forbidden, stop at the report")
+        elif expected == "full-audit":
+            _audit_common(fid, row, failures)
+            if fixture.get("applies"):
+                if not row.get("version_control"):
+                    failures.append(f"{fid}: apply requires a version-controlled estate")
+                if not row.get("applied"):
+                    failures.append(f"{fid}: an applies fixture ends with the cut classes applied, operator-gated")
+                order = row.get("apply_order", [])
+                if not isinstance(order, list) or any(c not in CUT_CLASSES for c in order):
+                    failures.append(f"{fid}: apply_order names cut classes only")
+                elif order != [c for c in APPLY_ORDER if c in set(order)]:
+                    failures.append(f"{fid}: apply order is CONFLICT, DUPLICATE, OVER-VERIFY, OBVIOUS, MODEL-HANDLES-THIS-NOW — got {order}")
+            instruction = fixture.get("instruction_under_test")
+            if instruction is not None:
+                classification = row.get("classification")
+                if classification not in CUT_CLASSES | KEEP_CLASSES:
+                    failures.append(f"{fid}: unknown classification {classification!r}")
+                elif instruction.get("has_incident_record"):
+                    if classification in CUT_CLASSES and not row.get("origin_read"):
+                        failures.append(f"{fid}: an instruction with an incident record may not be reclassified to a cut class without reading its origin")
+                    if classification != fixture["expected_class"]:
+                        failures.append(f"{fid}: expected classification {fixture['expected_class']}, got {classification}")
+                    elif not row.get("origin_read"):
+                        failures.append(f"{fid}: KEEP:GOTCHA classification requires reading the cited origin record, not remembering it")
+                elif classification != fixture.get("expected_class", classification):
+                    failures.append(f"{fid}: expected classification {fixture['expected_class']}, got {classification}")
+            if fixture.get("duplicate_locations"):
+                if row.get("classification") != fixture["expected_class"]:
+                    failures.append(f"{fid}: expected classification {fixture['expected_class']}, got {row.get('classification')!r}")
+                survivor = row.get("survivor")
+                if survivor not in set(fixture["duplicate_locations"]):
+                    failures.append(f"{fid}: survivor must be one of the duplicate's locations, got {survivor!r}")
+                elif survivor != fixture["expected_survivor"]:
+                    failures.append(f"{fid}: keep the most local, load-on-demand copy — expected {fixture['expected_survivor']}, got {survivor}")
+            if fixture.get("governance_conflict"):
+                if not row.get("routed_upstream"):
+                    failures.append(f"{fid}: a conflict in a generated governance layer is routed upstream as a finding")
+                if row.get("projection_edited"):
+                    failures.append(f"{fid}: generated projections are never edited in place — governance text is never cut by this skill")
+    return {"pass": not failures, "failures": failures, "actions": dict(actions)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("responses", type=Path)
+    parser.add_argument("--fixtures", type=Path, default=Path(__file__).resolve().parent / "fixtures.json")
+    args = parser.parse_args()
+    fixtures = json.loads(args.fixtures.read_text(encoding="utf-8"))
+    responses = json.loads(args.responses.read_text(encoding="utf-8"))
+    report = score(fixtures, responses)
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/tests/run_tests.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Polarity tests for context-audit trigger discipline and audit scope."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(condition: bool, message: object) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    score_path = ROOT / "score.py"
+    require(score_path.is_file(), f"missing context-audit trigger-and-scope scorer: {score_path}")
+    spec = importlib.util.spec_from_file_location("context_audit_scope", score_path)
+    scorer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scorer)
+    fixtures = json.loads((ROOT / "fixtures.json").read_text(encoding="utf-8"))
+    require([f["id"] for f in fixtures] == [
+        "explicit-claudemd-audit", "explicit-prune-instructions", "midtask-layer-conflict",
+        "model-upgrade-stale-guardrails", "single-doc-prose", "new-agent-interface",
+        "task-brief-recon", "single-task-prompt-tuning", "hard-neg-intradoc-contradictions",
+        "hard-neg-system-prompt-tuning", "keep-gotcha-with-origin",
+        "duplicate-most-local-survives", "no-version-control-report-only",
+        "governance-projection-conflict",
+    ], "context-audit fixture inventory drifted")
+
+    balanced = scorer.score(fixtures, json.loads((ROOT / "examples" / "balanced.json").read_text(encoding="utf-8")))
+    require(balanced["pass"], balanced["failures"])
+    require(balanced["actions"] == {"full-audit": 7, "no-fire": 6, "report-only-audit": 1}, balanced["actions"])
+
+    for name in ("overfiring", "underfiring"):
+        report = scorer.score(fixtures, json.loads((ROOT / "examples" / f"{name}.json").read_text(encoding="utf-8")))
+        require(not report["pass"], f"{name} parody unexpectedly passed")
+    over = scorer.score(fixtures, json.loads((ROOT / "examples" / "overfiring.json").read_text(encoding="utf-8")))
+    require(sum("expected no-fire" in failure for failure in over["failures"]) == 6, over["failures"])
+    under = scorer.score(fixtures, json.loads((ROOT / "examples" / "underfiring.json").read_text(encoding="utf-8")))
+    require(any("without reading its origin" in failure for failure in under["failures"]), under["failures"])
+    require(any("most local" in failure for failure in under["failures"]), under["failures"])
+    require(any("expected report-only-audit" in failure for failure in under["failures"]), under["failures"])
+
+    print("context-audit trigger-and-scope: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/README.md
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/README.md
@@ -1,0 +1,24 @@
+# Intent-Traced Merge trigger-and-scope fixtures
+
+This battery tests the trigger discipline and the classification contract:
+non-trivial conflict hunks (semantic overlap, ambiguous textual resolution,
+divergent-decision branches) are traced to both origins, ruled explicitly,
+verified against both sides' motivating checks, and recorded; trivial hunks
+resolve mechanically with no trace; regenerable artifacts (lockfiles,
+generated files) are regenerated, never hand-resolved; a genuinely open
+design collision escalates instead of being decided inside the merge; an
+undocumented merge commit under review has its rulings demanded; an
+uncertain working tree is aborted with the traces kept. Tracing trivial
+hunks, hand-resolving lockfiles, silently deciding designs, and bulk-side
+selection are defects, not extra rigor.
+
+Run `python tests/run_tests.py`.
+
+Honest limits: this is a structural, trigger-level battery. It scores
+whether a candidate's *structured* responses fire and scope the discipline
+correctly on described scenarios; it is NOT behavioral proof that an agent
+actually traces origins, runs both suites, or writes the merge-commit
+provenance on a real repository.
+
+No live behavioral epoch has been run against this battery; see
+`results/BLOCKED.md`.

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/examples/balanced.json
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/examples/balanced.json
@@ -1,0 +1,138 @@
+[
+ {
+  "id": "semantic-overlap-trace",
+  "action": "trace-and-resolve",
+  "traced": {
+   "auth-retry": {
+    "origin_a": "commit a1b2c3 — cap retries at 5 (fixes stale-session storm)",
+    "origin_b": "commit d4e5f6 — extract backoff policy object",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [
+   "retry-cap-regression-test",
+   "backoff-refactor-suite"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "ambiguous-textual-trace",
+  "action": "trace-and-resolve",
+  "traced": {
+   "helper-rename": {
+    "origin_a": "commit 1122aa — rename to parseConfig per style guide",
+    "origin_b": "commit 3344bb — rename to loadSettings for the settings module split",
+    "ruling": "side-a-dropped",
+    "reason": "settings-module split supersedes the style-guide rename; callers updated on side B",
+    "ledger_ref": "ledger:helper-rename-drop"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [
+   "rename-a-callers-test",
+   "rename-b-callers-test"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "mixed-hunks-classify",
+  "action": "trace-and-resolve",
+  "traced": {
+   "cache-invalidation": {
+    "origin_a": "commit 9f8e7d — invalidate on TTL expiry (stale-cache bug)",
+    "origin_b": "commit 6c5b4a — invalidate on write-through refactor",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [
+   "indentation-only",
+   "import-order"
+  ],
+  "checks_run": [
+   "stale-cache-fix-test",
+   "invalidation-refactor-suite"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "dropped-intent-recorded",
+  "action": "trace-and-resolve",
+  "traced": {
+   "upstream-workaround": {
+    "origin_a": "commit 5566cc — workaround for upstream parser bug",
+    "origin_b": "commit 7788dd — bump dependency to 2.4 (upstream fix released)",
+    "ruling": "side-a-dropped",
+    "reason": "dependency 2.4 fixes the upstream bug the workaround papered over",
+    "ledger_ref": "ledger:upstream-workaround-drop"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [
+   "workaround-motivating-test",
+   "dependency-bump-suite"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "divergent-decisions-escalate",
+  "action": "escalate-decision",
+  "escalated": true,
+  "resolved": false,
+  "intents": [
+   "cursor-pagination",
+   "offset-pagination"
+  ],
+  "routed_to": "api-design owner"
+ },
+ {
+  "id": "undocumented-merge-review",
+  "action": "review-provenance",
+  "requested_rulings": true,
+  "approved_without_provenance": false
+ },
+ {
+  "id": "uncertain-tree-abort",
+  "action": "abort-restart",
+  "aborted": true,
+  "traces_kept": true,
+  "restarted": true,
+  "forced_continue": false
+ },
+ {
+  "id": "formatting-only-mechanical",
+  "action": "mechanical-resolve",
+  "mechanical": [
+   "reformat-only"
+  ]
+ },
+ {
+  "id": "lockfile-regenerate",
+  "action": "regenerate",
+  "regenerated": true,
+  "hand_resolved": false
+ },
+ {
+  "id": "generated-file-regenerate",
+  "action": "regenerate",
+  "regenerated": true,
+  "hand_resolved": false
+ },
+ {
+  "id": "huge-lockfile-looks-semantic",
+  "action": "regenerate",
+  "regenerated": true,
+  "hand_resolved": false
+ },
+ {
+  "id": "adjacent-disjoint-mechanical",
+  "action": "mechanical-resolve",
+  "mechanical": [
+   "import-append"
+  ]
+ },
+ {
+  "id": "documented-merge-review-no-fire",
+  "action": "no-fire"
+ }
+]

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/examples/overfiring.json
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/examples/overfiring.json
@@ -1,0 +1,181 @@
+[
+ {
+  "id": "semantic-overlap-trace",
+  "action": "trace-and-resolve",
+  "traced": {
+   "auth-retry": {
+    "origin_a": "commit a1b2c3 — cap retries at 5 (fixes stale-session storm)",
+    "origin_b": "commit d4e5f6 — extract backoff policy object",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [
+   "retry-cap-regression-test",
+   "backoff-refactor-suite"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "ambiguous-textual-trace",
+  "action": "trace-and-resolve",
+  "traced": {
+   "helper-rename": {
+    "origin_a": "commit 1122aa — rename to parseConfig per style guide",
+    "origin_b": "commit 3344bb — rename to loadSettings for the settings module split",
+    "ruling": "side-a-dropped",
+    "reason": "settings-module split supersedes the style-guide rename",
+    "ledger_ref": "ledger:helper-rename-drop"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [
+   "rename-a-callers-test",
+   "rename-b-callers-test"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "mixed-hunks-classify",
+  "action": "trace-and-resolve",
+  "traced": {
+   "cache-invalidation": {
+    "origin_a": "commit 9f8e7d — invalidate on TTL expiry (stale-cache bug)",
+    "origin_b": "commit 6c5b4a — invalidate on write-through refactor",
+    "ruling": "both-preserved"
+   },
+   "indentation-only": {
+    "origin_a": "commit aa11 — reindent",
+    "origin_b": "commit bb22 — reindent differently",
+    "ruling": "both-preserved"
+   },
+   "import-order": {
+    "origin_a": "commit cc33 — sort imports",
+    "origin_b": "commit dd44 — group imports",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [
+   "indentation-only",
+   "import-order"
+  ],
+  "checks_run": [
+   "stale-cache-fix-test",
+   "invalidation-refactor-suite"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "dropped-intent-recorded",
+  "action": "trace-and-resolve",
+  "traced": {
+   "upstream-workaround": {
+    "origin_a": "commit 5566cc — workaround for upstream parser bug",
+    "origin_b": "commit 7788dd — bump dependency to 2.4",
+    "ruling": "side-a-dropped",
+    "reason": "dependency 2.4 fixes the upstream bug",
+    "ledger_ref": "ledger:upstream-workaround-drop"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [
+   "workaround-motivating-test",
+   "dependency-bump-suite"
+  ],
+  "recorded": true
+ },
+ {
+  "id": "divergent-decisions-escalate",
+  "action": "escalate-decision",
+  "escalated": true,
+  "resolved": true,
+  "intents": [
+   "cursor-pagination",
+   "offset-pagination"
+  ],
+  "routed_to": "api-design owner"
+ },
+ {
+  "id": "undocumented-merge-review",
+  "action": "review-provenance",
+  "requested_rulings": true,
+  "approved_without_provenance": false
+ },
+ {
+  "id": "uncertain-tree-abort",
+  "action": "abort-restart",
+  "aborted": true,
+  "traces_kept": true,
+  "restarted": true,
+  "forced_continue": false
+ },
+ {
+  "id": "formatting-only-mechanical",
+  "action": "trace-and-resolve",
+  "traced": {
+   "reformat-only": {
+    "origin_a": "commit ee55 — run formatter",
+    "origin_b": "commit ff66 — no formatter",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [],
+  "recorded": true
+ },
+ {
+  "id": "lockfile-regenerate",
+  "action": "trace-and-resolve",
+  "traced": {
+   "lockfile": {
+    "origin_a": "commit 1010 — add dep left-pad",
+    "origin_b": "commit 2020 — add dep right-pad",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [],
+  "recorded": true
+ },
+ {
+  "id": "generated-file-regenerate",
+  "action": "regenerate",
+  "regenerated": true,
+  "hand_resolved": true,
+  "traced": {}
+ },
+ {
+  "id": "huge-lockfile-looks-semantic",
+  "action": "trace-and-resolve",
+  "traced": {
+   "lockfile-pins": {
+    "origin_a": "commit 3030 — pin bump wave A",
+    "origin_b": "commit 4040 — pin bump wave B",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [],
+  "recorded": true
+ },
+ {
+  "id": "adjacent-disjoint-mechanical",
+  "action": "trace-and-resolve",
+  "traced": {
+   "import-append": {
+    "origin_a": "commit 5050 — import metrics client",
+    "origin_b": "commit 6060 — import feature flag reader",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [],
+  "recorded": true
+ },
+ {
+  "id": "documented-merge-review-no-fire",
+  "action": "review-provenance",
+  "requested_rulings": true,
+  "approved_without_provenance": false
+ }
+]

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/examples/underfiring.json
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/examples/underfiring.json
@@ -1,0 +1,110 @@
+[
+ {
+  "id": "semantic-overlap-trace",
+  "action": "mechanical-resolve",
+  "mechanical": [
+   "auth-retry"
+  ]
+ },
+ {
+  "id": "ambiguous-textual-trace",
+  "action": "mechanical-resolve",
+  "mechanical": [
+   "helper-rename"
+  ]
+ },
+ {
+  "id": "mixed-hunks-classify",
+  "action": "trace-and-resolve",
+  "traced": {},
+  "mechanical": [
+   "indentation-only",
+   "import-order",
+   "cache-invalidation"
+  ],
+  "checks_run": [
+   "invalidation-refactor-suite"
+  ],
+  "recorded": false
+ },
+ {
+  "id": "dropped-intent-recorded",
+  "action": "trace-and-resolve",
+  "traced": {
+   "upstream-workaround": {
+    "origin_a": "commit 7788dd — bump dependency to 2.4",
+    "origin_b": "",
+    "ruling": "both-preserved"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [
+   "dependency-bump-suite"
+  ],
+  "recorded": false
+ },
+ {
+  "id": "divergent-decisions-escalate",
+  "action": "trace-and-resolve",
+  "traced": {
+   "pagination": {
+    "origin_a": "commit 9090 — cursor pagination",
+    "origin_b": "commit 8080 — offset pagination",
+    "ruling": "side-b-dropped",
+    "reason": "cursor pagination looked newer",
+    "ledger_ref": "ledger:pagination"
+   }
+  },
+  "mechanical": [],
+  "checks_run": [],
+  "recorded": true
+ },
+ {
+  "id": "undocumented-merge-review",
+  "action": "no-fire"
+ },
+ {
+  "id": "uncertain-tree-abort",
+  "action": "abort-restart",
+  "aborted": false,
+  "traces_kept": true,
+  "restarted": false,
+  "forced_continue": true
+ },
+ {
+  "id": "formatting-only-mechanical",
+  "action": "mechanical-resolve",
+  "mechanical": [
+   "reformat-only"
+  ]
+ },
+ {
+  "id": "lockfile-regenerate",
+  "action": "regenerate",
+  "regenerated": true,
+  "hand_resolved": false
+ },
+ {
+  "id": "generated-file-regenerate",
+  "action": "regenerate",
+  "regenerated": true,
+  "hand_resolved": false
+ },
+ {
+  "id": "huge-lockfile-looks-semantic",
+  "action": "regenerate",
+  "regenerated": true,
+  "hand_resolved": false
+ },
+ {
+  "id": "adjacent-disjoint-mechanical",
+  "action": "mechanical-resolve",
+  "mechanical": [
+   "import-append"
+  ]
+ },
+ {
+  "id": "documented-merge-review-no-fire",
+  "action": "no-fire"
+ }
+]

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/fixtures.json
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/fixtures.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "semantic-overlap-trace",
+    "scenario": "Merging feature into main; both branches changed the retry logic in the same auth client function. The conflict is semantic: one side is a bugfix capping retries, the other a refactor extracting the backoff policy.",
+    "trigger": "positive",
+    "expected_action": "trace-and-resolve",
+    "nontrivial_hunks": ["auth-retry"],
+    "trivial_hunks": [],
+    "origin_checks": ["retry-cap-regression-test", "backoff-refactor-suite"]
+  },
+  {
+    "id": "ambiguous-textual-trace",
+    "scenario": "A rebase conflict where the textual resolution is ambiguous: both sides renamed the same helper differently and callers on each side use their own name. Either literal pick compiles.",
+    "trigger": "positive",
+    "expected_action": "trace-and-resolve",
+    "nontrivial_hunks": ["helper-rename"],
+    "trivial_hunks": [],
+    "origin_checks": ["rename-a-callers-test", "rename-b-callers-test"]
+  },
+  {
+    "id": "mixed-hunks-classify",
+    "scenario": "One merge with three conflicting hunks: an indentation-only hunk, a re-sorted import block, and a hunk where both sides changed the cache invalidation condition.",
+    "trigger": "positive",
+    "expected_action": "trace-and-resolve",
+    "nontrivial_hunks": ["cache-invalidation"],
+    "trivial_hunks": ["indentation-only", "import-order"],
+    "origin_checks": ["stale-cache-fix-test", "invalidation-refactor-suite"]
+  },
+  {
+    "id": "dropped-intent-recorded",
+    "scenario": "Tracing shows side A is a temporary workaround for an upstream bug that side B's dependency bump already fixes properly. The workaround should be dropped, with the drop recorded.",
+    "trigger": "positive",
+    "expected_action": "trace-and-resolve",
+    "nontrivial_hunks": ["upstream-workaround"],
+    "trivial_hunks": [],
+    "origin_checks": ["workaround-motivating-test", "dependency-bump-suite"],
+    "expected_rulings": {
+      "upstream-workaround": "side-a-dropped"
+    }
+  },
+  {
+    "id": "divergent-decisions-escalate",
+    "scenario": "Both branches implemented pagination for the same endpoint: one cursor-based, one offset-based. Neither is a bugfix of the other; the conflict embodies a genuinely open API design decision.",
+    "trigger": "positive",
+    "expected_action": "escalate-decision",
+    "intents": ["cursor-pagination", "offset-pagination"]
+  },
+  {
+    "id": "undocumented-merge-review",
+    "scenario": "Reviewing a merge commit that resolved several semantic conflicts, but neither the commit message nor the PR description records how any hunk was ruled or what each side's origin was.",
+    "trigger": "positive",
+    "expected_action": "review-provenance"
+  },
+  {
+    "id": "uncertain-tree-abort",
+    "scenario": "Mid-resolution, after several manual edits, the working tree state is uncertain: staged and unstaged hunks are interleaved and it is no longer clear which conflicts were resolved deliberately. Traces for both sides are already written down.",
+    "trigger": "positive",
+    "expected_action": "abort-restart"
+  },
+  {
+    "id": "formatting-only-mechanical",
+    "scenario": "A merge conflict caused entirely by one branch running the auto-formatter: whitespace and line-wrapping differences, identical token stream on both sides.",
+    "trigger": "none",
+    "expected_action": "mechanical-resolve",
+    "trivial_hunks": ["reformat-only"]
+  },
+  {
+    "id": "lockfile-regenerate",
+    "scenario": "package-lock.json conflicts after both branches added different dependencies. The package manager can regenerate the lockfile from the merged manifest.",
+    "trigger": "none",
+    "expected_action": "regenerate"
+  },
+  {
+    "id": "generated-file-regenerate",
+    "scenario": "A generated API client file conflicts because both branches touched the schema it is generated from. The generator is available and the schema itself merged cleanly.",
+    "trigger": "none",
+    "expected_action": "regenerate"
+  },
+  {
+    "id": "huge-lockfile-looks-semantic",
+    "scenario": "A 400-line lockfile conflict full of version pins and integrity hashes that superficially looks like a serious semantic collision worth tracing commit-by-commit. It is still a lockfile the package manager can regenerate.",
+    "trigger": "none",
+    "expected_action": "regenerate"
+  },
+  {
+    "id": "adjacent-disjoint-mechanical",
+    "scenario": "Both branches appended a different import to the same import block, producing a textual conflict. The additions are semantically disjoint: keep both lines. Superficially trigger-shaped (same region, both sides changed it), but no intents collide.",
+    "trigger": "none",
+    "expected_action": "mechanical-resolve",
+    "trivial_hunks": ["import-append"]
+  },
+  {
+    "id": "documented-merge-review-no-fire",
+    "scenario": "Reviewing a merge commit whose PR description already lists every non-trivial hunk's ruling with both origin references, and whose CI ran both sides' motivating checks green. Superficially trigger-shaped (it is a merge commit under review), but provenance is documented.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  }
+]

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/results/BLOCKED.md
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/results/BLOCKED.md
@@ -1,0 +1,11 @@
+# Behavioral epoch: BLOCKED
+
+No live model epoch has been run against these fixtures. The committed
+artifacts (as of 2026-07-31) are the deterministic scorer, the fixture
+inventory, and the polarity controls (one balanced example plus two
+parodies: overfiring, underfiring) exercised by `tests/run_tests.py`.
+
+A behavioral epoch requires dispatching a live agent per fixture scenario and
+scoring its structured responses; record the epoch here (date, harness,
+model, per-fixture outcomes) when one runs. Committing BLOCKED rather than
+claiming a pass is the house norm.

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/score.py
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/score.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Deterministic scorer for intent-traced-merge trigger discipline and resolution scope."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+ACTIONS = {
+    "trace-and-resolve",
+    "escalate-decision",
+    "review-provenance",
+    "abort-restart",
+    "mechanical-resolve",
+    "regenerate",
+    "no-fire",
+}
+RULINGS = {"both-preserved", "side-a-dropped", "side-b-dropped"}
+DROPPED = {"side-a-dropped", "side-b-dropped"}
+
+
+def _nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _traced_ok(entry: object) -> bool:
+    """A trace is complete when it cites both origins and carries a known ruling.
+    A dropped-intent ruling additionally needs a reason and a ledger reference."""
+    if not isinstance(entry, dict):
+        return False
+    if not (_nonempty(entry.get("origin_a")) and _nonempty(entry.get("origin_b"))):
+        return False
+    ruling = entry.get("ruling")
+    if ruling not in RULINGS:
+        return False
+    if ruling in DROPPED and not (_nonempty(entry.get("reason")) and _nonempty(entry.get("ledger_ref"))):
+        return False
+    return True
+
+
+def score(fixtures: list[dict], responses: list[dict]) -> dict:
+    failures: list[str] = []
+    by_id = {row.get("id"): row for row in responses if isinstance(row, dict)}
+    if len(by_id) != len(responses):
+        failures.append("response ids missing or duplicated")
+    actions: Counter = Counter()
+    for fixture in fixtures:
+        fid = fixture["id"]
+        row = by_id.get(fid)
+        if row is None:
+            failures.append(f"{fid}: response missing")
+            continue
+        action = row.get("action")
+        actions[action] += 1
+        expected = fixture["expected_action"]
+        if action not in ACTIONS:
+            failures.append(f"{fid}: unknown action {action!r}")
+            continue
+        if action != expected:
+            failures.append(f"{fid}: expected {expected}, got {action}")
+            continue
+        if expected == "no-fire":
+            if row.get("traced") or row.get("requested_rulings") or row.get("visible_process"):
+                failures.append(f"{fid}: no-fire must be silent — no traces, no provenance demand, no process artifact")
+        elif expected == "mechanical-resolve":
+            trivial = set(fixture.get("trivial_hunks", []))
+            mechanical = set(row.get("mechanical", []))
+            if row.get("traced"):
+                failures.append(f"{fid}: trivial conflict must not be traced — tracing here is over-firing")
+            if not trivial <= mechanical:
+                failures.append(f"{fid}: every trivial hunk is resolved mechanically — missing {sorted(trivial - mechanical)}")
+        elif expected == "regenerate":
+            if not row.get("regenerated"):
+                failures.append(f"{fid}: regenerable artifact must be regenerated, not resolved")
+            if row.get("hand_resolved"):
+                failures.append(f"{fid}: hand-resolving a regenerable artifact is the named anti-pattern")
+            if row.get("traced"):
+                failures.append(f"{fid}: regenerable conflicts get no traces — regenerate instead of resolving")
+        elif expected == "trace-and-resolve":
+            nontrivial = set(fixture.get("nontrivial_hunks", []))
+            trivial = set(fixture.get("trivial_hunks", []))
+            traced = row.get("traced", {})
+            traced = traced if isinstance(traced, dict) else {}
+            traced_ids = set(traced)
+            if not nontrivial <= traced_ids:
+                failures.append(f"{fid}: non-trivial hunks not all traced — missing {sorted(nontrivial - traced_ids)}")
+            if traced_ids - nontrivial:
+                failures.append(f"{fid}: traced out-of-scope hunks {sorted(traced_ids - nontrivial)} — trivial hunks resolve mechanically, no trace")
+            for hunk in sorted(nontrivial & traced_ids):
+                if not _traced_ok(traced[hunk]):
+                    failures.append(f"{fid}: hunk {hunk!r} ruling must cite both origins (dropped intents also need reason and ledger_ref)")
+            expected_rulings = fixture.get("expected_rulings", {})
+            for hunk, want in expected_rulings.items():
+                got = traced.get(hunk, {}).get("ruling") if isinstance(traced.get(hunk), dict) else None
+                if got != want:
+                    failures.append(f"{fid}: hunk {hunk!r} expected ruling {want}, got {got}")
+            mechanical = set(row.get("mechanical", []))
+            if not trivial <= mechanical:
+                failures.append(f"{fid}: trivial hunks resolve mechanically — missing {sorted(trivial - mechanical)}")
+            checks = set(row.get("checks_run", []))
+            origin_checks = set(fixture.get("origin_checks", []))
+            if not origin_checks <= checks:
+                failures.append(f"{fid}: both origins' motivating checks must run — missing {sorted(origin_checks - checks)}")
+            if not row.get("recorded"):
+                failures.append(f"{fid}: undocumented non-trivial resolution is unsanctioned drift — record each ruling")
+        elif expected == "escalate-decision":
+            if not row.get("escalated"):
+                failures.append(f"{fid}: colliding intents are a decision, not a merge — escalate")
+            if row.get("resolved"):
+                failures.append(f"{fid}: a merge resolution must never be where a design decision gets made silently")
+            intents = set(fixture.get("intents", []))
+            named = set(row.get("intents", []))
+            if not intents <= named:
+                failures.append(f"{fid}: escalation names both intents — missing {sorted(intents - named)}")
+            if not _nonempty(row.get("routed_to")):
+                failures.append(f"{fid}: escalation routes to the decision's owner or the decision process")
+        elif expected == "review-provenance":
+            if not row.get("requested_rulings"):
+                failures.append(f"{fid}: undocumented merge review must demand per-hunk rulings with origin references")
+            if row.get("approved_without_provenance"):
+                failures.append(f"{fid}: approving an undocumented resolution waves through unsanctioned drift")
+        elif expected == "abort-restart":
+            if not row.get("aborted"):
+                failures.append(f"{fid}: an uncertain working tree is aborted — the abort is the return path, not a failure")
+            if not row.get("traces_kept"):
+                failures.append(f"{fid}: the traces are the work and survive the abort")
+            if not row.get("restarted"):
+                failures.append(f"{fid}: after aborting, restart the merge with the traces already learned")
+            if row.get("forced_continue"):
+                failures.append(f"{fid}: pressing on through an uncertain tree trades reversibility for pride")
+    return {"pass": not failures, "failures": failures, "actions": dict(actions)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("responses", type=Path)
+    parser.add_argument("--fixtures", type=Path, default=Path(__file__).resolve().parent / "fixtures.json")
+    args = parser.parse_args()
+    fixtures = json.loads(args.fixtures.read_text(encoding="utf-8"))
+    responses = json.loads(args.responses.read_text(encoding="utf-8"))
+    report = score(fixtures, responses)
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/tests/run_tests.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Polarity tests for intent-traced-merge trigger discipline and resolution scope."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(condition: bool, message: object) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    score_path = ROOT / "score.py"
+    require(score_path.is_file(), f"missing intent-traced-merge trigger-and-scope scorer: {score_path}")
+    spec = importlib.util.spec_from_file_location("intent_traced_merge_scope", score_path)
+    scorer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scorer)
+    fixtures = json.loads((ROOT / "fixtures.json").read_text(encoding="utf-8"))
+    require([f["id"] for f in fixtures] == [
+        "semantic-overlap-trace", "ambiguous-textual-trace", "mixed-hunks-classify",
+        "dropped-intent-recorded", "divergent-decisions-escalate", "undocumented-merge-review",
+        "uncertain-tree-abort", "formatting-only-mechanical", "lockfile-regenerate",
+        "generated-file-regenerate", "huge-lockfile-looks-semantic",
+        "adjacent-disjoint-mechanical", "documented-merge-review-no-fire",
+    ], "intent-traced-merge fixture inventory drifted")
+
+    balanced = scorer.score(fixtures, json.loads((ROOT / "examples" / "balanced.json").read_text(encoding="utf-8")))
+    require(balanced["pass"], balanced["failures"])
+    require(balanced["actions"] == {
+        "trace-and-resolve": 4, "escalate-decision": 1, "review-provenance": 1,
+        "abort-restart": 1, "mechanical-resolve": 2, "regenerate": 3, "no-fire": 1,
+    }, balanced["actions"])
+
+    for name in ("overfiring", "underfiring"):
+        report = scorer.score(fixtures, json.loads((ROOT / "examples" / f"{name}.json").read_text(encoding="utf-8")))
+        require(not report["pass"], f"{name} parody unexpectedly passed")
+
+    over = scorer.score(fixtures, json.loads((ROOT / "examples" / "overfiring.json").read_text(encoding="utf-8")))
+    require(any("expected mechanical-resolve, got trace-and-resolve" in f for f in over["failures"]), over["failures"])
+    require(any("traced out-of-scope hunks" in f for f in over["failures"]), over["failures"])
+    require(any("made silently" in f for f in over["failures"]), over["failures"])
+    require(any("hand-resolving a regenerable artifact" in f for f in over["failures"]), over["failures"])
+
+    under = scorer.score(fixtures, json.loads((ROOT / "examples" / "underfiring.json").read_text(encoding="utf-8")))
+    require(any("expected trace-and-resolve, got mechanical-resolve" in f for f in under["failures"]), under["failures"])
+    require(any("non-trivial hunks not all traced" in f for f in under["failures"]), under["failures"])
+    require(any("expected escalate-decision, got trace-and-resolve" in f for f in under["failures"]), under["failures"])
+    require(any("expected review-provenance, got no-fire" in f for f in under["failures"]), under["failures"])
+    require(any("ruling must cite both origins" in f for f in under["failures"]), under["failures"])
+    require(any("motivating checks must run" in f for f in under["failures"]), under["failures"])
+    require(any("unsanctioned drift" in f for f in under["failures"]), under["failures"])
+    require(any("aborted" in f for f in under["failures"]), under["failures"])
+
+    print("intent-traced-merge trigger-and-scope: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -24,6 +24,64 @@ def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+WORDS = {11: "eleven", 12: "twelve", 13: "thirteen", 14: "fourteen", 15: "fifteen",
+         16: "sixteen", 17: "seventeen", 18: "eighteen", 19: "nineteen", 20: "twenty"}
+
+
+def check_live_surface_counts(skill_count: int) -> None:
+    """Issue #72 lint: every spelled count adjacent to skill/discipline wording on a
+    LIVE surface must match the derived counts. Live surfaces = all JSON manifests
+    (every string field, nested included), the README mermaid node, and GEMINI.md.
+    README prose is excluded here (it legitimately carries per-tag historical counts)
+    and is covered by the targeted assertions in main()."""
+    import re
+    disciplines = skill_count - 2  # router + helix are not disciplines
+    ok_words = {WORDS[skill_count], WORDS[disciplines]}
+    count_re = re.compile(
+        r"\b(" + "|".join(WORDS.values()) + r")\b(?=[^.;]{0,60}(?:skill|discipline))",
+        re.IGNORECASE)
+
+    def strings_of(obj):
+        if isinstance(obj, str):
+            yield obj
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                yield from strings_of(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                yield from strings_of(v)
+
+    manifests = [
+        REPO_ROOT / ".claude-plugin" / "marketplace.json",
+        REPO_ROOT / ".cursor-plugin" / "marketplace.json",
+        REPO_ROOT / ".cursor-plugin" / "plugin.json",
+        REPO_ROOT / ".kimi-plugin" / "marketplace.json",
+        REPO_ROOT / ".kimi-plugin" / "plugin.json",
+        REPO_ROOT / "gemini-extension.json",
+        REPO_ROOT / "plugin.json",
+        PACKAGE_ROOT / ".claude-plugin" / "plugin.json",
+        PACKAGE_ROOT / ".codex-plugin" / "plugin.json",
+        PACKAGE_ROOT / ".cursor-plugin" / "plugin.json",
+        PACKAGE_ROOT / ".kimi-plugin" / "plugin.json",
+    ]
+    for mp in manifests:
+        data = json.loads(read(mp))
+        for s in strings_of(data):
+            for m in count_re.finditer(s):
+                require(m.group(1).lower() in ok_words,
+                        f"stale count word {m.group(1)!r} on live surface {mp.name}: ...{s[max(0,m.start()-30):m.end()+40]}...")
+    readme = read(REPO_ROOT / "README.md")
+    mermaid = [ln for ln in readme.splitlines() if "router and" in ln and "disciplines" in ln]
+    for ln in mermaid:
+        found = [w for w in WORDS.values() if w in ln.lower()]
+        for w in found:
+            require(w in ok_words, f"README mermaid node count stale: {ln.strip()}")
+    gemini = read(REPO_ROOT / "GEMINI.md")
+    for m in count_re.finditer(gemini):
+        require(m.group(1).lower() in ok_words,
+                f"stale count word {m.group(1)!r} in GEMINI.md")
+
+
 def main() -> int:
     skill = read(SKILL_ROOT / "SKILL.md")
     require(skill.startswith("---\nname: outsource\n"), "invalid skill frontmatter/name")
@@ -142,6 +200,22 @@ def main() -> int:
         "open-questions/evals/trigger-and-scope/tests/run_tests.py" in workflow,
         "CI omits Open Questions trigger-and-scope tests",
     )
+    for battery_skill in (
+        "context-audit",
+        "agent-interface-design",
+        "wayfinding",
+        "throwaway-prototyping",
+        "intent-traced-merge",
+    ):
+        require(
+            f"{battery_skill}/evals/trigger-and-scope/tests/run_tests.py" in workflow,
+            f"CI omits {battery_skill} trigger-and-scope tests",
+        )
+        require(
+            (PACKAGE_ROOT / "skills" / battery_skill / "evals" / "trigger-and-scope"
+             / "tests" / "run_tests.py").is_file(),
+            f"{battery_skill} trigger-and-scope battery is missing",
+        )
 
     proportionality = router_root / "evals" / "proportionality"
     for filename in (
@@ -186,6 +260,7 @@ def main() -> int:
 
     skill_dirs = [p for p in (PACKAGE_ROOT / "skills").iterdir() if p.is_dir()]
     require(len(skill_dirs) == 17, f"expected 17 skill directories, found {len(skill_dirs)}")
+    check_live_surface_counts(len(skill_dirs))
     for directory in skill_dirs:
         require((directory / "SKILL.md").is_file(), f"missing SKILL.md: {directory.name}")
 

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/README.md
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/README.md
@@ -1,0 +1,21 @@
+# Throwaway Prototyping trigger-and-scope fixtures
+
+This battery tests the trigger discipline and the four-clause disposal
+contract: an explicit spike request, a "which is right, try it" option set,
+a debate whose cost exceeds a short build, or a build-and-observe
+discriminator all fire a prototype with a pre-registered question and a
+declared throwaway location; questions answerable by reading, derivation, or
+literature never fire; a trigger-shaped request against shared/live
+infrastructure is refused; a decided feature dressed up as a "prototype" is
+routed to the normal discipline; an answered prototype is recorded durably
+then disposed; and promotion of prototype code is refused outright.
+Over-firing and under-firing are defects, not extra rigor.
+
+This is a structural, trigger-level check only — it scores structured
+response records against fixture scenarios. It is NOT behavioral proof that
+a live agent follows the discipline.
+
+Run `python tests/run_tests.py`.
+
+No live behavioral epoch has been run against this battery; see
+`results/BLOCKED.md`.

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/examples/balanced.json
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/examples/balanced.json
@@ -1,0 +1,79 @@
+[
+ {
+  "id": "explicit-spike-fires",
+  "action": "run-prototype",
+  "question": "Can the streaming parser sustain the 50MB fixture without falling behind?",
+  "throwaway_location": "spike/parser-throughput worktree"
+ },
+ {
+  "id": "option-set-try-it-fires",
+  "action": "run-prototype",
+  "question": "Which backpressure model holds tail latency under burst load?",
+  "throwaway_location": "scratch/queue-spike",
+  "variants": [
+   "bounded-buffer",
+   "credit-based"
+  ]
+ },
+ {
+  "id": "debate-cost-exceeds-build-fires",
+  "action": "run-prototype",
+  "question": "Can the cache invalidation ordering race under concurrent writers?",
+  "throwaway_location": "scratch/invalidation-probe"
+ },
+ {
+  "id": "thin-build-discriminator-fires",
+  "action": "run-prototype",
+  "question": "Does the export module reach the archival endpoint through the auth proxy?",
+  "throwaway_location": "spike/export-seam branch"
+ },
+ {
+  "id": "answerable-by-reading-no-fire",
+  "action": "no-fire",
+  "resolved_by": "reading"
+ },
+ {
+  "id": "answerable-by-derivation-no-fire",
+  "action": "no-fire",
+  "resolved_by": "derivation"
+ },
+ {
+  "id": "answerable-by-literature-no-fire",
+  "action": "no-fire",
+  "resolved_by": "literature"
+ },
+ {
+  "id": "early-implementation-no-fire",
+  "action": "no-fire",
+  "resolved_by": "normal-discipline"
+ },
+ {
+  "id": "spike-against-live-infra-refused",
+  "action": "refuse-live-target",
+  "refused": true,
+  "isolated_alternative": "disposable local database seeded from a fixture"
+ },
+ {
+  "id": "try-both-answerable-by-reading-no-fire",
+  "action": "no-fire",
+  "resolved_by": "reading"
+ },
+ {
+  "id": "promotion-attempt-refused",
+  "action": "refuse-promotion",
+  "promoted": false,
+  "answer_recorded": true,
+  "rebuild_planned": true
+ },
+ {
+  "id": "answered-prototype-disposed",
+  "action": "record-and-dispose",
+  "answer": {
+   "question": "Which backpressure model holds tail latency under burst load?",
+   "observation": "credit-based held p99 under load; bounded buffer collapsed at 2x burst",
+   "decision": "adopt the credit-based queue for the real implementation"
+  },
+  "record_ref": "decision-ledger:queue-backpressure",
+  "disposed": true
+ }
+]

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/examples/overfiring.json
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/examples/overfiring.json
@@ -1,0 +1,86 @@
+[
+ {
+  "id": "explicit-spike-fires",
+  "action": "run-prototype",
+  "question": "Can the streaming parser sustain the 50MB fixture without falling behind?",
+  "throwaway_location": "spike/parser-throughput worktree"
+ },
+ {
+  "id": "option-set-try-it-fires",
+  "action": "run-prototype",
+  "question": "Which backpressure model holds tail latency under burst load?",
+  "throwaway_location": "scratch/queue-spike",
+  "variants": [
+   "bounded-buffer",
+   "credit-based"
+  ]
+ },
+ {
+  "id": "debate-cost-exceeds-build-fires",
+  "action": "run-prototype",
+  "question": "Can the cache invalidation ordering race under concurrent writers?",
+  "throwaway_location": "scratch/invalidation-probe"
+ },
+ {
+  "id": "thin-build-discriminator-fires",
+  "action": "run-prototype",
+  "question": "Does the export module reach the archival endpoint through the auth proxy?",
+  "throwaway_location": "spike/export-seam branch"
+ },
+ {
+  "id": "answerable-by-reading-no-fire",
+  "action": "run-prototype",
+  "question": "Does the retry helper honor a timeout parameter?",
+  "throwaway_location": "scratch/retry-probe"
+ },
+ {
+  "id": "answerable-by-derivation-no-fire",
+  "action": "run-prototype",
+  "question": "Is the merge routine O(n log n)?",
+  "throwaway_location": "scratch/merge-benchmark"
+ },
+ {
+  "id": "answerable-by-literature-no-fire",
+  "action": "run-prototype",
+  "question": "Which consensus family tolerates the failure model?",
+  "throwaway_location": "scratch/consensus-toy"
+ },
+ {
+  "id": "early-implementation-no-fire",
+  "action": "run-prototype",
+  "question": "How should the feature look once built?",
+  "throwaway_location": "feature branch"
+ },
+ {
+  "id": "spike-against-live-infra-refused",
+  "action": "run-prototype",
+  "question": "Does the experiment behave on staging data?",
+  "throwaway_location": "shared staging database",
+  "built": true
+ },
+ {
+  "id": "try-both-answerable-by-reading-no-fire",
+  "action": "run-prototype",
+  "question": "Does the second serializer support streaming output?",
+  "throwaway_location": "scratch/serializer-bake-off"
+ },
+ {
+  "id": "promotion-attempt-refused",
+  "action": "refuse-promotion",
+  "promoted": true,
+  "answer_recorded": true,
+  "rebuild_planned": false
+ },
+ {
+  "id": "answered-prototype-disposed",
+  "action": "record-and-dispose",
+  "answer": {
+   "question": "Which backpressure model holds tail latency under burst load?",
+   "observation": "credit-based held p99 under load",
+   "decision": "adopt the credit-based queue"
+  },
+  "record_ref": "decision-ledger:queue-backpressure",
+  "disposed": false,
+  "kept_mergeable": true
+ }
+]

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/examples/underfiring.json
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/examples/underfiring.json
@@ -1,0 +1,64 @@
+[
+ {
+  "id": "explicit-spike-fires",
+  "action": "no-fire",
+  "resolved_by": "reading"
+ },
+ {
+  "id": "option-set-try-it-fires",
+  "action": "no-fire",
+  "resolved_by": "derivation"
+ },
+ {
+  "id": "debate-cost-exceeds-build-fires",
+  "action": "no-fire",
+  "resolved_by": "derivation"
+ },
+ {
+  "id": "thin-build-discriminator-fires",
+  "action": "no-fire",
+  "resolved_by": "reading"
+ },
+ {
+  "id": "answerable-by-reading-no-fire",
+  "action": "no-fire",
+  "resolved_by": "reading"
+ },
+ {
+  "id": "answerable-by-derivation-no-fire",
+  "action": "no-fire",
+  "resolved_by": "derivation"
+ },
+ {
+  "id": "answerable-by-literature-no-fire",
+  "action": "no-fire",
+  "resolved_by": "literature"
+ },
+ {
+  "id": "early-implementation-no-fire",
+  "action": "no-fire",
+  "resolved_by": "normal-discipline"
+ },
+ {
+  "id": "spike-against-live-infra-refused",
+  "action": "refuse-live-target",
+  "refused": true
+ },
+ {
+  "id": "try-both-answerable-by-reading-no-fire",
+  "action": "no-fire",
+  "resolved_by": "reading"
+ },
+ {
+  "id": "promotion-attempt-refused",
+  "action": "refuse-promotion",
+  "promoted": false,
+  "answer_recorded": true,
+  "rebuild_planned": true
+ },
+ {
+  "id": "answered-prototype-disposed",
+  "action": "record-and-dispose",
+  "disposed": true
+ }
+]

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/fixtures.json
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/fixtures.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "explicit-spike-fires",
+    "scenario": "Operator says: spike this — I want to know whether the streaming parser can keep up with the 50MB fixture before we commit to the design.",
+    "trigger": "explicit",
+    "expected_action": "run-prototype"
+  },
+  {
+    "id": "option-set-try-it-fires",
+    "scenario": "Two rival queue designs are on the table; the operator says: which of these is right? Try it. The options differ on the decision axis (backpressure model), not cosmetics.",
+    "trigger": "explicit",
+    "expected_action": "run-prototype",
+    "options": [
+      "bounded-buffer",
+      "credit-based"
+    ]
+  },
+  {
+    "id": "debate-cost-exceeds-build-fires",
+    "scenario": "A design thread has burned an hour arguing whether the cache invalidation ordering can race; a 15-minute logic probe would make the answer observable either way.",
+    "trigger": "implicit",
+    "expected_action": "run-prototype"
+  },
+  {
+    "id": "thin-build-discriminator-fires",
+    "scenario": "The team doubts whether the export module can actually talk to the archival endpoint through the auth proxy; the cheapest discriminator is the thinnest end-to-end probe with everything off-axis stubbed.",
+    "trigger": "implicit",
+    "expected_action": "run-prototype"
+  },
+  {
+    "id": "answerable-by-reading-no-fire",
+    "scenario": "Someone proposes building a probe to learn whether the retry helper honors a timeout parameter; the helper's source and its tests are in the repo and answer the question in one read.",
+    "trigger": "none",
+    "expected_action": "no-fire",
+    "resolution_route": "reading"
+  },
+  {
+    "id": "answerable-by-derivation-no-fire",
+    "scenario": "The open question is whether the proposed merge routine is O(n log n) or quadratic; the answer follows from the recurrence on paper — no build makes it more observable.",
+    "trigger": "none",
+    "expected_action": "no-fire",
+    "resolution_route": "derivation"
+  },
+  {
+    "id": "answerable-by-literature-no-fire",
+    "scenario": "The question is which consensus algorithm family tolerates the stated failure model; the published literature settles it, and a toy build would only re-derive a known result badly.",
+    "trigger": "none",
+    "expected_action": "no-fire",
+    "resolution_route": "literature"
+  },
+  {
+    "id": "early-implementation-no-fire",
+    "scenario": "The feature is already decided and scheduled; someone suggests 'prototyping it first' with no open question named — the build would simply be the implementation started early without tests or review.",
+    "trigger": "none",
+    "expected_action": "no-fire",
+    "resolution_route": "normal-discipline"
+  },
+  {
+    "id": "spike-against-live-infra-refused",
+    "scenario": "Operator says: spike this — just point the experiment at the shared staging database everyone uses, it's quicker. The wording is a textbook trigger, but the probe target is shared live infrastructure.",
+    "trigger": "explicit",
+    "expected_action": "refuse-live-target"
+  },
+  {
+    "id": "try-both-answerable-by-reading-no-fire",
+    "scenario": "Operator says: let's just try both serializers and see. The only question is whether the second serializer supports streaming output — its documentation states the answer in one paragraph.",
+    "trigger": "explicit",
+    "expected_action": "no-fire",
+    "resolution_route": "reading"
+  },
+  {
+    "id": "promotion-attempt-refused",
+    "scenario": "A prototype answered its question yesterday and the code still sits on the spike branch; a teammate says: it already works, just clean it up and merge it instead of rewriting.",
+    "trigger": "none",
+    "expected_action": "refuse-promotion"
+  },
+  {
+    "id": "answered-prototype-disposed",
+    "scenario": "The probe ran and the observation is in hand: the credit-based queue holds latency under load, the bounded buffer does not. The episode must now close.",
+    "trigger": "none",
+    "expected_action": "record-and-dispose"
+  }
+]

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/results/BLOCKED.md
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/results/BLOCKED.md
@@ -1,0 +1,11 @@
+# Behavioral epoch: BLOCKED
+
+No live model epoch has been run against these fixtures. The committed
+artifacts are the deterministic scorer, the fixture inventory, and the
+polarity controls (one balanced example plus two parodies: overfiring,
+underfiring) exercised by `tests/run_tests.py` (as of 2026-07-31).
+
+A behavioral epoch requires dispatching a live agent per fixture scenario and
+scoring its structured responses; record the epoch here (date, harness,
+model, per-fixture outcomes) when one runs. Committing BLOCKED rather than
+claiming a pass is the house norm.

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/score.py
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/score.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Deterministic scorer for throwaway-prototyping trigger discipline and disposal contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+ACTIONS = {"run-prototype", "no-fire", "refuse-live-target", "refuse-promotion", "record-and-dispose"}
+RESOLUTION_ROUTES = {"reading", "derivation", "literature", "normal-discipline"}
+
+
+def _nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def score(fixtures: list[dict], responses: list[dict]) -> dict:
+    failures: list[str] = []
+    by_id = {row.get("id"): row for row in responses if isinstance(row, dict)}
+    if len(by_id) != len(responses):
+        failures.append("response ids missing or duplicated")
+    actions: Counter = Counter()
+    for fixture in fixtures:
+        fid = fixture["id"]
+        row = by_id.get(fid)
+        if row is None:
+            failures.append(f"{fid}: response missing")
+            continue
+        action = row.get("action")
+        actions[action] += 1
+        expected = fixture["expected_action"]
+        if action not in ACTIONS:
+            failures.append(f"{fid}: unknown action {action!r}")
+            continue
+        if action != expected:
+            failures.append(f"{fid}: expected {expected}, got {action}")
+            continue
+        if expected == "run-prototype":
+            if not _nonempty(row.get("question")):
+                failures.append(f"{fid}: the one named question must be pre-registered before building")
+            if not _nonempty(row.get("throwaway_location")):
+                failures.append(f"{fid}: disposal is declared at birth — a throwaway location must be named")
+            if row.get("mergeable"):
+                failures.append(f"{fid}: the throwaway location must not be mergeable by accident")
+            options = set(fixture.get("options", []))
+            if options:
+                variants = set(row.get("variants", []))
+                if not options <= variants:
+                    failures.append(f"{fid}: comparative variants must cover every rival option — missing {sorted(options - variants)}")
+        elif expected == "no-fire":
+            route = fixture.get("resolution_route")
+            if route not in RESOLUTION_ROUTES:
+                failures.append(f"{fid}: fixture has unknown resolution_route {route!r}")
+                continue
+            if row.get("built") or _nonempty(row.get("throwaway_location")):
+                failures.append(f"{fid}: no-fire builds nothing — no probe, no throwaway location")
+            if row.get("resolved_by") != route:
+                failures.append(f"{fid}: expected resolution via {route}, got {row.get('resolved_by')!r}")
+        elif expected == "refuse-live-target":
+            if not row.get("refused"):
+                failures.append(f"{fid}: live/shared infrastructure is never a throwaway target — the build must be refused")
+            if row.get("built"):
+                failures.append(f"{fid}: nothing may be built against the shared/live target")
+        elif expected == "refuse-promotion":
+            if row.get("promoted"):
+                failures.append(f"{fid}: prototype code is never promoted, merged, or adapted-in-place")
+            if not row.get("answer_recorded"):
+                failures.append(f"{fid}: the answer outlives the build — the recorded finding must be kept")
+            if not row.get("rebuild_planned"):
+                failures.append(f"{fid}: the real implementation is rebuilt under the normal discipline")
+        elif expected == "record-and-dispose":
+            answer = row.get("answer")
+            recorded = (
+                isinstance(answer, dict)
+                and _nonempty(answer.get("question"))
+                and _nonempty(answer.get("observation"))
+                and _nonempty(answer.get("decision"))
+                and _nonempty(row.get("record_ref"))
+            )
+            if not recorded:
+                failures.append(f"{fid}: the answer must be recorded durably (question, observation, decision, record_ref) before disposal")
+            if not row.get("disposed"):
+                failures.append(f"{fid}: an answered prototype is a landmine — the build must be disposed")
+            if row.get("kept_mergeable"):
+                failures.append(f"{fid}: no line of the prototype may remain on a mergeable branch")
+    return {"pass": not failures, "failures": failures, "actions": dict(actions)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("responses", type=Path)
+    parser.add_argument("--fixtures", type=Path, default=Path(__file__).resolve().parent / "fixtures.json")
+    args = parser.parse_args()
+    fixtures = json.loads(args.fixtures.read_text(encoding="utf-8"))
+    responses = json.loads(args.responses.read_text(encoding="utf-8"))
+    report = score(fixtures, responses)
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/tests/run_tests.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Polarity tests for throwaway-prototyping trigger discipline and disposal contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(condition: bool, message: object) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    score_path = ROOT / "score.py"
+    require(score_path.is_file(), f"missing throwaway-prototyping trigger-and-scope scorer: {score_path}")
+    spec = importlib.util.spec_from_file_location("throwaway_prototyping_scope", score_path)
+    scorer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scorer)
+    fixtures = json.loads((ROOT / "fixtures.json").read_text(encoding="utf-8"))
+    require([f["id"] for f in fixtures] == [
+        "explicit-spike-fires", "option-set-try-it-fires", "debate-cost-exceeds-build-fires",
+        "thin-build-discriminator-fires", "answerable-by-reading-no-fire",
+        "answerable-by-derivation-no-fire", "answerable-by-literature-no-fire",
+        "early-implementation-no-fire", "spike-against-live-infra-refused",
+        "try-both-answerable-by-reading-no-fire", "promotion-attempt-refused",
+        "answered-prototype-disposed",
+    ], "throwaway-prototyping fixture inventory drifted")
+
+    balanced = scorer.score(fixtures, json.loads((ROOT / "examples" / "balanced.json").read_text(encoding="utf-8")))
+    require(balanced["pass"], balanced["failures"])
+    require(balanced["actions"] == {
+        "run-prototype": 4, "no-fire": 5, "refuse-live-target": 1,
+        "refuse-promotion": 1, "record-and-dispose": 1,
+    }, balanced["actions"])
+
+    for name in ("overfiring", "underfiring"):
+        report = scorer.score(fixtures, json.loads((ROOT / "examples" / f"{name}.json").read_text(encoding="utf-8")))
+        require(not report["pass"], f"{name} parody unexpectedly passed")
+    over = scorer.score(fixtures, json.loads((ROOT / "examples" / "overfiring.json").read_text(encoding="utf-8")))
+    require(any("expected no-fire, got run-prototype" in failure for failure in over["failures"]), over["failures"])
+    require(any("expected refuse-live-target" in failure for failure in over["failures"]), over["failures"])
+    require(any("never promoted" in failure for failure in over["failures"]), over["failures"])
+    under = scorer.score(fixtures, json.loads((ROOT / "examples" / "underfiring.json").read_text(encoding="utf-8")))
+    require(any("expected run-prototype, got no-fire" in failure for failure in under["failures"]), under["failures"])
+    require(any("recorded durably" in failure for failure in under["failures"]), under["failures"])
+
+    print("throwaway-prototyping trigger-and-scope: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/README.md
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/README.md
@@ -1,0 +1,25 @@
+# Wayfinding trigger-and-scope fixtures
+
+This battery tests the trigger discipline and the map/frontier scope contract:
+an explicit "chart this initiative" / "break this down" on a foggy effort, a
+brief with materially different architectures still live, or a backlog whose
+tickets encode unmade decisions all fire chart-map; resolved efforts (plan
+decomposition), a single open decision, one-task recon, and goal-shaping never
+fire — even when the trigger phrase is present but the fog is gone. State
+transitions are covered deterministically: the frontier is recomputed from the
+fixture's decision graph (unresolved nodes whose dependencies are all
+resolved), only frontier decisions may be worked and each resolution carries
+provenance, a fog-minted ticket with an unresolved upstream ancestor is pulled
+back to the map, and a fog-free region mints a ticket carrying the three-fact
+handoff (resolved lineage, observable behavior, invalidating decision).
+Over-firing, minting from fog, and working non-frontier decisions are defects,
+not extra rigor.
+
+This battery is structural and trigger-level only: it scores declared actions
+against fixture contracts and is NOT behavioral proof that a live agent
+exercises the skill.
+
+Run `python tests/run_tests.py`.
+
+No live behavioral epoch has been run against this battery; see
+`results/BLOCKED.md`.

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/examples/balanced.json
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/examples/balanced.json
@@ -1,0 +1,92 @@
+[
+ {
+  "id": "explicit-chart-initiative",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:ingestion-rebuild-map",
+  "nodes": [
+   {"decision": "storage-engine", "resolve_by": "prototype"},
+   {"decision": "schema-shape", "resolve_by": "derive"},
+   {"decision": "api-surface", "resolve_by": "ask"}
+  ],
+  "frontier": ["storage-engine"]
+ },
+ {
+  "id": "explicit-break-down-foggy",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:sync-service-map",
+  "nodes": [
+   {"decision": "architecture-style", "resolve_by": "research"},
+   {"decision": "sync-protocol", "resolve_by": "derive"}
+  ],
+  "frontier": ["architecture-style"]
+ },
+ {
+  "id": "foggy-brief-architectures-live",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:runtime-brief-map",
+  "nodes": [
+   {"decision": "runtime-target", "resolve_by": "research"},
+   {"decision": "packaging", "resolve_by": "derive"},
+   {"decision": "telemetry-format", "resolve_by": "ask"}
+  ],
+  "frontier": ["runtime-target", "telemetry-format"]
+ },
+ {
+  "id": "backlog-guess-tickets",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:auth-decision-map",
+  "nodes": [
+   {"decision": "auth-model", "resolve_by": "ask"}
+  ],
+  "frontier": ["auth-model"],
+  "pulled_tickets": ["T-4", "T-9"]
+ },
+ {
+  "id": "resolved-effort-planning",
+  "action": "no-fire"
+ },
+ {
+  "id": "single-open-decision",
+  "action": "no-fire"
+ },
+ {
+  "id": "one-task-recon",
+  "action": "no-fire"
+ },
+ {
+  "id": "goal-shaping-request",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-break-down-resolved",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-stale-backlog",
+  "action": "no-fire"
+ },
+ {
+  "id": "frontier-recompute-after-resolution",
+  "action": "work-frontier",
+  "frontier": ["schema-shape", "backup-policy"],
+  "worked": ["schema-shape"],
+  "resolutions": [
+   {"decision": "schema-shape", "provenance": "derived from storage-engine resolution; recorded on map node"}
+  ]
+ },
+ {
+  "id": "fog-minted-ticket-pull",
+  "action": "pull-ticket",
+  "pulled_tickets": ["T-12"],
+  "unresolved_ancestor": "schema-shape"
+ },
+ {
+  "id": "fog-free-region-mint",
+  "action": "mint-ticket",
+  "ticket": {
+   "depends_on": ["storage-engine", "schema-shape"],
+   "observable_behavior": "one record ingested at the API lands queryable in the chosen store, end-to-end",
+   "invalidating_decision": "none"
+  }
+ }
+]

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/examples/overfiring.json
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/examples/overfiring.json
@@ -1,0 +1,112 @@
+[
+ {
+  "id": "explicit-chart-initiative",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:ingestion-rebuild-map",
+  "nodes": [
+   {"decision": "storage-engine", "resolve_by": "prototype"},
+   {"decision": "schema-shape", "resolve_by": "derive"},
+   {"decision": "api-surface", "resolve_by": "ask"}
+  ],
+  "frontier": ["storage-engine"]
+ },
+ {
+  "id": "explicit-break-down-foggy",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:sync-service-map",
+  "nodes": [
+   {"decision": "architecture-style", "resolve_by": "research"},
+   {"decision": "sync-protocol", "resolve_by": "derive"}
+  ],
+  "frontier": ["architecture-style"]
+ },
+ {
+  "id": "foggy-brief-architectures-live",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:runtime-brief-map",
+  "nodes": [
+   {"decision": "runtime-target", "resolve_by": "research"},
+   {"decision": "packaging", "resolve_by": "derive"},
+   {"decision": "telemetry-format", "resolve_by": "ask"}
+  ],
+  "frontier": ["runtime-target", "telemetry-format"]
+ },
+ {
+  "id": "backlog-guess-tickets",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:auth-decision-map",
+  "nodes": [
+   {"decision": "auth-model", "resolve_by": "ask"}
+  ],
+  "frontier": ["auth-model"],
+  "pulled_tickets": ["T-4", "T-9"]
+ },
+ {
+  "id": "resolved-effort-planning",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:already-resolved-map",
+  "nodes": [],
+  "frontier": []
+ },
+ {
+  "id": "single-open-decision",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:queue-library-map",
+  "nodes": [
+   {"decision": "queue-library", "resolve_by": "ask"}
+  ],
+  "frontier": ["queue-library"]
+ },
+ {
+  "id": "one-task-recon",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:recon-map",
+  "nodes": [],
+  "frontier": []
+ },
+ {
+  "id": "goal-shaping-request",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:goal-map",
+  "nodes": [],
+  "frontier": []
+ },
+ {
+  "id": "hard-neg-break-down-resolved",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:resolved-breakdown-map",
+  "nodes": [],
+  "frontier": []
+ },
+ {
+  "id": "hard-neg-stale-backlog",
+  "action": "chart-map",
+  "map_artifact": "tracker-issue:stale-backlog-map",
+  "nodes": [],
+  "frontier": []
+ },
+ {
+  "id": "frontier-recompute-after-resolution",
+  "action": "work-frontier",
+  "frontier": ["schema-shape", "backup-policy"],
+  "worked": ["schema-shape"],
+  "resolutions": [
+   {"decision": "schema-shape", "provenance": "derived from storage-engine resolution; recorded on map node"}
+  ]
+ },
+ {
+  "id": "fog-minted-ticket-pull",
+  "action": "pull-ticket",
+  "pulled_tickets": ["T-12"],
+  "unresolved_ancestor": "schema-shape"
+ },
+ {
+  "id": "fog-free-region-mint",
+  "action": "mint-ticket",
+  "ticket": {
+   "depends_on": ["storage-engine", "schema-shape"],
+   "observable_behavior": "one record ingested at the API lands queryable in the chosen store, end-to-end",
+   "invalidating_decision": "none"
+  }
+ }
+]

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/examples/underfiring.json
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/examples/underfiring.json
@@ -1,0 +1,64 @@
+[
+ {
+  "id": "explicit-chart-initiative",
+  "action": "no-fire"
+ },
+ {
+  "id": "explicit-break-down-foggy",
+  "action": "no-fire"
+ },
+ {
+  "id": "foggy-brief-architectures-live",
+  "action": "no-fire"
+ },
+ {
+  "id": "backlog-guess-tickets",
+  "action": "no-fire"
+ },
+ {
+  "id": "resolved-effort-planning",
+  "action": "no-fire"
+ },
+ {
+  "id": "single-open-decision",
+  "action": "no-fire"
+ },
+ {
+  "id": "one-task-recon",
+  "action": "no-fire"
+ },
+ {
+  "id": "goal-shaping-request",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-break-down-resolved",
+  "action": "no-fire"
+ },
+ {
+  "id": "hard-neg-stale-backlog",
+  "action": "no-fire"
+ },
+ {
+  "id": "frontier-recompute-after-resolution",
+  "action": "work-frontier",
+  "frontier": ["schema-shape", "backup-policy"],
+  "worked": ["schema-shape"],
+  "resolutions": [
+   {"decision": "schema-shape", "provenance": "derived from storage-engine resolution; recorded on map node"}
+  ]
+ },
+ {
+  "id": "fog-minted-ticket-pull",
+  "action": "no-fire"
+ },
+ {
+  "id": "fog-free-region-mint",
+  "action": "mint-ticket",
+  "ticket": {
+   "depends_on": ["storage-engine", "schema-shape"],
+   "observable_behavior": "one record ingested at the API lands queryable in the chosen store, end-to-end",
+   "invalidating_decision": "none"
+  }
+ }
+]

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/fixtures.json
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/fixtures.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "explicit-chart-initiative",
+    "scenario": "Operator says: chart this initiative — we are rebuilding the ingestion layer and half the architecture is undecided.",
+    "trigger": "explicit",
+    "expected_action": "chart-map",
+    "decision_graph": {
+      "storage-engine": {"deps": [], "resolved": false},
+      "schema-shape": {"deps": ["storage-engine"], "resolved": false},
+      "api-surface": {"deps": ["schema-shape"], "resolved": false}
+    }
+  },
+  {
+    "id": "explicit-break-down-foggy",
+    "scenario": "Operator says: break this down. Two materially different architectures (event-sourced vs CRUD) are still live and nothing records a choice.",
+    "trigger": "explicit",
+    "expected_action": "chart-map",
+    "decision_graph": {
+      "architecture-style": {"deps": [], "resolved": false},
+      "sync-protocol": {"deps": ["architecture-style"], "resolved": false}
+    }
+  },
+  {
+    "id": "foggy-brief-architectures-live",
+    "scenario": "A brief for a large effort arrives with no explicit phrase; materially different runtime targets are still live and would produce incompatible work.",
+    "trigger": "auto",
+    "expected_action": "chart-map",
+    "decision_graph": {
+      "runtime-target": {"deps": [], "resolved": false},
+      "packaging": {"deps": ["runtime-target"], "resolved": false},
+      "telemetry-format": {"deps": [], "resolved": false}
+    }
+  },
+  {
+    "id": "backlog-guess-tickets",
+    "scenario": "Reviewing a backlog: tickets T-4 and T-9 both silently assume a session-token auth model, but the auth-model decision has never been made or recorded.",
+    "trigger": "auto",
+    "expected_action": "chart-map",
+    "decision_graph": {
+      "auth-model": {"deps": [], "resolved": false}
+    },
+    "fog_tickets": ["T-4", "T-9"]
+  },
+  {
+    "id": "resolved-effort-planning",
+    "scenario": "A large effort where every material decision is already resolved in recorded ADRs; the operator asks for an implementation plan.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "single-open-decision",
+    "scenario": "Exactly one decision is open (which queue library to adopt); everything else about the effort is settled.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "one-task-recon",
+    "scenario": "Pre-work recon is needed on a single task in unfamiliar territory before starting it.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "goal-shaping-request",
+    "scenario": "Operator asks: help me define what done means for this initiative — a finish line, proof, and stop rule.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "hard-neg-break-down-resolved",
+    "scenario": "Operator says: break this down into tickets. The design document resolves every material decision with provenance; no architectures remain live.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "hard-neg-stale-backlog",
+    "scenario": "Reviewing a backlog whose tickets are stale — outdated estimates, two duplicates — but every ticket traces to a resolved, linked decision; nothing encodes a guess.",
+    "trigger": "none",
+    "expected_action": "no-fire"
+  },
+  {
+    "id": "frontier-recompute-after-resolution",
+    "scenario": "A maintained map exists; the storage-engine decision just resolved. Recompute the frontier and work only decisions on it, recording provenance.",
+    "trigger": "state",
+    "expected_action": "work-frontier",
+    "decision_graph": {
+      "storage-engine": {"deps": [], "resolved": true},
+      "schema-shape": {"deps": ["storage-engine"], "resolved": false},
+      "api-surface": {"deps": ["schema-shape"], "resolved": false},
+      "backup-policy": {"deps": ["storage-engine"], "resolved": false}
+    }
+  },
+  {
+    "id": "fog-minted-ticket-pull",
+    "scenario": "Falsifiable-gate walk: open build ticket T-12 has an upstream ancestor, schema-shape, that is unresolved. The ticket was minted from fog.",
+    "trigger": "state",
+    "expected_action": "pull-ticket",
+    "ticket": "T-12",
+    "unresolved_ancestor": "schema-shape"
+  },
+  {
+    "id": "fog-free-region-mint",
+    "scenario": "A region is fog-free: storage-engine and schema-shape are both resolved and linked, and no unresolved decision upstream could invalidate a slice. Mint the build ticket.",
+    "trigger": "state",
+    "expected_action": "mint-ticket",
+    "resolved_lineage": ["storage-engine", "schema-shape"]
+  }
+]

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/results/BLOCKED.md
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/results/BLOCKED.md
@@ -1,0 +1,11 @@
+# Behavioral epoch: BLOCKED
+
+No live model epoch has been run against these fixtures (as of 2026-07-31).
+The committed artifacts are the deterministic scorer, the fixture inventory,
+and the polarity controls (one balanced example plus two parodies: overfiring,
+underfiring) exercised by `tests/run_tests.py`.
+
+A behavioral epoch requires dispatching a live agent per fixture scenario and
+scoring its structured responses; record the epoch here (date, harness,
+model, per-fixture outcomes) when one runs. Committing BLOCKED rather than
+claiming a pass is the house norm.

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/score.py
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/score.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Deterministic scorer for Wayfinding trigger discipline and map/frontier scope."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+
+ACTIONS = {"chart-map", "work-frontier", "pull-ticket", "mint-ticket", "no-fire"}
+RESOLVE_METHODS = {"derive", "research", "prototype", "ask"}
+
+
+def _frontier(graph: dict) -> set:
+    """A decision is frontier iff it is unresolved and every dependency is resolved."""
+    return {
+        name
+        for name, spec in graph.items()
+        if not spec.get("resolved")
+        and all(graph.get(dep, {}).get("resolved") for dep in spec.get("deps", []))
+    }
+
+
+def _nonempty_str(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def score(fixtures: list[dict], responses: list[dict]) -> dict:
+    failures: list[str] = []
+    by_id = {row.get("id"): row for row in responses if isinstance(row, dict)}
+    if len(by_id) != len(responses):
+        failures.append("response ids missing or duplicated")
+    actions: Counter = Counter()
+    for fixture in fixtures:
+        fid = fixture["id"]
+        row = by_id.get(fid)
+        if row is None:
+            failures.append(f"{fid}: response missing")
+            continue
+        action = row.get("action")
+        actions[action] += 1
+        expected = fixture["expected_action"]
+        if action not in ACTIONS:
+            failures.append(f"{fid}: unknown action {action!r}")
+            continue
+        if action != expected:
+            failures.append(f"{fid}: expected {expected}, got {action}")
+            continue
+        graph = fixture.get("decision_graph", {})
+        if expected == "no-fire":
+            if row.get("map_artifact") or row.get("minted_tickets") or row.get("visible_process"):
+                failures.append(f"{fid}: no-fire must be silent — no map, no tickets, no process artifact")
+        elif expected == "chart-map":
+            if not _nonempty_str(row.get("map_artifact")):
+                failures.append(f"{fid}: chart-map requires one durable map artifact in the tracker")
+            nodes = row.get("nodes", [])
+            node_ids = {n.get("decision") for n in nodes if isinstance(n, dict)}
+            if node_ids != set(graph):
+                failures.append(f"{fid}: map nodes must be exactly the decisions — expected {sorted(graph)}, got {sorted(node_ids - {None})}")
+            for node in nodes:
+                if not isinstance(node, dict) or node.get("resolve_by") not in RESOLVE_METHODS:
+                    failures.append(f"{fid}: every decision node names its cheapest resolution method (derive/research/prototype/ask)")
+                    break
+            if set(row.get("frontier", [])) != _frontier(graph):
+                failures.append(f"{fid}: frontier wrong — expected {sorted(_frontier(graph))}, got {sorted(set(row.get('frontier', [])))}")
+            if row.get("minted_tickets"):
+                failures.append(f"{fid}: tickets minted from fog — unresolved decisions remain upstream")
+            fog_tickets = set(fixture.get("fog_tickets", []))
+            if fog_tickets and not fog_tickets <= set(row.get("pulled_tickets", [])):
+                failures.append(f"{fid}: guess-encoding tickets must be pulled back to the map — missing {sorted(fog_tickets - set(row.get('pulled_tickets', [])))}")
+        elif expected == "work-frontier":
+            frontier = _frontier(graph)
+            if set(row.get("frontier", [])) != frontier:
+                failures.append(f"{fid}: recomputed frontier wrong — expected {sorted(frontier)}, got {sorted(set(row.get('frontier', [])))}")
+            worked = row.get("worked", [])
+            if not worked:
+                failures.append(f"{fid}: at least one frontier decision must be worked")
+            off_frontier = set(worked) - frontier
+            if off_frontier:
+                failures.append(f"{fid}: non-frontier decision worked {sorted(off_frontier)} — its answer will be re-litigated")
+            recorded = {r.get("decision"): r for r in row.get("resolutions", []) if isinstance(r, dict)}
+            for decision in worked:
+                entry = recorded.get(decision)
+                if not entry or not _nonempty_str(entry.get("provenance")):
+                    failures.append(f"{fid}: resolution of {decision!r} must be recorded on the map with provenance")
+        elif expected == "pull-ticket":
+            if fixture["ticket"] not in set(row.get("pulled_tickets", [])):
+                failures.append(f"{fid}: fog-minted ticket {fixture['ticket']!r} must be pulled back to the map")
+            if row.get("unresolved_ancestor") != fixture["unresolved_ancestor"]:
+                failures.append(f"{fid}: the unresolved upstream ancestor must be named — expected {fixture['unresolved_ancestor']!r}")
+            if row.get("minted_tickets"):
+                failures.append(f"{fid}: no new tickets while an unresolved ancestor stands")
+        elif expected == "mint-ticket":
+            ticket = row.get("ticket")
+            if not isinstance(ticket, dict):
+                failures.append(f"{fid}: mint-ticket requires a ticket object carrying the three-fact handoff")
+                continue
+            if set(ticket.get("depends_on", [])) != set(fixture.get("resolved_lineage", [])):
+                failures.append(f"{fid}: ticket must link exactly its resolved decision lineage {sorted(fixture.get('resolved_lineage', []))}")
+            if not _nonempty_str(ticket.get("observable_behavior")):
+                failures.append(f"{fid}: ticket must state the observable behavior proving the slice works end-to-end")
+            if not _nonempty_str(ticket.get("invalidating_decision")):
+                failures.append(f"{fid}: ticket must name the upstream decision whose reversal invalidates it, or 'none'")
+    return {"pass": not failures, "failures": failures, "actions": dict(actions)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("responses", type=Path)
+    parser.add_argument("--fixtures", type=Path, default=Path(__file__).resolve().parent / "fixtures.json")
+    args = parser.parse_args()
+    fixtures = json.loads(args.fixtures.read_text(encoding="utf-8"))
+    responses = json.loads(args.responses.read_text(encoding="utf-8"))
+    report = score(fixtures, responses)
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/tests/run_tests.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Polarity tests for Wayfinding trigger discipline and map/frontier scope."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(condition: bool, message: object) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    score_path = ROOT / "score.py"
+    require(score_path.is_file(), f"missing Wayfinding trigger-and-scope scorer: {score_path}")
+    spec = importlib.util.spec_from_file_location("wayfinding_scope", score_path)
+    scorer = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scorer)
+    fixtures = json.loads((ROOT / "fixtures.json").read_text(encoding="utf-8"))
+    require([f["id"] for f in fixtures] == [
+        "explicit-chart-initiative", "explicit-break-down-foggy", "foggy-brief-architectures-live",
+        "backlog-guess-tickets", "resolved-effort-planning", "single-open-decision",
+        "one-task-recon", "goal-shaping-request", "hard-neg-break-down-resolved",
+        "hard-neg-stale-backlog", "frontier-recompute-after-resolution",
+        "fog-minted-ticket-pull", "fog-free-region-mint",
+    ], "Wayfinding fixture inventory drifted")
+
+    balanced = scorer.score(fixtures, json.loads((ROOT / "examples" / "balanced.json").read_text(encoding="utf-8")))
+    require(balanced["pass"], balanced["failures"])
+    require(balanced["actions"] == {"chart-map": 4, "no-fire": 6, "work-frontier": 1, "pull-ticket": 1, "mint-ticket": 1}, balanced["actions"])
+
+    for name in ("overfiring", "underfiring"):
+        report = scorer.score(fixtures, json.loads((ROOT / "examples" / f"{name}.json").read_text(encoding="utf-8")))
+        require(not report["pass"], f"{name} parody unexpectedly passed")
+    over = scorer.score(fixtures, json.loads((ROOT / "examples" / "overfiring.json").read_text(encoding="utf-8")))
+    require(any("expected no-fire, got chart-map" in failure for failure in over["failures"]), over["failures"])
+    under = scorer.score(fixtures, json.loads((ROOT / "examples" / "underfiring.json").read_text(encoding="utf-8")))
+    require(any("expected chart-map, got no-fire" in failure for failure in under["failures"]), under["failures"])
+    require(any("expected pull-ticket, got no-fire" in failure for failure in under["failures"]), under["failures"])
+
+    print("Wayfinding trigger-and-scope: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

**#70 (authoring half):** deterministic trigger-and-scope batteries for `context-audit` (14 fixtures), `agent-interface-design` (14), `wayfinding` (13), `throwaway-prototyping` (12), `intent-traced-merge` (13) — 66 fixtures total, each battery in the open-questions house shape: stdlib-only scorer, balanced example + over/under-firing parody polarity controls (scorer must reject both), results/BLOCKED.md recording honestly that no live behavioral epoch has run. Wired into CI (5 workflow steps + lint list) and asserted by the package integration test. Independent fresh-eyes verifier PASS: parodies re-executed via each scorer CLI with substantive failure strings, fixtures spot-checked against frontmatter triggers, zero fleet terms, zero wall-clock calls, all files LF.

**#72 (all four items):**
1. Migration erratum in RELEASE-3.4.0.md (the uat oracle-honesty rows *tighten* the acceptance gate — named explicitly).
2. `docs/release/PROVENANCE-3.4.0.md` — ConnorGriffin/skills pinned @ `04c2630297d3...`, synthesis doc pinned by sha256, Shihipar coordinates recorded.
3. **Live-surface count lint** in the integration test: walks every nested string of all 11 manifests + README mermaid + GEMINI for spelled counts near skill/discipline wording, derived from the actual skill-dir count. **Positive-controlled**: a planted stale count fails the suite; clean state passes. (The first draft passed while structurally unable to fire — an escaping bug had turned `\b` into literal backspace bytes — and only the plant-a-defect control exposed it. The control is the point.)
4. README catalog wording reconciled with the wiki-precedence rule.

## Honest limits
Batteries are structural/trigger-level — NOT behavioral proof. #70 stays open for the behavioral-epoch half per its exit criterion; #72 closes fully.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJ6DX41C4XuXJUoQa7ifr3