### PR TITLE
release: epistemic-skills 5.0.0 — version surfaces aligned, publication HELD on the gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fourteen self-triggering skills. Composes with workflow layers via the helix tandem entry point.",
-    "version": "4.1.0"
+    "version": "5.0.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fourteen self-triggering skills. Composes with workflow layers via the helix tandem entry point.",
-    "version": "4.1.0"
+    "version": "5.0.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"

--- a/.github/ci/cleanroom-job.yaml
+++ b/.github/ci/cleanroom-job.yaml
@@ -1,0 +1,86 @@
+# Run this repo's CI suites as a Kubernetes Job, without GitHub Actions.
+#
+# WHY
+#   GitHub-hosted runners can stop being allocated (billing, quota, incident),
+#   and when they do the jobs are auto-cancelled at the 15-minute assignment
+#   timeout — which GitHub reports as a run-level "failure". CI then looks broken
+#   while nothing is broken.
+#
+#   Running the same suites here gives three things a developer workstation
+#   cannot: Linux, a clean checkout of a named ref, and a machine that is not the
+#   one the code was written on. The last is the point — "the host that wrote the
+#   change verified the change" is weak evidence, and it is the failure mode this
+#   package exists to attack.
+#
+# FIDELITY
+#   image python:3.12 matches the runner's Python (3.12.x); the workflow targets
+#   ubuntu-24.04 and this pins amd64 so the architecture matches too. Do NOT let
+#   this land on arm64 nodes: a pass there would not be evidence about what CI
+#   runs. That is what the nodeSelector is for.
+#
+#   The step list is EXTRACTED from the workflow by cleanroom_ci.sh, not copied
+#   here. A hardcoded list would be one more hand-maintained projection, which is
+#   the defect class this repo keeps finding.
+#
+# USAGE
+#   kubectl create -f .github/ci/cleanroom-job.yaml            # runs main
+#   REF=feat/x envsubst < ... | kubectl create -f -            # or edit CI_REF
+#   kubectl logs -f job/epistemic-skills-cleanroom-ci
+#
+# SECURITY
+#   This is NOT a GitHub Actions self-hosted runner. It pulls a public repo and
+#   runs its committed test suites; it accepts no webhook, exposes no listener,
+#   and holds no token. A self-hosted RUNNER on a public repo would let any fork
+#   pull-request execute arbitrary code on this cluster — a different and much
+#   larger exposure, and one to adopt deliberately rather than as a workaround.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: epistemic-skills-cleanroom-ci
+  labels:
+    app.kubernetes.io/name: epistemic-skills-cleanroom-ci
+spec:
+  backoffLimit: 0          # a failing suite is a result, not something to retry
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: epistemic-skills-cleanroom-ci
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: ci
+          image: python:3.12
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CI_REF
+              value: "main"
+            - name: CI_REMOTE
+              value: "https://github.com/ZMS-Labs/epistemic-skills.git"
+            - name: PYTHONIOENCODING
+              value: "utf-8"
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -uo pipefail
+              echo "cleanroom CI on $(hostname), arch $(uname -m), $(python3 --version)"
+              git clone --quiet --depth 50 --branch "$CI_REF" "$CI_REMOTE" /tmp/repo || {
+                echo "FATAL: clone failed for ref $CI_REF"; exit 2; }
+              cd /tmp/repo
+              # The harness is fetched WITH the ref under test, so it can never be
+              # a stale copy verifying a newer tree.
+              exec bash .github/scripts/cleanroom_ci.sh "$CI_REF" "$CI_REMOTE"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: false
+            capabilities:
+              drop: ["ALL"]

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Epistemic disciplines for agentic work: use the least process that can still expose an error capable of changing the action or the completion claim.
 
