### PR TITLE
feat(helix): compose the complete epistemic set

### DIFF
--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -34,6 +34,8 @@ jobs:
         run: python plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/run_tests.py
       - name: Blinded proportionality packet tests
         run: python plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/blinded/tests/run_tests.py
+      - name: Helix composition contract tests
+        run: python plugins/epistemic-skills/skills/helix/evals/composition/tests/run_tests.py
       - name: Formal-rigor v2 structural scorer self-test
         run: python plugins/epistemic-skills/skills/applying-formal-rigor/evals/formal-rigor-v2-fixtures/tests/run_tests.py
       - name: Formal-rigor focused proportionality test
@@ -84,6 +86,8 @@ jobs:
             plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/run_tests.py \
             plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/blinded/runner.py \
             plugins/epistemic-skills/skills/using-epistemic-skills/evals/proportionality/blinded/tests/run_tests.py \
+            plugins/epistemic-skills/skills/helix/evals/composition/verify.py \
+            plugins/epistemic-skills/skills/helix/evals/composition/tests/run_tests.py \
             plugins/epistemic-skills/skills/applying-formal-rigor/evals/formal-rigor-v2-fixtures/score.py \
             plugins/epistemic-skills/skills/applying-formal-rigor/evals/formal-rigor-v2-fixtures/tests/run_tests.py \
             plugins/epistemic-skills/skills/applying-formal-rigor/evals/formal-rigor-v2-fixtures/tests/test_focused.py \

--- a/plugins/epistemic-skills/skills/helix/SKILL.md
+++ b/plugins/epistemic-skills/skills/helix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: helix
-description: "Use when both a workflow-skill layer (such as superpowers) and the epistemic-skills collection are installed, the task has not cleared the routine-work fast path, and a workflow stage has a positive epistemic pairing trigger; when work is crossing to an external model, agent, or process; or when sequencing the two collections is ambiguous. Not for single-collection routing, routine reversible work, or emitting inventories of absent pairs."
+description: "Use when both a workflow-skill layer (such as superpowers) and the epistemic-skills collection are installed, the task has not cleared the routine-work fast path, and a workflow stage has a positive epistemic pairing trigger; when a resumed workflow depends on summary, handoff, or remembered state; when work is crossing to an external model, agent, or process; or when sequencing the two collections is ambiguous. Not for single-collection routing, fresh routine reversible work, or emitting inventories of absent pairs."
 ---
 
 # helix — two strands, one axis
@@ -19,11 +19,21 @@ each stage of one strand binds to a specific member of the other, and the
 task is the axis both wind around. This skill tells you which member pairs
 with which stage, in what position — and nothing else. **It never routes
 within a collection** — `using-superpowers` and `using-epistemic-skills`
-remain the routers; read the skill this map pairs you to.
+remain the routers; read every skill this map pairs you to.
 
-## Routine path comes first
+## Entry order: resumption, then routine path
 
-Apply `using-epistemic-skills/reference/routine-fast-path.md` before pairing.
+A resumed task is not yet eligible for the routine fast path when its next
+action depends on a compaction summary, handoff note, or remembered prior-session
+state. Run **continuity-verify first**, before routine-path classification or any
+resumed workflow stage. Its live state digest feeds `using-epistemic-skills`,
+which then applies the routine gate and routes the verified task. When unfamiliar
+territory also has a positive reconnaissance trigger, the order is
+**continuity-verify → blindspot-pass**; continuity verifies remembered state,
+then recon maps the present territory.
+
+For a fresh task, or after the resumption digest exists, apply
+`using-epistemic-skills/reference/routine-fast-path.md` before ordinary pairing.
 A reversible, local, directly checkable, non-precedential task proceeds through
 ordinary workflow with no epistemic pair, no `helix-check` line, and no process-
 only artifact. Unfamiliar routine-looking work gets the two-read micro-recon;
@@ -45,6 +55,7 @@ are silent.
 
 | Workflow stage | Epistemic pair | Position |
 |---|---|---|
+| session start/resumption whose next action depends on summary, handoff, or remembered state | **continuity-verify** | *pre-arc* — before routine-path classification and every resumed workflow stage; its digest feeds the epistemic router |
 | task start after routine micro-recon reveals a material map/territory mismatch, unresolved hidden coupling, or costly fan-out risk | **blindspot-pass** | *before* brainstorming — full recon the territory, then design |
 | brainstorming (a material ≥2-option design choice) | **applying-formal-rigor** | *inside* — the choice is derived from named theory, not asserted |
 | any stage (a premise leans on "research says…", or any scholarly-tool call) | **evidence-research** | *cross-cutting* — reception-check the literature before the premise bears load |
@@ -57,28 +68,60 @@ are silent.
 | writing-skills / instruction-layer maintenance (explicit audit request, a detected cross-layer instruction conflict, or a model-generation upgrade) | **context-audit** | *outside the per-task arc* — audit the assembled instruction context as one set; report before apply, one version-controlled commit per cut class |
 | writing-plans (the effort is large and material decisions are still unresolved) | **wayfinding** | *before* planning — decompose by decisions, resolve the frontier, and plan only fog-free regions; tickets minted from fog are the failure the pairing prevents |
 | brainstorming (a live option is cheaper to build thin than to keep debating) | **throwaway-prototyping** | *inside* — instantiate the option as a disposable probe under the four-clause contract; the answer returns to the design dialogue, the code does not |
