### PR TITLE
Release v4.1.0 — the evidence release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, eleven self-triggering skills. Composes with workflow layers via the helix tandem entry point.",
-    "version": "4.0.0"
+    "version": "4.1.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, eleven self-triggering skills. Composes with workflow layers via the helix tandem entry point.",
-    "version": "4.0.0"
+    "version": "4.1.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: a router plus nine disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"

--- a/.github/scripts/check_pin_tags.py
+++ b/.github/scripts/check_pin_tags.py
@@ -23,6 +23,10 @@ import sys
 PINS = {
     # tag name -> peeled commit that must stay reachable at that name
     "pin/ecs-contract-2026-07-27": "8d9b2f85bd8e081a547e33f4bb9b5eb880a4c2b0",
+    # v4.0.0 is the counterpart's v4 re-pin coordinate (issue #84): the
+    # release tag itself is the reachability guarantee for the v4 event
+    # contract, so it is guarded like a pin tag.
+    "v4.0.0": "53ad6d523107d8c0d84f50945e22d6b744199446",
 }
 
 

--- a/.github/scripts/sync_skill_surfaces.py
+++ b/.github/scripts/sync_skill_surfaces.py
@@ -75,7 +75,7 @@ def count_surfaces() -> list[tuple[Path, list[tuple[str, str]]]]:
             (rf"canonical skill cores \({ANY_WORD}\)", "canonical skill cores ({n})"),
             (rf"router and {ANY_WORD} disciplines", "router and {d} disciplines"),
             (rf"a v4\.0\.0 package or tagged checkout ships {ANY_WORD} ",
-             "a v4.0.0 package or tagged checkout ships {n} "),
+             "a v4.1.0 package or tagged checkout ships {n} "),
         ]),
         (REPO / "GEMINI.md", [
             (rf"{ANY_WORD} skills: router \+ {ANY_WORD} disciplines",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "The full epistemic-discipline collection in one package: a router plus nine disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Epistemic disciplines for agentic work: use the least process that can still expose an error capable of changing the action or the completion claim.
 
-**Version 4.0.0.** This is the project's current [immutable support point](https://github.com/ZMS-Labs/epistemic-skills/releases/tag/v4.0.0). The package is harness-agnostic, follows the [Agent Skills specification](https://agentskills.io/specification), and is licensed under [GPL-3.0-or-later](LICENSE).
+**Version 4.1.0.** This is the project's current [immutable support point](https://github.com/ZMS-Labs/epistemic-skills/releases/tag/v4.1.0). The package is harness-agnostic, follows the [Agent Skills specification](https://agentskills.io/specification), and is licensed under [GPL-3.0-or-later](LICENSE).
 
 [![Release](https://img.shields.io/github/v/release/ZMS-Labs/epistemic-skills?display_name=tag)](https://github.com/ZMS-Labs/epistemic-skills/releases/latest)
 [![epistemic-flexibility](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml)
@@ -66,20 +66,20 @@ Users and maintainers are equal first-class audiences:
 | [Installation and Harness Compatibility](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) | [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) |
 | [Skill Catalog](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Catalog) | [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO) |
 
-The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v4.0.0` source controls.
+The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v4.1.0` source controls.
 
 ## Five-minute start
 
 1. **Install one immutable copy.** Choose the native path for your harness under [Installation and compatibility](#installation-and-compatibility). Use the generic Agent Skills path only when no native plugin or extension exists.
 2. **Reload the harness or start a fresh task.** Trigger discovery and role registries are commonly session-bound.
 3. **Choose the entry point.** Start with the epistemic router when only this collection is active. If a workflow-skill layer is also active and a positive pairing exists, enter through Helix.
-4. **Verify the inventory and source.** Expect exactly the count your source ships: a v4.0.0 package or tagged checkout ships eleven (v3.4.0 ships seventeen; v3.3.0 ships fourteen; v3.1.0/v3.2.0 ship twelve; the pinned `v3.0.0` tag also ships eleven — its different eleven)—not two copies found through different install mechanisms.
+4. **Verify the inventory and source.** Expect exactly the count your source ships: a v4.1.0 package or tagged checkout ships eleven (v4.0.0 ships the same eleven; v3.4.0 ships seventeen; v3.3.0 ships fourteen; v3.1.0/v3.2.0 ship twelve; the pinned `v3.0.0` tag also ships eleven — its different eleven)—not two copies found through different install mechanisms.
 5. **Let routine work leave.** A local, reversible, directly checkable, non-precedential task should finish with its bounded check and no process-only artifact.
 
 For a harness without a native package surface, the complete generic install is:
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v4.0.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v4.1.0/plugins/epistemic-skills/skills
 ```
 
 Do not run that command on top of a native plugin install. The [installation handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) includes verification and recovery details for every packaged harness.
@@ -97,7 +97,7 @@ For unfamiliar but routine-looking work, perform **two-read micro-recon**: inspe
 
 Routine work produces no router record, Helix skip inventory, blindspot report, formal record, ledger entry, UAT packet, or proof that other triggers were absent. Escalate only when the reads expose an observed mismatch, hidden coupling, unresolved scope, material fan-out risk, or another positive trigger.
 
-See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v4.0.0/plugins/epistemic-skills/skills/using-epistemic-skills/reference/routine-fast-path.md).
+See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v4.1.0/plugins/epistemic-skills/skills/using-epistemic-skills/reference/routine-fast-path.md).
 
 ## Helix: the central passage
 
@@ -190,13 +190,13 @@ The package contains exactly one router, Helix, and nine disciplines. Each name 
 
 ### One copy, one version, one canonical tree
 
-Install with **exactly one mechanism per harness**. Native plugin **or** generic skill install—never both. For 4.0.0, replace an older untagged copy, reload, and verify both the skill count and source path. Duplicate copies create duplicate triggers and can silently mix contract versions.
+Install with **exactly one mechanism per harness**. Native plugin **or** generic skill install—never both. For 4.1.0, replace an older untagged copy, reload, and verify both the skill count and source path. Duplicate copies create duplicate triggers and can silently mix contract versions.
 
-| Harness | v4.0.0 surface | Required follow-through | Honest support boundary |
+| Harness | v4.1.0 surface | Required follow-through | Honest support boundary |
 |---|---|---|---|
 | Claude Code | Local marketplace from tagged checkout | Start a fresh task | Package discovery from one immutable checkout |
 | Codex | Tagged plugin marketplace | Render five Gauntlet roles; start a new task | Manifest does not itself register custom collaboration-agent types |
-| Cursor | Tagged local checkout or team marketplace | Reload window; verify the tag's full skill count (eleven at v4.0.0) | Public listing unavailable; recorded behavioral epoch is `BLOCKED_EXTERNAL` |
+| Cursor | Tagged local checkout or team marketplace | Reload window; verify the tag's full skill count (eleven at v4.1.0) | Public listing unavailable; recorded behavioral epoch is `BLOCKED_EXTERNAL` |
 | Gemini CLI | Tagged extension | Restart and validate extension | Uses root context and canonical symlinked tree |
 | Antigravity (`agy`) | Tagged native local plugin | Validate with `agy` | Choose native, Gemini link, or import—only one |
 | Kimi Code | Tagged repository plugin | `/reload` or new session | Plugin instructions map isolated-agent primitives |
@@ -254,7 +254,7 @@ mkdir -p ~/.cursor/plugins/local
 ln -sfn "$(pwd)/plugins/epistemic-skills" ~/.cursor/plugins/local/epistemic-skills
 ```
 
-Run **Developer: Reload Window**, verify the tag's full skill count (eleven at v4.0.0) under Customize → Skills, and do not also install them into `~/.cursor/skills/`.
+Run **Developer: Reload Window**, verify the tag's full skill count (eleven at v4.1.0) under Customize → Skills, and do not also install them into `~/.cursor/skills/`.
 
 ### Gemini CLI
 
@@ -289,7 +289,7 @@ Run `/reload` or start a new session. `.kimi-plugin/plugin.json` points to the c
 ### Generic harness
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v4.0.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v4.1.0/plugins/epistemic-skills/skills
 ```
 
 Use this only when the host has no native plugin or extension. Frontmatter `description` is the trigger; the body is the method. Compatibility means the host preserves the selected skill's capability, ordering, isolation, persistence, and fail-closed contracts—not merely that it can display Markdown.

--- a/docs/release/RELEASE-3.0.0-RISK-ACCEPTANCE.json
+++ b/docs/release/RELEASE-3.0.0-RISK-ACCEPTANCE.json
@@ -25,11 +25,12 @@
       "evidence": "docs/release/evidence/2026-07-26-formal-rigor-v3-posthoc-diagnostic.md",
       "owner": "ZMS-Labs epistemic-skills maintainers",
       "scope": "formal-rigor behavioral confidence",
-      "revisit_trigger": "before the next release tag after v4.0.0, or 2026-10-31, whichever comes first; or immediately on a field report matching either failed scenario",
+      "revisit_trigger": "before the next release tag after v4.1.0, or 2026-10-31, whichever comes first; or immediately on a field report matching either failed scenario",
       "exit_criterion": "a fresh preregistered campaign passes both scenarios under independent valid adjudication",
       "revisit_history": [
         "2026-07-31: re-adjudicated at the v3.3.0 publication gauntlet, re-accepted unchanged (issue #69)",
-        "2026-08-04: trigger fired at the v4.0.0 tag (created without a prior revisit; no v3.5.0 tag will exist). Re-adjudicated post-tag, re-accepted UNCHANGED: the 2026-08-04 four-arm campaign was an epistemic-flexibility comparison, not the preregistered formal-rigor behavioral campaign the exit criterion requires \u2014 no fresh evidence touches the tm-02/tm-03 P0 posture, and v4.0.0 moved the method unchanged into resolve/derivation. Exit criterion stands. Trigger re-dated to the earlier of the next release tag after v4.0.0 or 2026-10-31 (issue #69 closes; this record is now the dated artifact)."
+        "2026-08-04: trigger fired at the v4.0.0 tag (created without a prior revisit; no v3.5.0 tag will exist). Re-adjudicated post-tag, re-accepted UNCHANGED: the 2026-08-04 four-arm campaign was an epistemic-flexibility comparison, not the preregistered formal-rigor behavioral campaign the exit criterion requires \u2014 no fresh evidence touches the tm-02/tm-03 P0 posture, and v4.0.0 moved the method unchanged into resolve/derivation. Exit criterion stands. Trigger re-dated to the earlier of the next release tag after v4.0.0 or 2026-10-31 (issue #69 closes; this record is now the dated artifact).",
+        "2026-08-04: trigger fired ahead of the v4.1.0 tag (revisit-before-tag honored). Re-accepted UNCHANGED: no new formal-rigor behavioral evidence since the same-day v4.0.0 re-adjudication \u2014 the v4 Tier-1 wave epoched trigger surfaces, not the tm-02/tm-03 behavioral scenarios; the derivation instrument's semantic adjudication remains NOT_RUN. Trigger re-dated: before the next release tag after v4.1.0, or 2026-10-31, whichever comes first; field-report clause unchanged."
       ]
     },
     {
@@ -38,11 +39,12 @@
       "evidence": "docs/release/evidence/2026-07-26-formal-rigor-v3-posthoc-diagnostic.md",
       "owner": "ZMS-Labs epistemic-skills maintainers",
       "scope": "cross-provider semantic coverage",
-      "revisit_trigger": "before the next release tag after v4.0.0, or 2026-10-31, whichever comes first; or immediately when AGY-equivalent independent adjudication capacity becomes available",
+      "revisit_trigger": "before the next release tag after v4.1.0, or 2026-10-31, whichever comes first; or immediately when AGY-equivalent independent adjudication capacity becomes available",
       "exit_criterion": "complete independent semantic judgments exist for every planned provider arm",
       "revisit_history": [
         "2026-07-31: re-adjudicated at the v3.3.0 publication gauntlet, re-accepted unchanged (issue #69)",
-        "2026-08-04: trigger fired at the v4.0.0 tag (created without a prior revisit; no v3.5.0 tag will exist). Re-adjudicated post-tag, re-accepted UNCHANGED: independent non-Codex (AGY-equivalent) adjudication capacity has not materialized; the 44 OpenAI-origin candidates remain unadjudicated availability failures. Exit criterion stands. Trigger re-dated to the earlier of the next release tag after v4.0.0 or 2026-10-31 (issue #69 closes; this record is now the dated artifact)."
+        "2026-08-04: trigger fired at the v4.0.0 tag (created without a prior revisit; no v3.5.0 tag will exist). Re-adjudicated post-tag, re-accepted UNCHANGED: independent non-Codex (AGY-equivalent) adjudication capacity has not materialized; the 44 OpenAI-origin candidates remain unadjudicated availability failures. Exit criterion stands. Trigger re-dated to the earlier of the next release tag after v4.0.0 or 2026-10-31 (issue #69 closes; this record is now the dated artifact).",
+        "2026-08-04: trigger fired ahead of the v4.1.0 tag (revisit-before-tag honored). Re-accepted UNCHANGED: independent adjudication capacity still absent; the 44 OpenAI-origin candidates remain unadjudicated. The paired proposal (issue #84) names the counterpart's model-family round-robin runner as a candidate execution vehicle for a future cross-provider slice \u2014 noted as prospect, not capacity. Trigger re-dated: before the next release tag after v4.1.0, or 2026-10-31, whichever comes first; capacity clause unchanged."
       ]
     },
     {

--- a/docs/release/RELEASE-4.1.0.md
+++ b/docs/release/RELEASE-4.1.0.md
@@ -1,0 +1,89 @@
+# Release 4.1.0 — the evidence release
+
+**Date:** 2026-08-04. **Additive, non-breaking.** Same eleven skills as
+v4.0.0 (router, helix, nine disciplines); no trigger-surface contract
+changes. Operator-authorized (2026-08-04 session: merge of PR #83 and the
+release motion approved).
+
+## What this release adds
+
+- **Post-consolidation evidence exists now.** The v4 Tier-1 epoch wave ran
+  under a committed preregistration
+  (`docs/superpowers/specs/2026-08-04-v4-tier1-epoch-preregistration.md`):
+  recon candidate **PASS 14/14** (first battery to clear its first epoch
+  with zero contract-shape failures), resolve literature **PASS 14/14**
+  (second consecutive clean epoch), recon brief 12/14, resolve probe
+  11/12, recon initiative 11/13 — 62/67 valid trials, **zero
+  mode/instrument-selection failures** (the consolidation's novel risk
+  class did not appear), one genuine hard-negative over-fire recorded
+  honestly (the program's first), one dispatch-defect run quarantined as a
+  defect record. The decision-ledger resume mode re-ran its full battery:
+  skilled arm meets the gate in all 3 runs (8/8 traps, 0 false flags),
+  with same-model baseline context recorded.
+- **Live-epoch methodology is law:**
+  `docs/policy/LIVE-EPOCH-DISPATCH-CONTRACT.md` (vocabularies inline,
+  silence semantics, extraction-only prose tolerance, simulation-clause
+  rule 4, opaque keys, preregistration before dispatch, results as-is).
+- **New battery:** recon candidate-mode trigger-and-scope (14 fixtures,
+  adversarially verified, CI-wired) — every v4 mode now has an eval
+  surface.
+- **Trace dialects unified:** `validate_trace.py` is the single
+  structural authority (string|array `residual_uncertainty`; `scenario`
+  validated when present); `score_behavior.py --bound` serves blinded
+  harnesses. Real-incident behavioral fixtures 07/08 landed; the
+  contract-vs-nothing ablation is preregistered as design-only
+  (Tier-3 gated, not run).
+- **Calibration coordination advanced to the edge of Phase 2:** Phase 0
+  complete (counterpart confirmed, digests re-verified), Phase 1 charted
+  and frontier-resolved
+  (`docs/coordination/2026-08-04-phase1-inventory-and-map.md` — the full
+  measurement matrix with subject revisions and sampling frames), the
+  charter amended to test current reality (latest release tag + HEAD),
+  the paired proposal filed (issue #84), and pin-tag reachability now
+  CI-guarded (`check_pin_tags.py`; `v4.0.0` is the counterpart's v4
+  re-pin coordinate and is guarded like a pin tag — **neither guarded tag
+  is ever deleted or moved**).
+- Gauntlet Step-7b consult packet committed (#40, operator hand-carry
+  pending); runtime tool-call gate productized as honest
+  cooperative-grade reference machinery (#42); open-questions evidence
+  deposited durably (#63); wiki v4.0.0 hand-off committed under
+  `docs/wiki-updates/v4.0.0/` (wiki pushes are proxy-blocked from
+  sessions).
+
+## Evidence posture (honest status)
+
+- **Tier 0:** 37 unconditional CI steps green at release (two new:
+  candidate battery tests, pin-tag reachability guard).
+- **Tier 2 at this release candidate:** every trigger battery has a
+  current epoch under the evidence policy's subject-hash rule — the five
+  re-armed post-consolidation surfaces epoched 2026-08-04 (results above),
+  and the unchanged subjects (write-goal 14/14, outsource 12/14,
+  open-questions 8/10, context-audit 8/14 — failures diagnosed as
+  #77-class reporting/battery-design divergences) retain their valid
+  2026-08-04 epochs. The resume-fixtures battery holds its v4 gate PASS.
+- **Behavioral superiority: still UNESTABLISHED.** The four-arm campaign's
+  null stands; issue #39 remains open; the contract-ablation design is
+  committed but not run. No superiority language attaches to this
+  release.
+- **Risk acceptance:** `RELEASE-3.0.0-RISK-ACCEPTANCE.json` remains the
+  controlling record, append-only. FR3-R1/R2 were re-adjudicated ahead of
+  this tag (revisit-before-tag honored), re-accepted unchanged, triggers
+  re-dated to the next tag after v4.1.0 or 2026-10-31.
+- Single-model-family evidence throughout the 2026-08-04 waves
+  (claude-fable-5, N=1 per fixture; N=3 runs for resume). Every claim
+  above cites its committed artifact, per the evidence policy's rule 5.
+
+## Migration from v4.0.0
+
+None required. Install surfaces re-pin to `v4.1.0`; the skill inventory,
+trigger vocabulary, and ECS event contract are unchanged (`v4.0.0`
+remains the counterpart's valid contract-pin coordinate — see issue #84
+for the coordination state).
+
+## What this release does not claim
+
+No behavioral-superiority claim; no claim that the epoch passes measure
+real-world effectiveness (trigger/shape evidence only, per the evidence
+policy); no cross-provider generality; the calibration loop is designed
+but not yet fed (field pairs ≈ zero until the store lands and Phase 2
+runs).

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: a router plus nine disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "contextFileName": "GEMINI.md"
 }

--- a/plugins/epistemic-skills/.claude-plugin/plugin.json
+++ b/plugins/epistemic-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: a router plus nine disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/epistemic-skills/.codex-plugin/plugin.json
+++ b/plugins/epistemic-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "The full epistemic-discipline collection in one package: a router plus nine disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
   "author": {
     "name": "ZMS Labs",

--- a/plugins/epistemic-skills/.cursor-plugin/plugin.json
+++ b/plugins/epistemic-skills/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: a router plus nine disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": {
     "name": "ZMS Labs"
   },

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "The full epistemic-discipline collection in one package: a router plus nine disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -11,7 +11,7 @@ HERE = Path(__file__).resolve()
 SKILL_ROOT = HERE.parents[1]
 PACKAGE_ROOT = HERE.parents[3]
 REPO_ROOT = HERE.parents[5]
-EXPECTED_VERSION = "4.0.0"
+EXPECTED_VERSION = "4.1.0"
 
 
 def require(condition: bool, message: str) -> None:


### PR DESCRIPTION
One release commit on top of the merged resolution arc. Additive, non-breaking: same eleven skills, no trigger-surface contract changes.

- `docs/release/RELEASE-4.1.0.md` — the release record (post-consolidation epoch evidence, methodology-as-law, Phase 1 map, amended charter, honest boundaries: superiority still unestablished, field pairs still ≈ zero).
- Version surfaces 4.0.0 → 4.1.0 via all manifests, README, and the generator pattern; outsource canary `EXPECTED_VERSION` bumped; full battery green (37 steps).
- FR3-R1/R2 re-adjudicated **ahead of the tag** (revisit-before-tag honored), re-accepted unchanged, triggers re-dated to next-tag-after-v4.1.0 or 2026-10-31.
- `v4.0.0` registered in the pin-tag reachability guard — it is the counterpart's v4 re-pin coordinate (issue #84) and is now guarded like a pin tag.

**After merge, the operator pushes the tag** (session git proxy drops tag pushes): `git tag -a v4.1.0 -m "v4.1.0 — the evidence release" <merge-commit> && git push origin v4.1.0`, then a GitHub Release with `RELEASE-4.1.0.md` as notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBSZozu7WMUbfcyBxUiStz

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBSZozu7WMUbfcyBxUiStz)_