-**Version 4.1.0.** This is the project's current [immutable support point](https://github.com/ZMS-Labs/epistemic-skills/releases/tag/v4.1.0). The package is harness-agnostic, follows the [Agent Skills specification](https://agentskills.io/specification), and is licensed under [GPL-3.0-or-later](LICENSE).
+**Version 5.0.0.** This is the project's current [immutable support point](https://github.com/ZMS-Labs/epistemic-skills/releases/tag/v5.0.0). The package is harness-agnostic, follows the [Agent Skills specification](https://agentskills.io/specification), and is licensed under [GPL-3.0-or-later](LICENSE).
 
 [![Release](https://img.shields.io/github/v/release/ZMS-Labs/epistemic-skills?display_name=tag)](https://github.com/ZMS-Labs/epistemic-skills/releases/latest)
 [![epistemic-flexibility](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml)
@@ -66,20 +66,20 @@ Users and maintainers are equal first-class audiences:
 | [Installation and Harness Compatibility](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) | [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) |
 | [Skill Catalog](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Catalog) | [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO) |
 
-The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v4.1.0` source controls.
+The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v5.0.0` source controls.
 
 ## Five-minute start
 
 1. **Install one immutable copy.** Choose the native path for your harness under [Installation and compatibility](#installation-and-compatibility). Use the generic Agent Skills path only when no native plugin or extension exists.
 2. **Reload the harness or start a fresh task.** Trigger discovery and role registries are commonly session-bound.
 3. **Choose the entry point.** There is one: `metacognate`. It is the only skill you invoke by name; every other member fires on its own description. It applies the routine gate first, and declining is its most common correct outcome.
-4. **Verify the inventory and source.** Expect exactly the count your source ships: a v4.1.0 package or tagged checkout ships eleven (v4.0.0 ships the same eleven; v3.4.0 ships seventeen; v3.3.0 ships fourteen; v3.1.0/v3.2.0 ship twelve; the pinned `v3.0.0` tag also ships eleven — its different eleven)—not two copies found through different install mechanisms.
+4. **Verify the inventory and source.** Expect exactly the count your source ships: a v5.0.0 package or tagged checkout ships fourteen (v4.1.0 and v4.0.0 ship eleven; v3.4.0 ships seventeen; v3.3.0 ships fourteen; v3.1.0/v3.2.0 ship twelve; the pinned `v3.0.0` tag also ships eleven — its different eleven)—not two copies found through different install mechanisms.
 5. **Let routine work leave.** A local, reversible, directly checkable, non-precedential task should finish with its bounded check and no process-only artifact.
 
 For a harness without a native package surface, the complete generic install is:
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v4.1.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v5.0.0/plugins/epistemic-skills/skills
 ```
 
 Do not run that command on top of a native plugin install. The [installation handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) includes verification and recovery details for every packaged harness.
@@ -97,7 +97,7 @@ For unfamiliar but routine-looking work, perform **two-read micro-recon**: inspe
 
 Routine work produces no entry-point record, blindspot report, formal record, ledger entry, UAT packet, or proof that other triggers were absent. Escalate only when the reads expose an observed mismatch, hidden coupling, unresolved scope, material fan-out risk, or another positive trigger.
 
-See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v4.1.0/plugins/epistemic-skills/skills/using-epistemic-skills/reference/routine-fast-path.md).
+See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v5.0.0/plugins/epistemic-skills/skills/metacognate/reference/routine-fast-path.md).
 
 ## metacognate: the single entry point
 
@@ -205,13 +205,13 @@ The package contains exactly one entry point and thirteen disciplines. Each name
 
 ### One copy, one version, one canonical tree
 
-Install with **exactly one mechanism per harness**. Native plugin **or** generic skill install—never both. For 4.1.0, replace an older untagged copy, reload, and verify both the skill count and source path. Duplicate copies create duplicate triggers and can silently mix contract versions.
+Install with **exactly one mechanism per harness**. Native plugin **or** generic skill install—never both. For 5.0.0, replace an older untagged copy, reload, and verify both the skill count and source path. Duplicate copies create duplicate triggers and can silently mix contract versions.
 
-| Harness | v4.1.0 surface | Required follow-through | Honest support boundary |
+| Harness | v5.0.0 surface | Required follow-through | Honest support boundary |
 |---|---|---|---|
 | Claude Code | Local marketplace from tagged checkout | Start a fresh task | Package discovery from one immutable checkout |
 | Codex | Tagged plugin marketplace | Render five Gauntlet roles; start a new task | Manifest does not itself register custom collaboration-agent types |
-| Cursor | Tagged local checkout or team marketplace | Reload window; verify the tag's full skill count (eleven at v4.1.0) | Public listing unavailable; recorded behavioral epoch is `BLOCKED_EXTERNAL` |
+| Cursor | Tagged local checkout or team marketplace | Reload window; verify the tag's full skill count (fourteen at v5.0.0) | Public listing unavailable; recorded behavioral epoch is `BLOCKED_EXTERNAL` |
 | Gemini CLI | Tagged extension | Restart and validate extension | Uses root context and canonical symlinked tree |
 | Antigravity (`agy`) | Tagged native local plugin | Validate with `agy` | Choose native, Gemini link, or import—only one |
 | Kimi Code | Tagged repository plugin | `/reload` or new session | Plugin instructions map isolated-agent primitives |
@@ -269,7 +269,7 @@ mkdir -p ~/.cursor/plugins/local
 ln -sfn "$(pwd)/plugins/epistemic-skills" ~/.cursor/plugins/local/epistemic-skills
 ```
 
-Run **Developer: Reload Window**, verify the tag's full skill count (eleven at v4.1.0) under Customize → Skills, and do not also install them into `~/.cursor/skills/`.
+Run **Developer: Reload Window**, verify the tag's full skill count (fourteen at v5.0.0) under Customize → Skills, and do not also install them into `~/.cursor/skills/`.
 
 ### Gemini CLI
 
@@ -304,7 +304,7 @@ Run `/reload` or start a new session. `.kimi-plugin/plugin.json` points to the c
 ### Generic harness
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v4.1.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v5.0.0/plugins/epistemic-skills/skills
 ```
 
 Use this only when the host has no native plugin or extension. Frontmatter `description` is the trigger; the body is the method. Compatibility means the host preserves the selected skill's capability, ordering, isolation, persistence, and fail-closed contracts—not merely that it can display Markdown.

--- a/docs/release/RELEASE-5.0.0.md
+++ b/docs/release/RELEASE-5.0.0.md
@@ -1,0 +1,124 @@
+# Release 5.0.0 — the loop release
+
+**Date:** 2026-08-06. **Breaking.** Fourteen skills: one entry point,
+`metacognate`, and thirteen disciplines.
+
+> **PUBLICATION HELD.** These notes are committed; the tag is not created. Two
+> release-gate items cannot be satisfied while GitHub-hosted runners are
+> unavailable — see *Release gate status* below. `RELEASING.md` forbids
+> improvising around the gate, so publication waits rather than the gate bending.
+
+## What changed and why
+
+v4.0.0 consolidated eighteen skills into eleven. v5.0.0 does something different:
+it **removes the routing layer entirely** and adds the four capabilities that
+close an operational loop.
+
+| v5.0.0 skill | Owns | Refuses |
+|---|---|---|
+| **`metacognate`** | how much process this deserves — usually none | enumerating its members, ever |
+| **`health`** | is the subject within declared bounds — *and did we look?* | rendering `UNKNOWN` as `OK` |
+| **`triage`** | what is the cause, and what observation rules out the alternatives | naming a cause it did not observe |
+| **`did-it-land`** | is the change in effect *on the runtime* | a green check whose oracle only read source |
+| **`watch`** | a bound was crossed *while nobody was looking* | claiming installed before it has fired once |
+
+Together: **watch** notices, **health** assesses, **triage** diagnoses,
+**did-it-land** verifies the fix took.
+
+Each carries four-valued states where the third value is the point — `UNKNOWN`,
+`UNVERIFIED`, `NARROWED`, `SUSPECT`. **Absence of evidence never renders as
+success.**
+
+## Removed
+
+`using-epistemic-skills` (the router), `helix`, and
+`helix/reference/composition-contract.json` (the pair table).
+
+`metacognate` replaces both seats. A pair table maps stages; it cannot express
+the two things that turned out to matter — that **either strand may interrupt the
+other**, and that **control must come back** to the point of interruption.
+
+### The check that deleted itself
+
+`ROUTER_DESCRIPTION_DRIFT` required the router's frontmatter to enumerate every
+discipline. It was the single largest source of the enumeration tax — adding any
+skill forced an edit to *another skill's firing surface* — and it is precisely the
+defect that shipped in v4.0.0, where the router's description named two skills
+that no longer existed.
+
+`metacognate` enumerates nothing, so the check had nothing left to check. **The
+package's integration suite now asserts the inverse:** it globs the skills
+directory and fails if the entry point names any member. Enumeration went from
+*enforced* to *forbidden*.
+
+## The measured constraint behind the release
+
+The Claude Code harness applies a **total description-byte budget** to its
+assembled skill listing. A skill whose description is dropped cannot fire on
+description match — it is functionally uninstalled, with no error anywhere.
+
+Confirmed by reversible manipulation and then by intervention:
+
+```
+108 skills             -> one description dropped
+111 (+3 probe skills)  -> five dropped
+108 (-3 probes)        -> back to one
+100 (-8 commands)      -> zero; the dropped skill returned
+```
+
+**Adding a skill is a transfer, not an addition** — it silently uninstalls roughly
+its own byte-weight of other skills' descriptions. Total description budget across
+all fourteen skills: **8,208 bytes**.
+
+This is why consolidation here is a resource constraint rather than a preference.
+
+## Migration from 4.1.0
+
+- **`using-epistemic-skills` and `helix` no longer exist.** Invoke `metacognate`
+  instead. It is the only skill invoked by name; every other member fires on its
+  own `description`.
+- **Trigger vocabulary maps directly:** "route this", "which skills apply",
+  "pair this with my workflow" → `metacognate`. Its Tier 2 replaces the router's
+  routine gate, and *declining is its most common correct outcome*.
+- **Install exactly one mechanism per harness**, as before. Replace the older
+  copy; do not stack them.
+- **Evaluation corpora moved** from `skills/using-epistemic-skills/evals/` and
+  `skills/helix/evals/` to package-level `evals/`. Any local automation
+  referencing those paths must be repointed.
+
+## Evidence posture (honest status)
+
+- **Deterministic suite:** the complete local gate passes on the release commit —
+  0 non-usage failures across every step the workflow declares, at 14 skills /
+  13 disciplines.
+- **Clean-room verification:** run in a fresh Linux clone of the release ref, on a
+  machine that did not author the change. It found two real defects on its first
+  run that every Windows run had passed — an environment-dependent guard, and a
+  broken relative link.
+- **Behavioral superiority: UNESTABLISHED, unchanged.** The four-arm campaign
+  found **no arm separation** (primary D>A `p=0.875`; A=5 B=4 C=7 D=4 of 18).
+  Nothing in this release alters that. A tidier architecture is not evidence that
+  the skills improve outcomes, and this release does not claim it is.
+- **Two eval batteries were retired**, their subjects having been deleted:
+  the composition contract battery, and the blinded-proportionality battery which
+  asserted the router's enumerated routing content. **Results and experimental
+  design were kept in full**; only the harnesses were retired. Each carries a
+  `RETIRED.md`.
+
+## Release gate status — two items unmet
+
+Per `RELEASING.md` §Release gate:
+
+| Item | Status |
+|---|---|
+| 4 — version surfaces aligned, link-existence checked | **met.** All ten surfaces agree on 5.0.0. Version-pinned URLs were checked individually: `.../using-epistemic-skills/reference/routine-fast-path.md` does not exist in the v5 tree, so that link was repointed to the file's new home rather than blind-bumped — the P1 class caught in v3.2.0. |
+| 5 — deterministic suite, DCO, manifest parity, committed-JSON | **partially met.** Suite, DCO equivalence, manifest parity and JSON checks pass. **CodeQL has not run.** |
+| 6 — redacted full-history secret scan | **not met.** gitleaks requires a runner. |
+| 8 — independent Gauntlet publication review reaching GO | **not run.** |
+
+GitHub-hosted runners stopped being allocated at 17:10 UTC on 2026-08-06; jobs
+queue unassigned and are auto-cancelled at the 15-minute timeout, which GitHub
+reports as a run-level `failure`. Tracked in issue #95.
+
+**Publication resumes when items 5, 6 and 8 can be satisfied on the exact release
+commit.** The notes ship held rather than the gate shipping bent.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "contextFileName": "GEMINI.md"
 }

--- a/plugins/epistemic-skills/.claude-plugin/plugin.json
+++ b/plugins/epistemic-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/epistemic-skills/.codex-plugin/plugin.json
+++ b/plugins/epistemic-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
   "author": {
     "name": "ZMS Labs",

--- a/plugins/epistemic-skills/.cursor-plugin/plugin.json
+++ b/plugins/epistemic-skills/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "author": {
     "name": "ZMS Labs"
   },

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -11,7 +11,7 @@ HERE = Path(__file__).resolve()
 SKILL_ROOT = HERE.parents[1]
 PACKAGE_ROOT = HERE.parents[3]
 REPO_ROOT = HERE.parents[5]
-EXPECTED_VERSION = "4.1.0"
+EXPECTED_VERSION = "5.0.0"
 
 
 def require(condition: bool, message: str) -> None:


### PR DESCRIPTION
Gate item 4 of `RELEASING.md`, done in the release PR as the procedure requires. **This PR does not publish.** The tag is not created and will not be until the gate can be met.

## Aligned to 5.0.0

Ten version-bearing surfaces: nine harness manifests plus the package-integration `EXPECTED_VERSION`. README version statement, release-tag link, immutable-source statement, and install guidance.

## The link-existence check, which actually bites here

`RELEASING.md` warns that a blind version bump can mint links to files that will never exist at that coordinate — a **P1 caught in v3.2.0** that had already shipped undetected in v3.1.0. Every version-pinned URL was checked individually against the v5 tree:

| URL | Action |
|---|---|
| `tree/v4.1.0/plugins/epistemic-skills/skills` | bumped — path exists at v5 |
| `blob/v4.1.0/.../using-epistemic-skills/reference/routine-fast-path.md` | **not blind-bumped.** That path does not exist in v5. Its content moved when the router seat was deleted, so the link was **repointed** to `.../metacognate/reference/routine-fast-path.md`, which will exist at the tag |
| `blob/v3.2.0`, `blob/v3.3.0` release docs | left alone — historical |

## Historical vs live, applied deliberately

README's per-version count table says *v4.1.0 ships eleven*. **That is true and stays true** — v5.0.0 was added alongside it, not over it. Install guidance and harness-surface tables are live and were bumped, including the verification count (eleven → **fourteen**).

## Release gate status

| Item | Status |
|---|---|
| 4 — version surfaces + link existence | **met** |
| 5 — deterministic suite, DCO, manifest parity, committed JSON | **partial** — suite, DCO equivalence, parity and JSON pass; **CodeQL has not run** |
| 6 — redacted full-history secret scan | **not met** — gitleaks needs a runner |
| 8 — independent Gauntlet publication review reaching GO | **not run** |

GitHub-hosted runners stopped being allocated at **17:10 UTC**; jobs queue unassigned and auto-cancel at the 15-minute timeout, which GitHub reports as a run-level `failure`. Tracked in #95.

`RELEASING.md` says never improvise around the gate. **So the tag waits.** Aligning version surfaces is preparation; creating the tag is publication; the two are kept distinct on purpose.

## Local gate on this commit

`0` non-usage failures across every step the workflow declares. `sync --check`: **14 skills, 13 disciplines**.

## What publication still needs

1. Actions runners available (org spending limit — #95)
2. CodeQL + full-history secret scan green on the exact release commit
3. An independent Gauntlet publication review reaching GO
4. Annotated tag `v5.0.0`, non-draft Release from `docs/release/RELEASE-5.0.0.md`, then the four identity assertions in §Procedure step 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121zdSgSmJv3gRwgrmwXRrZ