+| any stage, immediately after a consequential decision, load-bearing assumption, or recurrent/operator correction (per decision-ledger's own positive and no-op gates) | **decision-ledger** | *retrospective cross-cutting* — reuse an adequate durable artifact or append only the uncovered persistence gap; never log before the moment exists |
 | finishing-a-development-branch / any merge or rebase with non-trivial conflicts | **intent-traced-merge** | *at integration* — resolve hunks by tracing both origins, verify against both sides' motivating checks, record rulings in the merge commit |
 | receiving-code-review (acceptance about to be signed on a change the acceptor has not restated) | **evidence-locked-uat** acceptor comprehension gate | *at acceptance* — the acceptor states what changed and what breaks first if it's wrong, or the state is recorded `ACCEPTED-UNREVIEWED`, never silently upgraded |
 | systematic-debugging (fix rests on a complexity or correctness claim) | **applying-formal-rigor** | *inside* — "this is O(n log n) now" and "this can't race" are derived, not asserted |
 | verification-before-completion (material UI-facing acceptance surface) | **evidence-locked-uat** | *is* that skill's UI-facing instance — blinded verifier, never self-certification; routine directly checkable presentation changes use the bounded check instead of a full packet |
 | finishing-a-development-branch (per gauntlet's own positive trigger list) | **gauntlet** | *pre-merge* — after the user selects merge or push+PR, before the merge/push executes |
 | receiving-code-review (feedback asserts a material design claim or proposes an alternative) | **applying-formal-rigor** | *inside* — derive the claim from named theory before implementing it or pushing back on it |
-| any gated stage outside active design dialogue (operator explicitly asks to be interviewed until no open questions remain; while a design skill is running, that skill owns its own questioning) | **open-questions** | *before* the gated stage — the ledger empties (or parks on operator release), then the stage proceeds |
+| any gated stage outside active design dialogue (per open-questions' member-authoritative trigger) | **open-questions** | *before* the gated stage — explicit invocation uses full-exhaustion mode; the narrow automatic trigger uses fork-scoped mode; while a design skill is running, that skill owns its own questioning |
 | any workflow stage not listed above | *(none mandatory)* | disciplines still fire on their own standalone positive triggers — the member skill, not helix, remains authoritative |
 
-Positions mean exactly what they say: *before* = the epistemic output is an
-input to the stage; *inside* = the stage pauses at the decision point, runs
-the discipline, and resumes with its verdict; *at approval* / *pre-merge* =
-the stage's exit gate; *cross-cutting* = called at the moment a qualifying
-premise appears, at any stage; *is* = the workflow stage and the discipline
-are the same act for that surface — running the stage under that surface
-condition means running the discipline.
+Positions mean exactly what they say: *pre-arc* = before the routine gate and
+any resumed-work stage; *before* = the epistemic output is an input to the
+stage; *inside* = the stage pauses at the decision point, runs the discipline,
+and resumes with its verdict; *retrospective cross-cutting* = the discipline
+fires immediately after the qualifying moment, never as a prerequisite;
+*at approval* / *pre-merge* = the stage's exit gate; *cross-cutting* = called
+at the moment a qualifying premise appears, at any stage; *is* = the workflow
+stage and the discipline are the same act for that surface — running the stage
+under that surface condition means running the discipline.
 
-The cross-cutting epistemic-flexibility controls do not add rows to this table. They are
-checked **inside the existing pair** that consumes them: claim/source separation in recon
-and resumption; priority/proxy separation in goal authoring; preregistration in formal
-claims and UAT; failure chains when a recurring correction is persisted; closure control
-wherever evidence remains insufficient.
+## Composition contract: route the whole set
+
+The machine-checkable registry at
+[`reference/composition-contract.json`](reference/composition-contract.json)
+classifies every packaged discipline by composition moment and position without
+copying its member trigger. **The member skill owns its trigger.**
+`using-epistemic-skills` selects the complete **zero, one, or ordered set** of
+positive epistemic fires; Helix positions that whole set around the workflow
+stage and carries order custody. A table row is never permission to choose one
+pair and discard another positive member trigger.
+
+When multiple disciplines fire, follow the router's arc and the registry's
+context-bound order rules. The most important combined paths are:
+
+- `continuity-verify → blindspot-pass` when resumed state and unfamiliar
+  territory both bear load;
+- formal rigor names an empirical premise, evidence research qualifies it,
+  then formal rigor closes the derivation;
+- `intent-traced-merge → gauntlet` when a high-risk branch first needs semantic
+  conflict resolution and then a frozen pre-merge verdict; and
+- `gauntlet → evidence-locked-uat` when the same change needs both a high-risk
+  gate and material UI proof.
+
+The registry is a composition contract, not a second trigger table. If its
+classification and a member skill ever appear to conflict, the member owns
+whether it fires; the router owns the full selected set; Helix owns only where
+that set sits relative to workflow execution.
+
+The cross-cutting epistemic-flexibility controls do not add rows to the pairing
+table or registry. They are checked **inside the existing pair** that consumes
+them: claim/source separation in recon and resumption; priority/proxy separation
+in goal authoring; preregistration in formal claims and UAT; failure chains when
+a recurring correction is persisted; closure control wherever evidence remains
+insufficient.
 
 ## Co-fire record
 
@@ -91,13 +134,18 @@ When an authorized operator explicitly overrides a positive trigger, emit:
 `helix-check: <stage> → <pair> → overridden(<authority-ref>: <bounded reason>)`
 
 Do **not** emit a line for an absent trigger, a `(none mandatory)` row, or a task
-that cleared the routine path. The member skill's own output is the record for a
-single fired pair; `helix-check` carries stage-order custody where that
+that cleared the fresh routine path. The member skill's own output is the record
+for a single fired pair; `helix-check` carries stage-order custody where that
 relationship matters.
 
+- **A resumed workflow depends on remembered state.** Run continuity-verify
+  before the routine gate or any resumed workflow skill. If recon also fires,
+  record both artifacts in `continuity-verify → blindspot-pass` order.
 - **A workflow stage has a positive epistemic trigger.** Run the member in its
   position and reference its output. Do not re-implement or soften the member's
   trigger here.
+- **More than one epistemic member has a positive trigger.** Ask the epistemic
+  router for the complete ordered set; do not select a single favorite pair.
 - **brainstorming is starting after routine micro-recon exposed a mismatch** →
   run blindspot-pass before design.
 - **a material design choice is being argued** → applying-formal-rigor owns the
@@ -120,25 +168,24 @@ relationship matters.
 - **a material UI acceptance claim is about to be made** → the stage is
   evidence-locked-uat. A routine directly checkable presentation edit records
   its bounded preview/test result without constructing the full UAT container.
-- **a recurring failure was corrected and future work will rely on the lesson**
-  → decision-ledger persists it unless an existing durable artifact already
-  satisfies the consumption contract.
+- **a consequential decision, load-bearing assumption, or recurrent/operator
+  correction was just made and future work will rely on it** → decision-ledger
+  reuses the existing durable record when adequate or persists only the gap.
 - **evidence is insufficient at a load-bearing boundary** → choose hold,
   escalate, or a reversible probe; do not continue reasoning merely to
   manufacture `proceed`.
 - **a branch is about to merge** → use gauntlet's own trigger list; the member
-  gate, not helix shorthand, decides.
-- **the operator asks to answer the open questions one by one** → open-questions
-  conducts the interview before the gated stage resumes; blindspot-pass's
-  Questions section, when present, seeds the ledger. Presence alone never
-  fires it, and while a design skill's own dialogue is active, open-questions
-  defers to that skill's questioning.
+  gate, not Helix shorthand, decides.
+- **open-questions fires** → preserve its **explicit full-exhaustion mode and
+  automatic fork-scoped mode**. Blindspot-pass's Questions section may seed the
+  ledger, but its presence alone never fires an interview; while active design
+  dialogue owns questioning, open-questions defers.
 - **An epistemic discipline fired standalone.** Ask which workflow stage
   consumes its output. An epistemic output no workflow stage consumes is a
   report no one reads.
 
-Fire-nothing is a valid outcome. A routine task pairs zero disciplines with
-zero ceremony and emits no proof that it did so.
+Fire-nothing is a valid outcome. A fresh routine task pairs zero disciplines
+with zero ceremony and emits no proof that it did so.
 
 ## Any harness, any layer
 
@@ -147,11 +194,11 @@ means whatever your harness does — description-triggered skill loading,
 a context-file include, or pasting the file into the loop.
 
 - **If your harness auto-triggers by description** (Claude Code, Cursor,
-  Codex): the routine gate prevents the mere presence of both layers from
-  turning task start into a pairing event.
+  Codex): the entry-order rule prevents both layers from turning fresh task
+  start into ceremony while still making resumption verification pre-arc.
 - **If your harness loads one context file** (Gemini CLI via GEMINI.md, or
-  similar): the collection's context file names helix as the tandem entry
-  point; apply the routine gate before the map.
+  similar): the collection's context file names Helix as the tandem entry
+  point; apply resumption verification first, then the routine gate and map.
 - **If nothing auto-triggers**: the path in is `using-epistemic-skills`,
   which points here whenever a workflow layer and a positive pair are present.
 - **If your workflow layer is not superpowers** (Kimi, agy, a house style,
@@ -164,10 +211,12 @@ a context-file include, or pasting the file into the loop.
 
 | Thought | Reality |
 |---|---|
-| "Both layers are installed — check every pair at every stage" | Ceremony. The routine gate and positive member triggers govern; absent pairs are silent. |
+| "Both layers are installed — check every pair at every stage" | Ceremony. Resumption state, the routine gate, and positive member triggers govern; absent pairs are silent. |
+| "The routine gate comes before continuity verification" | Not on resumption. You cannot classify remembered work as routine until the load-bearing state is re-anchored. |
+| "The table gave me one pair, so I can ignore the other positive triggers" | The router selects the complete ordered set; Helix positions every member that actually fires. |
 | "I'll emit skipped lines so reviewers know I was rigorous" | A skip inventory is process as proxy. Record fired pairs and authorized overrides only. |
 | "I'll do the workflow stage first and add the epistemic check after" | Backwards when a positive pair exists. Recon after design is archaeology. |
-| "helix told me which skill; I know roughly what it does" | helix only pairs. Read the paired skill; the discipline lives there. |
+| "Helix told me which skill; I know roughly what it does" | Helix only pairs. Read the paired skill; the discipline lives there. |
 | "This replaces the two routers" | It sits between them. Member-level routing stays in `using-superpowers` and `using-epistemic-skills`. |
 | "Superpowers isn't installed, so none of this applies" | The pairings are stage-shaped. Map them to whatever workflow steps the session actually has. |
 | "A short prompt is enough for an external model" | Only after `outsource` makes the repository packet complete, pushed, and reachable. Shortness belongs in the pointer, not the context. |
@@ -178,4 +227,5 @@ a context-file include, or pasting the file into the loop.
 If a `LOCAL.md` exists alongside this SKILL.md, read it after this file — it
 binds the pairings to the local environment (which harness auto-fires which
 stage, local workflow-layer names, fleet-specific gates). An overlay may add
-bindings; it never overrides the pairing map or require absent-trigger records.
+bindings; it never overrides the pairing map, the composition contract, or
+require absent-trigger records.

--- a/plugins/epistemic-skills/skills/helix/evals/composition/README.md
+++ b/plugins/epistemic-skills/skills/helix/evals/composition/README.md
@@ -1,0 +1,24 @@
+# Helix composition contract checks
+
+This battery protects the cross-collection composition surface rather than testing any member discipline's internal method.
+
+It verifies that:
+
+- every packaged epistemic discipline has exactly one composition classification;
+- member skills remain authoritative for their own positive and negative triggers;
+- `using-epistemic-skills` selects the complete zero/one/ordered set while Helix owns workflow-stage position and order custody;
+- Continuity Verify is pre-arc and precedes routine-path classification on resumption;
+- Decision Ledger remains retrospective and covers decisions, assumptions, and recurrent/operator corrections without duplicating adequate durable artifacts;
+- Open Questions preserves both explicit full-exhaustion and automatic fork-scoped modes;
+- the required continuity→recon, recon→derivation, integration→gate, and gate→proof order rules remain present and scoped to their named lineage; and
+- the human-readable `SKILL.md` still exposes the load-bearing contract markers.
+
+The test suite includes planted mutations for every high-risk omission. A clean contract must pass; deleting Continuity Verify, narrowing Decision Ledger, dropping Open Questions auto-fire, reversing Gauntlet/UAT, erasing an order rule's lineage condition, assigning triggers to Helix, or adding an unclassified future skill must fail.
+
+Run:
+
+```bash
+python tests/run_tests.py
+```
+
+This is a deterministic structural and mutation-sensitivity check. It does not establish that a live model or harness invokes Helix correctly; that remains a behavioral evaluation question.

--- a/plugins/epistemic-skills/skills/helix/evals/composition/results/BLOCKED.md
+++ b/plugins/epistemic-skills/skills/helix/evals/composition/results/BLOCKED.md
@@ -1,0 +1,7 @@
+# Behavioral epoch status
+
+No live model/harness behavioral epoch has been run for the Helix composition contract.
+
+The committed suite verifies source-level completeness, ordering invariants, and mutation sensitivity. It does **not** measure live trigger recall, over-firing, or whether a particular harness reliably loads Helix and the member skill at the intended boundary.
+
+A future behavioral epoch should pin model, harness, installed skill revision, prompt set, and settings; compare the skilled contract against at least an unpaired baseline and planted over/under-firing parodies; and score both missed positive pairings and unnecessary ceremony. Until then, behavioral effectiveness is `NOT_RUN`, not inferred from the structural PASS.

--- a/plugins/epistemic-skills/skills/helix/evals/composition/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/helix/evals/composition/tests/run_tests.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Mutation-sensitive tests for the Helix composition contract."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELIX_ROOT = Path(__file__).resolve().parents[3]
+SKILLS_ROOT = Path(__file__).resolve().parents[4]
+
+
+def require(condition: bool, message: object) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_failure(
+    verifier,
+    name: str,
+    contract: dict,
+    discovered: set[str],
+    skill_text: str,
+    needle: str,
+) -> None:
+    report = verifier.validate(contract, discovered, skill_text)
+    require(not report["pass"], f"{name} mutation unexpectedly passed")
+    require(any(needle in failure for failure in report["failures"]), report["failures"])
+
+
+def main() -> int:
+    verify_path = ROOT / "verify.py"
+    require(verify_path.is_file(), f"missing Helix composition verifier: {verify_path}")
+    spec = importlib.util.spec_from_file_location("helix_composition", verify_path)
+    verifier = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(verifier)
+
+    contract = json.loads(
+        (HELIX_ROOT / "reference" / "composition-contract.json").read_text(encoding="utf-8")
+    )
+    skill_text = (HELIX_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    discovered = verifier.discover_members(SKILLS_ROOT)
+
+    clean = verifier.validate(contract, discovered, skill_text)
+    require(clean["pass"], clean["failures"])
+    require(clean["member_count"] == len(discovered), clean)
+    require(clean["order_rules"] >= len(verifier.REQUIRED_ORDER_RULES), clean)
+
+    missing_continuity = copy.deepcopy(contract)
+    del missing_continuity["members"]["continuity-verify"]
+    expect_failure(
+        verifier,
+        "missing-continuity",
+        missing_continuity,
+        discovered,
+        skill_text,
+        "member classification mismatch",
+    )
+
+    helix_owns_triggers = copy.deepcopy(contract)
+    helix_owns_triggers["trigger_authority"] = "helix"
+    expect_failure(
+        verifier,
+        "trigger-authority-drift",
+        helix_owns_triggers,
+        discovered,
+        skill_text,
+        "trigger-authoritative",
+    )
+
+    routine_before_resume = copy.deepcopy(contract)
+    routine_before_resume["routine_policy"]["resumption_precedes_routine_classification"] = False
+    expect_failure(
+        verifier,
+        "resumption-order-drift",
+        routine_before_resume,
+        discovered,
+        skill_text,
+        "precede routine-path classification",
+    )
+
+    narrowed_ledger = copy.deepcopy(contract)
+    narrowed_ledger["members"]["decision-ledger"]["moments"].remove("load-bearing-assumption")
+    expect_failure(
+        verifier,
+        "decision-ledger-narrowing",
+        narrowed_ledger,
+        discovered,
+        skill_text,
+        "decisions, assumptions",
+    )
+
+    explicit_only_questions = copy.deepcopy(contract)
+    explicit_only_questions["members"]["open-questions"]["modes"] = ["explicit-full-exhaustion"]
+    expect_failure(
+        verifier,
+        "open-questions-explicit-only",
+        explicit_only_questions,
+        discovered,
+        skill_text,
+        "automatic fork-scoped",
+    )
+
+    reversed_gate_prove = copy.deepcopy(contract)
+    for rule in reversed_gate_prove["required_order_rules"]:
+        if rule.get("id") == "gate-before-ui-proof":
+            rule["before"], rule["after"] = rule["after"], rule["before"]
+            break
+    else:
+        raise AssertionError("gate-before-ui-proof rule missing from clean contract")
+    expect_failure(
+        verifier,
+        "gate-prove-reversal",
+        reversed_gate_prove,
+        discovered,
+        skill_text,
+        "order rule gate-before-ui-proof drifted",
+    )
+
+    globalized_order = copy.deepcopy(contract)
+    for rule in globalized_order["required_order_rules"]:
+        if rule.get("id") == "task-start-recon-before-design-derivation":
+            rule["when"] = "always"
+            break
+    else:
+        raise AssertionError("task-start-recon-before-design-derivation rule missing from clean contract")
+    expect_failure(
+        verifier,
+        "context-erased-from-order",
+        globalized_order,
+        discovered,
+        skill_text,
+        "order rule task-start-recon-before-design-derivation drifted",
+    )
+
+    expect_failure(
+        verifier,
+        "future-member-unclassified",
+        contract,
+        discovered | {"future-discipline"},
+        skill_text,
+        "member classification mismatch",
+    )
+
+    expect_failure(
+        verifier,
+        "human-map-lost-registry-pointer",
+        contract,
+        discovered,
+        skill_text.replace("reference/composition-contract.json", "reference/removed.json"),
+        "registry pointer",
+    )
+
+    expect_failure(
+        verifier,
+        "ordered-set-collapsed-to-single-pair",
+        contract,
+        discovered,
+        skill_text.replace("zero, one, or ordered set", "one selected pair"),
+        "ordered-set handshake",
+    )
+
+    print("Helix composition contract: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/helix/evals/composition/verify.py
+++ b/plugins/epistemic-skills/skills/helix/evals/composition/verify.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Validate Helix's machine-checkable cross-collection composition contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+SCHEMA = "helix-composition-contract@1"
+ROUTER = "using-epistemic-skills"
+HELIX = "helix"
+REQUIRED_MEMBER_FIELDS = {"composition_class", "moments", "position"}
+REQUIRED_ORDER_RULES = {
+    "resumption-before-recon": {
+        "when": "same-resumption-lineage",
+        "before": "continuity-verify",
+        "after": "blindspot-pass",
+    },
+    "task-start-recon-before-design-derivation": {
+        "when": "same-design-lineage-after-micro-recon-mismatch",
+        "before": "blindspot-pass",
+        "after": "applying-formal-rigor",
+    },
+    "conflict-resolution-before-pre-merge-gate": {
+        "when": "same-branch-pre-merge-lineage",
+        "before": "intent-traced-merge",
+        "after": "gauntlet",
+    },
+    "gate-before-ui-proof": {
+        "when": "same-change-needs-gate-and-material-ui-proof",
+        "before": "gauntlet",
+        "after": "evidence-locked-uat",
+    },
+}
+REQUIRED_INTERLOCK = (
+    frozenset({"applying-formal-rigor", "evidence-research"}),
+    "formal-names-empirical-premise-research-qualifies-formal-closes",
+)
+REQUIRED_TEXT_MARKERS = {
+    "registry pointer": "reference/composition-contract.json",
+    "ordered-set handshake": "zero, one, or ordered set",
+    "member trigger authority": "the member skill owns its trigger",
+    "resumption order": "continuity-verify → blindspot-pass",
+    "decision persistence breadth": "consequential decision, load-bearing assumption, or recurrent/operator correction",
+    "open-questions modes": "explicit full-exhaustion mode and automatic fork-scoped mode",
+    "gate/prove order": "gauntlet → evidence-locked-uat",
+    "context-bound ordering": "context-bound order rules",
+}
+
+
+def discover_members(skills_root: Path) -> set[str]:
+    """Discover every packaged skill that Helix must classify."""
+    return {
+        skill_file.parent.name
+        for skill_file in skills_root.glob("*/SKILL.md")
+        if skill_file.parent.name not in {ROUTER, HELIX}
+    }
+
+
+def _nonempty_strings(value: object) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(item, str) and item.strip() for item in value)
+    )
+
+
+def validate(contract: object, discovered_members: set[str], skill_text: str) -> dict:
+    failures: list[str] = []
+    if not isinstance(contract, dict):
+        return {"pass": False, "failures": ["contract root must be an object"], "member_count": 0}
+
+    if contract.get("schema") != SCHEMA:
+        failures.append(f"schema must be {SCHEMA}")
+    if contract.get("trigger_authority") != "member":
+        failures.append("member skills, not Helix, must remain trigger-authoritative")
+    if contract.get("selection_owner") != ROUTER:
+        failures.append("the epistemic router must select the complete zero/one/ordered set")
+    if contract.get("position_owner") != HELIX:
+        failures.append("Helix must own cross-collection position and order custody")
+
+    routine = contract.get("routine_policy")
+    if not isinstance(routine, dict):
+        failures.append("routine_policy must be an object")
+    else:
+        if routine.get("fresh_routine_path") != "silent":
+            failures.append("fresh routine work must remain record-free and silent")
+        if routine.get("resumption_precedes_routine_classification") is not True:
+            failures.append("resumption verification must precede routine-path classification")
+
+    members = contract.get("members")
+    if not isinstance(members, dict):
+        failures.append("members must be an object")
+        members = {}
+    contract_members = set(members)
+    missing = sorted(discovered_members - contract_members)
+    extra = sorted(contract_members - discovered_members)
+    if missing or extra:
+        failures.append(f"member classification mismatch: missing={missing} extra={extra}")
+
+    for name, row in members.items():
+        if not isinstance(row, dict):
+            failures.append(f"{name}: composition entry must be an object")
+            continue
+        absent_fields = sorted(REQUIRED_MEMBER_FIELDS - set(row))
+        if absent_fields:
+            failures.append(f"{name}: missing fields {absent_fields}")
+        if not (isinstance(row.get("composition_class"), str) and row["composition_class"].strip()):
+            failures.append(f"{name}: composition_class must be a non-empty string")
+        if not _nonempty_strings(row.get("moments")):
+            failures.append(f"{name}: moments must be a non-empty list of strings")
+        if not (isinstance(row.get("position"), str) and row["position"].strip()):
+            failures.append(f"{name}: position must be a non-empty string")
+
+    continuity = members.get("continuity-verify", {})
+    if continuity.get("composition_class") != "pre-arc" or continuity.get("position") != "before":
+        failures.append("continuity-verify must be classified pre-arc and before")
+    if set(continuity.get("precedes_boundaries", [])) != {"routine-classification", "workflow-stage"}:
+        failures.append("continuity-verify must precede routine classification and every resumed workflow stage")
+    if "resumption" not in continuity.get("moments", []):
+        failures.append("continuity-verify must classify the resumption moment")
+
+    ledger = members.get("decision-ledger", {})
+    if ledger.get("composition_class") != "retrospective-cross-cutting" or ledger.get("position") != "after":
+        failures.append("decision-ledger must be retrospective-cross-cutting and after the moment")
+    required_ledger_moments = {
+        "consequential-decision",
+        "load-bearing-assumption",
+        "recurrent-or-operator-correction",
+    }
+    if not required_ledger_moments <= set(ledger.get("moments", [])):
+        failures.append("decision-ledger must cover decisions, assumptions, and recurrent/operator corrections")
+    if set(ledger.get("persistence_modes", [])) != {
+        "reuse-existing-durable-artifact",
+        "append-gap-only",
+    }:
+        failures.append("decision-ledger must reuse adequate artifacts and append only uncovered gaps")
+
+    questions = members.get("open-questions", {})
+    if set(questions.get("modes", [])) != {
+        "explicit-full-exhaustion",
+        "automatic-fork-scoped",
+    }:
+        failures.append("open-questions must preserve explicit full-exhaustion and automatic fork-scoped modes")
+
+    raw_rules = contract.get("required_order_rules")
+    rules: dict[str, dict[str, str]] = {}
+    if not isinstance(raw_rules, list):
+        failures.append("required_order_rules must be a list")
+    else:
+        for index, rule in enumerate(raw_rules):
+            if not isinstance(rule, dict):
+                failures.append(f"required_order_rules[{index}] must be an object")
+                continue
+            rule_id = rule.get("id")
+            when = rule.get("when")
+            before = rule.get("before")
+            after = rule.get("after")
+            fields = {"id": rule_id, "when": when, "before": before, "after": after}
+            if not all(isinstance(value, str) and value.strip() for value in fields.values()):
+                failures.append(f"required_order_rules[{index}] needs non-empty id/when/before/after strings")
+                continue
+            if rule_id in rules:
+                failures.append(f"duplicate order rule id: {rule_id}")
+                continue
+            if before == after:
+                failures.append(f"order rule {rule_id} cannot order a member before itself")
+            if before not in discovered_members or after not in discovered_members:
+                failures.append(
+                    f"order rule {rule_id} names an unclassified member: before={before} after={after}"
+                )
+            rules[rule_id] = {"when": when, "before": before, "after": after}
+
+    for rule_id, expected in REQUIRED_ORDER_RULES.items():
+        actual = rules.get(rule_id)
+        if actual is None:
+            failures.append(f"required order rule missing: {rule_id}")
+        elif actual != expected:
+            failures.append(f"order rule {rule_id} drifted: expected={expected} got={actual}")
+
+    interlocks = contract.get("interlocks")
+    found_interlock = False
+    if isinstance(interlocks, list):
+        for row in interlocks:
+            if not isinstance(row, dict):
+                continue
+            members_pair = row.get("members")
+            if (
+                isinstance(members_pair, list)
+                and len(members_pair) == 2
+                and all(isinstance(item, str) for item in members_pair)
+            ):
+                candidate = (frozenset(members_pair), row.get("rule"))
+                if candidate == REQUIRED_INTERLOCK:
+                    found_interlock = True
+                    break
+    if not found_interlock:
+        failures.append("formal-rigor/evidence-research decide-stage interlock is missing")
+
+    lowered = " ".join(skill_text.lower().split())
+    for label, marker in REQUIRED_TEXT_MARKERS.items():
+        normalized_marker = " ".join(marker.lower().split())
+        if normalized_marker not in lowered:
+            failures.append(f"SKILL.md missing {label}: {marker}")
+
+    return {
+        "pass": not failures,
+        "failures": failures,
+        "member_count": len(contract_members),
+        "order_rules": len(rules),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_root = Path(__file__).resolve().parents[2]
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=default_root / "reference" / "composition-contract.json",
+    )
+    parser.add_argument("--skill", type=Path, default=default_root / "SKILL.md")
+    parser.add_argument("--skills-root", type=Path, default=default_root.parent)
+    args = parser.parse_args()
+
+    contract = json.loads(args.contract.read_text(encoding="utf-8"))
+    skill_text = args.skill.read_text(encoding="utf-8")
+    report = validate(contract, discover_members(args.skills_root), skill_text)
+    print(json.dumps(report, indent=2))
+    return 0 if report["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/skills/helix/reference/composition-contract.json
+++ b/plugins/epistemic-skills/skills/helix/reference/composition-contract.json
@@ -1,0 +1,171 @@
+{
+  "schema": "helix-composition-contract@1",
+  "trigger_authority": "member",
+  "selection_owner": "using-epistemic-skills",
+  "position_owner": "helix",
+  "routine_policy": {
+    "fresh_routine_path": "silent",
+    "resumption_precedes_routine_classification": true
+  },
+  "required_order_rules": [
+    {
+      "id": "resumption-before-recon",
+      "when": "same-resumption-lineage",
+      "before": "continuity-verify",
+      "after": "blindspot-pass"
+    },
+    {
+      "id": "task-start-recon-before-design-derivation",
+      "when": "same-design-lineage-after-micro-recon-mismatch",
+      "before": "blindspot-pass",
+      "after": "applying-formal-rigor"
+    },
+    {
+      "id": "conflict-resolution-before-pre-merge-gate",
+      "when": "same-branch-pre-merge-lineage",
+      "before": "intent-traced-merge",
+      "after": "gauntlet"
+    },
+    {
+      "id": "gate-before-ui-proof",
+      "when": "same-change-needs-gate-and-material-ui-proof",
+      "before": "gauntlet",
+      "after": "evidence-locked-uat"
+    }
+  ],
+  "interlocks": [
+    {
+      "members": [
+        "applying-formal-rigor",
+        "evidence-research"
+      ],
+      "rule": "formal-names-empirical-premise-research-qualifies-formal-closes"
+    }
+  ],
+  "members": {
+    "blindspot-pass": {
+      "composition_class": "stage-bound",
+      "moments": [
+        "task-start-after-micro-recon",
+        "first-material-agent-dispatch"
+      ],
+      "position": "before"
+    },
+    "applying-formal-rigor": {
+      "composition_class": "decision-point",
+      "moments": [
+        "material-design-choice",
+        "correctness-or-complexity-claim",
+        "material-design-claim-in-review"
+      ],
+      "position": "inside"
+    },
+    "evidence-research": {
+      "composition_class": "cross-cutting",
+      "moments": [
+        "qualifying-scholarly-premise"
+      ],
+      "position": "at-premise"
+    },
+    "write-goal": {
+      "composition_class": "pre-execution",
+      "moments": [
+        "explicit-goal-authoring"
+      ],
+      "position": "before"
+    },
+    "continuity-verify": {
+      "composition_class": "pre-arc",
+      "moments": [
+        "resumption"
+      ],
+      "position": "before",
+      "precedes_boundaries": [
+        "routine-classification",
+        "workflow-stage"
+      ]
+    },
+    "decision-ledger": {
+      "composition_class": "retrospective-cross-cutting",
+      "moments": [
+        "consequential-decision",
+        "load-bearing-assumption",
+        "recurrent-or-operator-correction"
+      ],
+      "position": "after",
+      "persistence_modes": [
+        "reuse-existing-durable-artifact",
+        "append-gap-only"
+      ]
+    },
+    "outsource": {
+      "composition_class": "execution-boundary",
+      "moments": [
+        "external-handoff"
+      ],
+      "position": "before"
+    },
+    "gauntlet": {
+      "composition_class": "gate",
+      "moments": [
+        "design-approval",
+        "pre-merge"
+      ],
+      "position": "at-approval-or-pre-merge"
+    },
+    "evidence-locked-uat": {
+      "composition_class": "prove",
+      "moments": [
+        "material-ui-acceptance",
+        "acceptor-comprehension"
+      ],
+      "position": "at-acceptance"
+    },
+    "open-questions": {
+      "composition_class": "gated-cross-cutting",
+      "moments": [
+        "gated-stage"
+      ],
+      "position": "before",
+      "modes": [
+        "explicit-full-exhaustion",
+        "automatic-fork-scoped"
+      ]
+    },
+    "context-audit": {
+      "composition_class": "maintenance-outside-arc",
+      "moments": [
+        "instruction-assembly-maintenance"
+      ],
+      "position": "outside"
+    },
+    "agent-interface-design": {
+      "composition_class": "build-stage",
+      "moments": [
+        "agent-consumed-interface-build"
+      ],
+      "position": "inside"
+    },
+    "wayfinding": {
+      "composition_class": "initiative-pre-arc",
+      "moments": [
+        "large-foggy-effort"
+      ],
+      "position": "before"
+    },
+    "throwaway-prototyping": {
+      "composition_class": "decide-instrument",
+      "moments": [
+        "build-cheaper-than-debate"
+      ],
+      "position": "inside"
+    },
+    "intent-traced-merge": {
+      "composition_class": "integration-stage",
+      "moments": [
+        "non-trivial-merge-conflict"
+      ],
+      "position": "at-integration"
+    }
+  }
+}

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -135,9 +135,29 @@ def main() -> int:
         "routine fast-path reference is missing",
     )
 
-    helix = read(PACKAGE_ROOT / "skills" / "helix" / "SKILL.md")
+    helix_root = PACKAGE_ROOT / "skills" / "helix"
+    helix = read(helix_root / "SKILL.md")
     require("external delegation / model handoff" in helix, "helix lacks outsource pairing")
     require("Do **not** emit a line for an absent trigger" in helix, "helix still records non-events")
+    require("continuity-verify → blindspot-pass" in helix, "helix lacks pre-arc resumption ordering")
+    require("zero, one, or ordered set" in helix, "helix still implies single-pair selection")
+    helix_contract = json.loads(read(helix_root / "reference" / "composition-contract.json"))
+    require(
+        helix_contract.get("schema") == "helix-composition-contract@1",
+        "helix composition contract schema is missing or stale",
+    )
+    require(
+        len(helix_contract.get("members", {})) == 15,
+        "helix composition contract does not classify all fifteen disciplines",
+    )
+    helix_eval = helix_root / "evals" / "composition"
+    for filename in (
+        "README.md",
+        "verify.py",
+        "tests/run_tests.py",
+        "results/BLOCKED.md",
+    ):
+        require((helix_eval / filename).is_file(), f"missing Helix composition artifact: {filename}")
 
     readme = read(REPO_ROOT / "README.md")
     require(f"**Version {EXPECTED_VERSION}.**" in readme, "README version is stale")
@@ -163,6 +183,10 @@ def main() -> int:
     require(
         "continuity-verify/evals/resume-fixtures/score.py" in workflow,
         "CI omits continuity-verify committed-result scoring",
+    )
+    require(
+        "helix/evals/composition/tests/run_tests.py" in workflow,
+        "CI omits Helix composition contract tests",
     )
     require(
         "python .github/scripts/test_check_dco.py" in workflow,


### PR DESCRIPTION
## What changed

- Makes `continuity-verify` an explicit pre-arc Helix binding that runs before routine-path classification and every resumed workflow stage.
- Restores Decision Ledger's complete retrospective composition moment: consequential decisions, load-bearing assumptions, and recurrent/operator corrections, with reuse-before-append preserved.
- Preserves both Open Questions modes in the pairing surface: explicit full exhaustion and the narrow automatic fork-scoped trigger.
- Defines the router/Helix handshake: `using-epistemic-skills` selects the complete zero/one/ordered set of positive fires; Helix positions the whole set and carries order custody rather than selecting one pair.
- Adds context-bound combined-order rules for continuity→recon, recon→derivation, semantic integration→Gauntlet, and Gauntlet→UAT. Each rule is scoped to the same resumption/design/branch/change lineage rather than imposed as a global task DAG.
- Adds `helix-composition-contract@1`, a machine-readable classification for all fifteen disciplines that deliberately leaves trigger authority with each member skill.

## Root cause

Helix was a strong human-readable pair map, but its catch-all carried too much load. `continuity-verify` was absent, Decision Ledger was surfaced only through recurring corrections, Open Questions' automatic mode was not represented, and nothing mechanically failed when a future discipline was added without a Helix composition classification. Pairwise rows also left the multi-fire ordered-set relationship implicit.

## Verification added

A new stdlib-only structural and mutation-sensitivity suite now fails when any of the following is planted:

- Continuity Verify is removed or sequenced after the routine gate;
- Helix takes trigger authority from member skills;
- Decision Ledger loses assumption coverage;
- Open Questions becomes explicit-invocation-only;
- Gauntlet/UAT order is reversed;
- an order rule loses its lineage condition and becomes global;
- a future skill appears without classification;
- the human map loses the registry pointer or collapses the ordered set to one pair.

The suite is wired into the permanent `epistemic-flexibility` workflow and both new Python files are included in the compile gate. Package integration asserts the registry, all four Helix evaluation artifacts, and permanent workflow wiring. JSON parsing covers the committed registry.

## Verification status

Final head: `edb0270e8432d01b5ad1c01eca19398b0b0c98c3`

GitHub Actions run `epistemic-flexibility` #157: **PASS**. The completed job includes:

- Helix composition mutation suite;
- package integration;
- continuity resume fixtures;
- proportionality and blinded-packet checks;
- formal-rigor structural, focused, isolation, and diagnostic checks;
- UAT and Decision Ledger proportionality checks;
- Open Questions and all five v3.3/v3.4 trigger-and-scope batteries;
- DCO policy tests;
- Python compilation and JSON parsing;
- receipt verifier, UAT judge, recurrent-correction examples, and the existing Gauntlet suite.

## Honest limits

This does not claim live behavioral improvement. No model/harness epoch has tested whether agents actually invoke the expanded composition correctly; `evals/composition/results/BLOCKED.md` records that state as `NOT_RUN`. No version bump, tag, release, or behavioral certification is included.