### PR TITLE
ci: add workflow_dispatch to the two release-gate workflows

### DIFF
--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -1,6 +1,12 @@
 name: epistemic-flexibility
 
 "on":
+  # Manual trigger. A release gate reachable only by pushing a commit cannot be run
+  # against the exact commit you are about to tag, which is what the gate asks for.
+  # It is also the only way in when event delivery stalls: on 2026-08-06 no `push`
+  # or `pull_request` event dispatched a run in this repository for over an hour,
+  # while `pull_request_target` and GitHub-managed workflows kept working.
+  workflow_dispatch:
   pull_request:
     paths:
       - "plugins/epistemic-skills/skills/**"

--- a/.github/workflows/release-security.yml
+++ b/.github/workflows/release-security.yml
@@ -1,6 +1,9 @@
 name: release-security
 
 "on":
+  # Manual trigger, so the full-history scan can be run against the exact commit
+  # being released rather than only as a side effect of pushing one.
+  workflow_dispatch:
   # Secrets can be introduced anywhere in the tree. Do not narrow either trigger
   # with path filters: doing so creates an unscanned path to main.
   pull_request:


### PR DESCRIPTION
Neither release-gate workflow could be run on demand — both were reachable only as a side effect of pushing a commit or opening a PR.

That fails the gate on its own terms. `RELEASING.md` asks for CodeQL and the full-history secret scan **on the exact release commit**, and there was no way to ask for that.

It also left no way in when event delivery stalls. From ~20:03 UTC on 2026-08-06, no `push` or `pull_request` event dispatched a run in this repo — PR #97 received nothing across open, reopen, a merge push, and a forced synchronize — while `pull_request_target` (DCO) and GitHub-managed CodeQL kept dispatching. Not quota (29,752/50,000 min, \/usr/bin/bash billable) and not queue depth (3 runs in flight org-wide). Diagnosis in #95.

**No trigger is narrowed and no path filter is touched.** `release-security`'s comment about never adding path filters still holds and is left in place.

Verified locally: both files parse, triggers resolve to `[pull_request, push, workflow_dispatch]`, and the full gate reports 0 non-usage failures across every step the workflow declares.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121zdSgSmJv3gRwgrmwXRrZ