### PR TITLE
chore(deps): bump actions/checkout from 4.3.1 to 7.0.1

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out trusted base revision
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false

--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out the tested revision without stored credentials
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Python

--- a/.github/workflows/release-security.yml
+++ b/.github/workflows/release-security.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out the complete history without stored credentials
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `actions/checkout` pin from v4.3.1 (`34e1148…`) to v7.0.1 (`3d3c42e…`) in all three workflows: `dco.yml`, `epistemic-flexibility.yml`, `release-security.yml`.
- Same dependency bump as Dependabot #81, recreated with an author-matching DCO sign-off and corrected version comments (`# v7.0.1` instead of stale `# v4`).
- **Safety note for `pull_request_target`:** `dco.yml` checks out `${{ github.event.pull_request.base.sha }}` (trusted base), not the PR head, so checkout v7’s fork-PR hardening does not change this workflow’s trust model. Other workflows keep `persist-credentials: false`.

## Test plan
- [ ] DCO check passes (exercises checkout v7 on `pull_request_target` + base SHA)
- [ ] `epistemic-flexibility` / stdlib-checks passes
- [ ] `release-security` / full-history-secret-scan passes (`fetch-depth: 0`)
- [ ] Close Dependabot #81 as superseded after merge

Supersedes #81.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd288-611a-74d2-b18f-7b0a25d573bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd288-611a-74d2-b18f-7b0a25d573bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

