### PR TITLE
docs: repair the README front page, including the find/replace that renamed history

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The README is the fast path into the project. The [GitHub Wiki](https://github.c
 
 Most agent-skill collections organize **how work proceeds**: brainstorming, planning, implementation, debugging, review, and verification. epistemic-skills sits beneath that workflow layer and asks a different question: **what would make the target, decision, evidence, handoff, or acceptance claim trustworthy enough to bear load?**
 
-The package provides **fourteen** skills: one entry point, **thirteen** disciplines, and Helix—the passage that pairs those disciplines with a workflow-skill layer such as [superpowers](https://github.com/obra/superpowers). Each method has a positive trigger, an output contract, and a stopping boundary.
+The package provides **fourteen** skills: one entry point and **thirteen** disciplines. Pairing them with a workflow-skill layer such as [superpowers](https://github.com/obra/superpowers) is a judgment the entry point makes at the moment it is needed, not a separate seat. Each method has a positive trigger, an output contract, and a stopping boundary.
 
 It is not:
 
@@ -61,10 +61,10 @@ Users and maintainers are equal first-class audiences:
 | [Start Here](https://github.com/ZMS-Labs/epistemic-skills/wiki/Start-Here) | [Architecture and Contracts](https://github.com/ZMS-Labs/epistemic-skills/wiki/Architecture-and-Contracts) |
 | [Choosing a Skill](https://github.com/ZMS-Labs/epistemic-skills/wiki/Choosing-a-Skill) | [Cross-Harness Packaging](https://github.com/ZMS-Labs/epistemic-skills/wiki/Cross-Harness-Packaging) |
 | [Routine Work and Proportionality](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) | [Testing and Evaluations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Testing-and-Evaluations) |
-| [Helix: Central Passage](https://github.com/ZMS-Labs/epistemic-skills/wiki/Helix-Central-Passage) | [Evidence, Status, and Known Limitations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Evidence-Status-and-Known-Limitations) |
-| [Workflow Recipes](https://github.com/ZMS-Labs/epistemic-skills/wiki/Workflow-Recipes) | [Contributing](https://github.com/ZMS-Labs/epistemic-skills/wiki/Contributing) |
-| [Installation and Harness Compatibility](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) | [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) |
-| [Skill Catalog](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Catalog) | [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO) |
+| [Workflow Recipes](https://github.com/ZMS-Labs/epistemic-skills/wiki/Workflow-Recipes) | [Evidence, Status, and Known Limitations](https://github.com/ZMS-Labs/epistemic-skills/wiki/Evidence-Status-and-Known-Limitations) |
+| [Installation and Harness Compatibility](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) | [Contributing](https://github.com/ZMS-Labs/epistemic-skills/wiki/Contributing) |
+| [Skill Catalog](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Catalog) | [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) |
+| | [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO) |
 
 The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v5.0.0` source controls.
 


### PR DESCRIPTION
> **Scope grew after opening.** `ab53ab8` landed on `main` while this PR was open, attempting the same fix by find/replace. It made things worse in four places rather than better in one. This PR now merges `main` and repairs all of it. Original description below the fold.

## What `main` currently says

`ab53ab8 "Update README to replace 'Helix' with 'Metacognate'"` is a blind substitution of `Helix`→`Metacognate` and `helix`→`metacognate`. Four resulting statements on the front page of a published package:

| Line | `main` says | Reality |
|---|---|---|
| 43 | "fourteen skills: one entry point, thirteen disciplines, **and Metacognate**" | `metacognate` **is** the entry point — now counted twice. And it is called "the passage that pairs those disciplines", which was the deleted seat's role. The arithmetic error the rename was meant to fix survives it: 1 + 13 + 1 = 15, stated as 14. |
| 64 | links wiki page `Metacognate-Central-Passage` | That page does not exist. A dead link became a *differently* dead link with a more convincing name. |
| 125 | "the former **`metacognate`** pair table was replaced rather than renamed" | `metacognate` never had a pair table. `helix` did. This asserts the opposite of what happened. |
| 128 | "Replaced `using-epistemic-skills` and **`metacognate`** in v5.0.0. **Both seats were deleted**" | States that the package's only invoked-by-name skill was deleted by the release that added it. |

Lines 125 and 128 are the ones this PR had **deliberately left alone**, because they were correct historical references to a deleted seat. A rename that cannot distinguish *"this seat exists"* from *"this seat used to exist"* corrupts precisely the sentences that were already right.

**Those two merged cleanly.** Only `main` changed them, so git had no reason to flag text that is syntactically fine and semantically false. A clean merge is not evidence of a correct one.

---

## Original defect (still the core of this PR)

`README.md:43` read:

> The package provides **fourteen** skills: one entry point, **thirteen** disciplines, and Helix—the passage that pairs those disciplines with a workflow-skill layer such as superpowers.

`helix` was deleted in v5.0.0, and the arithmetic never worked. The "Choose your path" table then linked a wiki page for it.

## The fix

Describes what the package ships, with the pairing placed where it actually lives — `metacognate` makes that judgment at the moment it is needed rather than occupying a seat, which is the v5 design decision. The Helix row is removed from the wiki table and the remaining twelve entries re-flowed, rather than renamed to a page that does not exist. Lines 125 and 128 are restored to referring to `helix`, which is what they are about.

**The wiki itself is a separate unversioned surface and is not touched here.** Note that `Metacognate-Central-Passage` does not exist there; if a page was created to match `ab53ab8`, it should go.

Net vs `main`: **7 insertions, 7 deletions**, no line-ending noise.

## Why CI did not catch the original

`check_no_phantom_skills.py` **does** scan `README.md`, and passes. Its own success line says why:

```
no phantom skill references: 14 live skills; 9 retired names allowed in prose,
banned in routing surfaces
```

It matches `skills/<name>/` **path** references. A prose mention of a deleted skill is outside its scope — and that scope is **deliberate, not broken**: widening it to prose names would fire on the two legitimate historical mentions this PR restores.

So this is a blind spot to report, not a bug to fix. A guard's regex scope is its blind spot, and this one's includes the package's own front page. Closing it properly needs a different oracle — one that checks *claims about what the package contains* against the skills glob — which is a larger question than this PR.

It would not have caught `ab53ab8` either, for the same reason.

## CI status

No repo workflow has dispatched for any PR in this repo since 18:21 UTC — see [#95](https://github.com/ZMS-Labs/epistemic-skills/issues/95) for the diagnosis and what was ruled out. `check_no_phantom_skills.py` was run locally against this branch and passes. **This PR has not been verified by CI.**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121zdSgSmJv3gRwgrmwXRrZ
