### PR TITLE
chore(deps): bump actions/setup-python from 5.6.0 to 7.0.0

### DIFF
--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Epistemic event contract tests


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `actions/setup-python` pin in `epistemic-flexibility.yml` from v5.6.0 (`a26af69…`) to v7.0.0 (`5fda3b9…`).
- Same change as Dependabot #82, recreated with an author-matching DCO sign-off.
- v7 removes the `pip-install` input; this workflow only sets `python-version: "3.12"`, so the bump is compatible.

## Test plan
- [ ] DCO check passes
- [ ] `epistemic-flexibility` / stdlib-checks passes (exercises setup-python 3.12)
- [ ] Close Dependabot #82 as superseded after merge

Supersedes #82.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd288-611a-74d2-b18f-7b0a25d573bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd288-611a-74d2-b18f-7b0a25d573bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

