### PR TITLE
fix(ci): execute and validate new trigger-and-scope batteries

### DIFF
--- a/.github/scripts/check_json_artifacts.py
+++ b/.github/scripts/check_json_artifacts.py
@@ -29,6 +29,16 @@ def main() -> int:
         REPO_ROOT / "plugins/epistemic-skills/skills/decision-ledger/reference",
         REPO_ROOT / "plugins/epistemic-skills/skills/open-questions/evals/trigger-and-scope",
     ]
+    roots.extend(
+        REPO_ROOT / f"plugins/epistemic-skills/skills/{skill}/evals/trigger-and-scope"
+        for skill in (
+            "context-audit",
+            "agent-interface-design",
+            "wayfinding",
+            "throwaway-prototyping",
+            "intent-traced-merge",
+        )
+    )
     files = [path for root in roots for path in root.rglob("*.json")]
     observed_invalid: set[Path] = set()
     for path in files:

--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -48,6 +48,16 @@ jobs:
         run: python plugins/epistemic-skills/skills/decision-ledger/evals/proportionality/tests/run_tests.py
       - name: Open Questions trigger-and-scope tests
         run: python plugins/epistemic-skills/skills/open-questions/evals/trigger-and-scope/tests/run_tests.py
+      - name: Context Audit trigger-and-scope tests
+        run: python plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/tests/run_tests.py
+      - name: Agent Interface Design trigger-and-scope tests
+        run: python plugins/epistemic-skills/skills/agent-interface-design/evals/trigger-and-scope/tests/run_tests.py
+      - name: Wayfinding trigger-and-scope tests
+        run: python plugins/epistemic-skills/skills/wayfinding/evals/trigger-and-scope/tests/run_tests.py
+      - name: Throwaway Prototyping trigger-and-scope tests
+        run: python plugins/epistemic-skills/skills/throwaway-prototyping/evals/trigger-and-scope/tests/run_tests.py
+      - name: Intent-traced Merge trigger-and-scope tests
+        run: python plugins/epistemic-skills/skills/intent-traced-merge/evals/trigger-and-scope/tests/run_tests.py
       - name: Outsource packet and package integration
         run: python plugins/epistemic-skills/skills/outsource/tests/run_tests.py
       - name: Continuity resume-fixture committed results

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -207,9 +207,10 @@ def main() -> int:
         "throwaway-prototyping",
         "intent-traced-merge",
     ):
+        test_path = f"plugins/epistemic-skills/skills/{battery_skill}/evals/trigger-and-scope/tests/run_tests.py"
         require(
-            f"{battery_skill}/evals/trigger-and-scope/tests/run_tests.py" in workflow,
-            f"CI omits {battery_skill} trigger-and-scope tests",
+            f"run: python {test_path}" in workflow,
+            f"CI does not execute {battery_skill} trigger-and-scope tests",
         )
         require(
             (PACKAGE_ROOT / "skills" / battery_skill / "evals" / "trigger-and-scope"


### PR DESCRIPTION
### Motivation

- The recent addition of five v3.3/v3.4 trigger-and-scope batteries was only compiled in CI and not actually executed, leaving a coverage gap. 
- The committed-JSON validator omitted fixtures/examples for those batteries, so malformed or missing fixtures could go unnoticed. 
- The package-integration assertion could be satisfied by a compile-only workflow entry, so it needed a stricter check that the tests are executed.

### Description

- Add explicit execution steps for each new battery to `.github/workflows/epistemic-flexibility.yml` so CI runs the tests with `run: python .../tests/run_tests.py` for each battery. 
- Extend `.github/scripts/check_json_artifacts.py` to include the `fixtures` and `examples` trees for the five batteries (`context-audit`, `agent-interface-design`, `wayfinding`, `throwaway-prototyping`, `intent-traced-merge`). 
- Harden `plugins/epistemic-skills/skills/outsource/tests/run_tests.py` to assert the workflow contains an actual `run: python <battery>/tests/run_tests.py` entry rather than just a compiled-path substring. 
- Validate the changes locally and update the test orchestration so the new batteries are executed as part of the integration checks.

### Testing

- Ran each battery individually with `python plugins/epistemic-skills/skills/<battery>/evals/trigger-and-scope/tests/run_tests.py` and all five passed. 
- Ran `python .github/scripts/check_json_artifacts.py` which checked `203` JSON artifacts and preserved `1` declared hash-pinned malformed response. 
- Ran `python plugins/epistemic-skills/skills/outsource/tests/run_tests.py` which passed the strengthened workflow-execution assertions. 
- Ran `python -m py_compile .github/scripts/check_json_artifacts.py plugins/epistemic-skills/skills/outsource/tests/run_tests.py` and a malformed-JSON positive control for the context-audit battery which correctly failed, validating the negative-control behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e331b5d3c8332b673426754893ecf)