### PR TITLE
chore(deps): bump actions/setup-go from 5.0.2 to 7.0.0

### DIFF
--- a/.github/workflows/release-security.yml
+++ b/.github/workflows/release-security.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up the pinned Go toolchain
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.25.1"
           check-latest: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `actions/setup-go` pin in `release-security.yml` from v5.0.2 (`0a12ed9…`) to v7.0.0 (`b7ad1da…`).
- Same change as Dependabot #80, recreated with an author-matching DCO sign-off (Dependabot’s sign-off email does not match its commit author, so #80 fails the DCO gate).
- Inputs (`go-version: 1.25.1`, `check-latest: false`) are unchanged and remain valid on v7.

## Test plan
- [ ] DCO check passes
- [ ] `release-security` / full-history-secret-scan passes (exercises setup-go + gitleaks)
- [ ] Close Dependabot #80 as superseded after merge

Supersedes #80.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd288-611a-74d2-b18f-7b0a25d573bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd288-611a-74d2-b18f-7b0a25d573bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

