### PR TITLE
Explore leveraging Fudge DESIGN.md as visual craft doctrine

### DIFF
--- a/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
@@ -4,6 +4,7 @@
 **Branch:** `cursor/fudge-design-md-leverage-b285`  
 **Draft PR:** [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100)  
 **Design spec:** [`docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md`](../superpowers/specs/2026-08-06-fudge-design-md-leverage.md)  
+**Stack alignment (Fudge + Claude Design + frontend-design + Impeccable):** [`docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md`](../superpowers/specs/2026-08-07-visual-design-stack-alignment.md)  
 **Draft craft stub:** [`plugins/epistemic-skills/reference/craft/visual-design-md.md`](../../plugins/epistemic-skills/reference/craft/visual-design-md.md)  
 **Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT)  
 **Status:** recommendations recorded; **not operator-approved**; no implementation beyond this exploratory PR
@@ -17,6 +18,13 @@ approves the design and the exploratory markers are removed.
 **Ship Approach A only:** thin craft doctrine under
 `plugins/epistemic-skills/reference/craft/visual-design-md.md`, pin Fudge
 guides **by link**, do not vendor the collection, do not add a routed skill.
+
+**Stack (2026-08-07):** Treat Fudge as the *reference seed*; **Claude Design**
+(canvas + org design system + Claude Code handoff/`/design-sync` on API) as
+*optional Claude-harness exploration* — distinct from the **`frontend-design`**
+skill; Impeccable as *optional per-project* `PRODUCT.md` / `DESIGN.md` + commands.
+See the alignment spec. Do **not** bundle Impeccable or Claude Design into
+`epistemic-skills` (D8 budget).
 
 ### Why
 

--- a/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
@@ -1,0 +1,68 @@
+# Handoff — Fudge DESIGN.md leverage recommendations
+
+**Date:** 2026-08-06  
+**Branch:** `cursor/fudge-design-md-leverage-b285`  
+**Draft PR:** [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100)  
+**Design spec:** [`docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md`](../superpowers/specs/2026-08-06-fudge-design-md-leverage.md)  
+**Draft craft stub:** [`plugins/epistemic-skills/reference/craft/visual-design-md.md`](../../plugins/epistemic-skills/reference/craft/visual-design-md.md)  
+**Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT)  
+**Status:** recommendations recorded; **not operator-approved**; no implementation beyond this exploratory PR
+
+This file is the durable pick-up brief for a future agent. Prefer it over chat
+history. Do not treat the draft craft stub as live doctrine until an operator
+approves the design and the exploratory markers are removed.
+
+## Verdict (recommended)
+
+**Ship Approach A only:** thin craft doctrine under
+`plugins/epistemic-skills/reference/craft/visual-design-md.md`, pin Fudge
+guides **by link**, do not vendor the collection, do not add a routed skill.
+
+### Why
+
+1. **Hole is real.** `agent-interface-design` declines human UI;
+   `evidence-locked-uat` accepts UI but does not choose visual direction.
+   Fudge `DESIGN.md` is the missing pre-build visual packet.
+2. **Craft slot matches package law.** v4 already demoted workflow methods to
+   `reference/craft/`. v5 D8 forbids burning description bytes on a new
+   "when doing UI" skill trigger.
+3. **Link > vendor.** Upstream is MIT and churns (~287 guides). Vendoring
+   copies (Approach B) adds stale trees and attribution surface for little
+   gain. Operator-only notes (Approach C) leave the hole invisible to plugin
+   consumers.
+4. **Calibration stays out.** `epistemic-calibration` is no-UI by design;
+   do not invent a surface there under this workstream.
+
+## Do / don't for the next agent
+
+| Do | Don't |
+|---|---|
+| Get operator approval of Approach A (or an explicit override to B/C) before merging as doctrine | Merge the exploratory stub as if it were approved craft |
+| On approval: strip "EXPLORATORY DRAFT" markers; optionally add a one-line craft pointer from wiki/catalog pages the way other craft is listed | Add `visual-design-md` to metacognate roster or any skill description |
+| Keep shortlist as **pointers** to upstream `design-md/<domain>.md` | Copy the full Fudge tree into this repo |
+| If a product needs offline durability, vendor **one** guide with MIT attribution + fetch date | Invent hex/type tokens the capture marked as unknown |
+| Leave `evidence-locked-uat` as acceptance authority | Treat a pinned DESIGN.md as a UAT PASS |
+
+## Defaults on open questions (unless operator overrides)
+
+1. **Approach:** A (craft + pin-by-link).  
+2. **Host Cursor frontend rules:** mention as complementary in craft only if
+   the package stays honest that they are host-local, not portable doctrine;
+   default = stay package-portable and silent about host rules.  
+3. **Pointer from `evidence-locked-uat`:** skip for v1; discovery via craft
+   only. Add a one-liner later only if agents keep skipping the pin.  
+4. **First project-local DESIGN.md:** none required by this PR; spawn a
+   follow-up only when a concrete human-facing surface is in scope.
+
+## Artifacts already on this branch
+
+- Design with A/B/C and recommendation:
+  `docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md`
+- Exploratory craft sketch (same recommendation, operational form):
+  `plugins/epistemic-skills/reference/craft/visual-design-md.md`
+- This handoff
+
+## Stop condition for *this* session
+
+Recommendations are committed on the PR branch for future consideration.
+No further implementation in the originating session.

--- a/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
@@ -5,6 +5,7 @@
 **Draft PR:** [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100)  
 **Design spec:** [`docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md`](../superpowers/specs/2026-08-06-fudge-design-md-leverage.md)  
 **Stack alignment (Fudge + Claude Design + frontend-design + Impeccable):** [`docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md`](../superpowers/specs/2026-08-07-visual-design-stack-alignment.md)  
+**ZMS org design repo placement (skill decision + fleet):** [`docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md`](../superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md) — *blocked until `zms-labs-design` is readable by agents*  
 **Draft craft stub:** [`plugins/epistemic-skills/reference/craft/visual-design-md.md`](../../plugins/epistemic-skills/reference/craft/visual-design-md.md)  
 **Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT)  
 **Status:** recommendations recorded; **not operator-approved**; no implementation beyond this exploratory PR

--- a/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
@@ -1,0 +1,114 @@
+# Leveraging Fudge DESIGN.md for agent visual work
+
+**Date:** 2026-08-06  
+**Status:** exploratory draft (Approach A recommended; not approved)  
+**Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT) · [design.withfudge.com](https://design.withfudge.com/)  
+**Sibling note:** `epistemic-calibration` remains no-UI by design; this proposal does not add a surface there.
+
+## What Fudge DESIGN.md is
+
+[fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) is a curated collection (~287 guides as of this draft) of **agent-consumable visual briefs** generated from real websites captured in Fudge. Each `design-md/<domain>.md` guide typically:
+
+- states a **design character** (mood, hierarchy, what to preserve);
+- separates **captured measurements** from **interpretation**;
+- lists typography / color / spacing / radius observations when retained;
+- shows representative page captures;
+- ends with **practical guidance** and **known gaps** (what the capture did *not* establish).
+
+The intended use, from the upstream README: drop one guide into a project so a coding agent gets a specific visual direction grounded in a real reference, instead of inventing a generic SaaS look.
+
+## Why this package should care
+
+`epistemic-skills` already owns two adjacent seats and leaves a hole between them:
+
+| Seat | Owns | Explicitly declines |
+|---|---|---|
+| `reference/craft/agent-interface-design.md` | Machine contracts another agent consumes | Human-facing UI/UX and docs for people |
+| `evidence-locked-uat` | Acceptance of material UI-facing change | Choosing the visual language before build |
+
+There is **no craft doctrine for grounding visual direction** before an agent paints pixels. Operator Cursor rules already constrain frontend taste (one composition, brand-first, no default purple SaaS, etc.), but those rules are session-global and not project-scoped reference packets. Fudge guides are exactly that missing packet class: portable, citeable, measurement-honest visual contracts.
+
+This is craft, not a new routed skill. Description-byte budget (v5 D8) forbids adding a trigger row for "when doing UI." The pattern matches the v4 demotion of `agent-interface-design` and `intent-traced-merge` into `reference/craft/`.
+
+## Non-goals
+
+- Do **not** vendor the full ~287-guide tree into this repo.
+- Do **not** mint a routed skill or expand the metacognate roster for visual design.
+- Do **not** treat a Fudge guide as a license to clone a brand; adapt character, not trademarked marks or proprietary fonts.
+- Do **not** invent UI for `epistemic-calibration` under this proposal.
+- Do **not** weaken `evidence-locked-uat`: DESIGN.md is pre-build direction, not acceptance evidence.
+
+## Approaches
+
+### A — Craft doctrine + pin-by-link (recommended)
+
+Add thin craft under `plugins/epistemic-skills/reference/craft/visual-design-md.md` that teaches agents:
+
+1. When human-facing visual work starts, **pin one DESIGN.md** (project root or `docs/design/DESIGN.md`) before implementing layout/chrome.
+2. Prefer a Fudge guide matched to the intended character; link upstream rather than copying unless a durable offline pin is required.
+3. Adapt character and token *relationships*; do not treat missing measurements as license to invent a full design system.
+4. Hand off to `evidence-locked-uat` (or the routine presentation check) for acceptance.
+
+**Pros:** Matches package thesis and craft slot; zero description-byte cost; MIT-compatible via link/attribution; reversible.  
+**Cons:** Agents must discover the craft file (same as other craft doctrine).
+
+### B — Curated shortlist vendored under `reference/visual-references/`
+
+Copy a small set of guides (e.g. anthropic, linear, stripe, abc.xyz) into-tree with MIT attribution and a README that maps each to a use case (editorial product, dense workspace, calm infra landing, austere investor page).
+
+**Pros:** Offline, reviewable diffs when upstream changes.  
+**Cons:** Stale copies; license attribution surface; still need craft doctrine for *when/how* to use them; duplicates upstream.
+
+### C — Operator-only convention (no package change)
+
+Document "put a DESIGN.md in the target repo" in fleet notes / Cursor rules only; leave `epistemic-skills` untouched.
+
+**Pros:** Fastest.  
+**Cons:** Invisible to anyone loading the plugin; does not close the craft hole next to `agent-interface-design`.
+
+## Recommended decision
+
+**Ship Approach A** as craft doctrine. Optionally keep a **shortlist pointer table** (links only, no file copies) inside that craft file for common characters. Revisit Approach B only if offline pins become load-bearing for a specific product surface.
+
+## Suggested shortlist (links only)
+
+| Character | Guide | When to prefer |
+|---|---|---|
+| Calm editorial tech | [anthropic.com](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/anthropic.com.md) | Docs, research, long-form product narrative |
+| Dense product workspace | [linear.app](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/linear.app.md) | Operator tools, issue/project chrome |
+| Quiet infra / payments landing | [stripe.com](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/stripe.com.md) | Marketing surfaces that must feel precise, not loud |
+| Austere empty canvas | [abc.xyz](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/abc.xyz.md) | Brand-first pages that win by restraint |
+| Dark developer workstation | [cursor.com](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/cursor.com.md) | Devtool account/settings/marketplace shells |
+
+Full catalog: [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md).
+
+## Relation to existing disciplines
+
+```text
+visual need appears
+        │
+        ▼
+  craft: visual-design-md   ← pin DESIGN.md / Fudge guide (this proposal)
+        │
+        ▼
+  build the surface
+        │
+        ▼
+  evidence-locked-uat       ← routine check or full UAT packet
+        │
+        ▼
+  acceptance claim
+```
+
+`agent-interface-design` remains the twin for **machine** interfaces. A surface that is both human UI and agent-consumed API needs both crafts, applied to their respective layers.
+
+## Open questions for review
+
+1. Approve Approach A (craft + pin-by-link), or prefer B/C?
+2. Should the craft file mention operator frontend Cursor rules as complementary constraints, or stay package-portable and silent about host rules?
+3. Is a one-line pointer from `evidence-locked-uat` ("visual direction should already be pinned; see craft/visual-design-md") worth the coupling, or keep discovery via craft only?
+4. Any ZMS Labs product surface that should get a *project-local* DESIGN.md in a follow-up PR (wiki, future operator UI, etc.)?
+
+## Draft artifact in this PR
+
+See [`plugins/epistemic-skills/reference/craft/visual-design-md.md`](../../../plugins/epistemic-skills/reference/craft/visual-design-md.md) — a concrete Approach A sketch, marked exploratory until this design is approved.

--- a/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
@@ -4,6 +4,7 @@
 **Status:** exploratory draft (Approach A recommended; not approved)  
 **Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT) · [design.withfudge.com](https://design.withfudge.com/)  
 **Future-agent pick-up:** [`docs/handoffs/2026-08-06-fudge-design-md-leverage.md`](../../handoffs/2026-08-06-fudge-design-md-leverage.md)  
+**Stack alignment:** [`2026-08-07-visual-design-stack-alignment.md`](2026-08-07-visual-design-stack-alignment.md) (Fudge + Claude Design + `frontend-design` + Impeccable)  
 **Sibling note:** `epistemic-calibration` remains no-UI by design; this proposal does not add a surface there.
 
 ## What Fudge DESIGN.md is

--- a/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
@@ -3,6 +3,7 @@
 **Date:** 2026-08-06  
 **Status:** exploratory draft (Approach A recommended; not approved)  
 **Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT) · [design.withfudge.com](https://design.withfudge.com/)  
+**Future-agent pick-up:** [`docs/handoffs/2026-08-06-fudge-design-md-leverage.md`](../../handoffs/2026-08-06-fudge-design-md-leverage.md)  
 **Sibling note:** `epistemic-calibration` remains no-UI by design; this proposal does not add a surface there.
 
 ## What Fudge DESIGN.md is

--- a/docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md
+++ b/docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md
@@ -1,0 +1,201 @@
+# Visual design stack alignment — Fudge, Claude Design, frontend-design, Impeccable
+
+**Date:** 2026-08-07 (Claude Design harness section added same day)  
+**Status:** design draft (extends PR [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100); not operator-approved)  
+**Related:** [`2026-08-06-fudge-design-md-leverage.md`](2026-08-06-fudge-design-md-leverage.md) · [`2026-08-06-epistemic-skills-v5-design.md`](2026-08-06-epistemic-skills-v5-design.md) (D8 estate budget)
+
+**Primary external docs (Claude Design ↔ harness):**
+
+- [Get started with Claude Design](https://support.claude.com/en/articles/14604416-get-started-with-claude-design) — canvas flow, `/design-sync`, MCP setup, handoff to Claude Code  
+- [Claude Code commands — `/design-login`, `/design-sync`](https://code.claude.com/docs/en/commands) — bundled skill behavior and API-only availability  
+- [Claude Design admin guide](https://support.claude.com/en/articles/14604406-claude-design-admin-guide-for-team-and-enterprise-plans) — org design systems, rollout, Enterprise admin role  
+
+## Naming (do not conflate)
+
+| Name | What it is | Where it lives |
+|---|---|---|
+| **Claude Design** | Anthropic Labs **product**: chat + canvas for prototypes, decks, microsites; org **design systems**; export and **handoff to Claude Code** | [claude.ai/design](https://claude.ai/design), Claude Desktop sidebar; beta on paid plans |
+| **`frontend-design` skill** | Anthropic **implementation craft** (bold direction, eight domains, anti–AI-slop) — text skill, not the canvas product | Bundled in Impeccable; Apache 2.0 |
+| **Impeccable** | Third-party **harness toolkit** (commands + `frontend-design` + anti-patterns + repo `PRODUCT.md` / `DESIGN.md`) | Per-project `.cursor/skills/` etc. |
+| **Fudge DESIGN.md** | Third-party **capture briefs** (~287 sites) for agent-consumable visual character | Link to [fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) |
+| **`/design-sync`** | Claude Code **bundled skill**: upload/sync a **React** design system with Claude Design | Terminal; requires Anthropic API path to claude.ai |
+| **Claude Design MCP** | HTTP MCP so Claude Code can create/edit design projects without leaving the terminal | `claude mcp add --scope user --transport http claude-design https://api.anthropic.com/v1/design/mcp` + `/design-login` per Help Center |
+
+“Claude design” in operator conversation often means **Claude Design the product**, not the **`frontend-design` skill**. This document treats both and states how they compose.
+
+## Problem
+
+Five layers can all speak “design” to agents, with overlapping goals but different
+shapes, install surfaces, and authority:
+
+| Layer | Primary artifact | Typical harness |
+|---|---|---|
+| Fudge guide | Upstream `design-md/<domain>.md` | Any |
+| Claude Design | Org design system + canvas project + handoff bundle | Web/Desktop; Claude Code via MCP/handoff |
+| Repo `DESIGN.md` / `PRODUCT.md` | Stitch-style / Impeccable context | Cursor, Claude Code, Codex, … |
+| `frontend-design` | Skill doctrine | Impeccable or host-shipped skill |
+| Impeccable commands | Audit, polish, normalize, … | Cursor nightly / other harnesses |
+
+Without alignment, agents pin a Fudge file, skip org design systems, ignore a
+Claude Design handoff, or treat canvas output as shipped software — while
+`DESIGN.md` means three different things.
+
+## Design goal
+
+One **ordered stack** with clear seats, **harness-aware branches**, and
+`epistemic-skills` staying package-portable (craft pointers only — no vendoring
+Fudge, Impeccable, or Claude Design).
+
+## Recommended stack (harness-aware)
+
+### A — Claude Code on Anthropic API (full loop available)
+
+```text
+Human-facing UI work starts
+        │
+        ├─ Optional exploration: Claude Design (canvas) OR Fudge character seed
+        │
+        ▼
+[1] epistemic-skills craft: visual-design-md
+        │  Direction pinned? If React DS exists: note /design-sync expectation
+        ▼
+[2] Claude Design integration (when used)
+        │  /design-login → org design system attached to project
+        │  /design-sync [hint]  — repo React DS → Claude Design (re-run after DS changes; not a watcher)
+        │  Optional MCP: claude-design server for terminal create/edit
+        │  Handoff bundle → Claude Code (continues from design work, not a screenshot-only prompt)
+        ▼
+[3] Repo ground truth
+        │  PRODUCT.md + DESIGN.md (Impeccable when installed)
+        │  Fudge link only in Reference section if it seeded character
+        ▼
+[4] Build / refine in code
+        │  frontend-design principles; Impeccable audit · normalize · polish
+        ▼
+[5] evidence-locked-uat
+        ▼
+Acceptance claim
+```
+
+**Constraints from Anthropic docs:**
+
+- `/design-sync` is **unavailable** on Amazon Bedrock, Google Cloud Agent
+  Platform, Microsoft Foundry, and Claude Platform on AWS — the tool cannot reach
+  claude.ai ([commands reference](https://code.claude.com/docs/en/commands)).
+  On those deployments, use branch **B** only.
+- First `/design-sync` on a large React repo can take hours (per-component verify).
+- Claude Design without an org design system still produces **functional but
+  generic** output ([admin guide](https://support.claude.com/en/articles/14604406-claude-design-admin-guide-for-team-and-enterprise-plans)) — same failure class as unpinned Fudge.
+
+### B — Cursor and other harnesses (no Claude Design product API)
+
+```text
+visual-design-md craft → Fudge seed (link) → repo DESIGN.md/PRODUCT.md (Impeccable)
+        → frontend-design / Impeccable during build → evidence-locked-uat
+```
+
+Do not instruct Cursor agents to run `/design-sync` or depend on Claude Design
+MCP. Treat Claude Design handoff artifacts as **inputs** when the operator
+drops them into the repo or task, not as an assumed integration.
+
+### C — Machine-only surfaces
+
+`agent-interface-design` only; this stack does not apply.
+
+## Role of each layer
+
+### Claude Design (product) — *explore, systematize, hand off*
+
+- **Owns:** Canvas iteration, org-scoped design systems (from codebase, GitHub,
+  uploads, web capture), exports (HTML, PDF, PPTX, partners), **handoff bundle**
+  into Claude Code.
+- **Does not own:** Production merge authority, CI acceptance, or epistemic
+  claims about “done.”
+- **epistemic-skills stance:** Document as **optional Claude-harness path** in
+  craft; never bundle or proxy Claude Design inside the plugin. Handoff bundle +
+  implemented code still require **evidence-locked-uat** for material UI claims.
+
+### `/design-sync` + `/design-login` — *bridge code ↔ Claude Design*
+
+- **Owns:** Keeping Claude Design’s generated UI aligned with **real React
+  components** in the repo (push/upload semantics per Anthropic; re-sync after
+  token/component changes).
+- **Does not own:** Non-React stacks, offline harnesses, or automatic bidirectional
+  merge without operator review (community reports: design→code may need explicit
+  steps beyond a single command).
+- **epistemic-skills stance:** Mention in craft under “when on Claude Code (API)”;
+  point to official commands doc; flag Bedrock/Foundry gap.
+
+### Fudge DESIGN.md — *reference seed*
+
+(Unchanged from PR #100.) Capture-derived character; link-by-default; cite in
+project `DESIGN.md` when Impeccable or Claude Design org system is primary.
+
+### Claude `frontend-design` — *implementation craft*
+
+(Unchanged.) Distinct from Claude Design product; execution quality during coding.
+
+### Impeccable — *repo-local design ops*
+
+(Unchanged.) Out of `epistemic-skills` package; complements both Cursor and
+Claude Code terminal work **after** direction exists.
+
+## Resolving `DESIGN.md` and “design system” collisions
+
+| Artifact | Authority |
+|---|---|
+| Claude Design **org design system** (cloud) | Source for **canvas** and synced React components after `/design-sync` |
+| Repo **`DESIGN.md`** (Impeccable / Stitch) | **Build-time truth** for coding agents in that repo |
+| Fudge **`design-md/*.md`** | **Reference seed** only — mood, hierarchy, gaps |
+| Claude Design **handoff bundle** | **Contract input** for implementation session — not a PASS |
+
+**Rule:** One primary repo `DESIGN.md` per surface. After `/design-sync`, prefer
+**real components** over re-inventing markup. If Fudge seeded the project, keep a
+short Reference section; do not let Fudge override synced org tokens.
+
+## Composability matrix (extended)
+
+| Situation | Claude Design | /design-sync | Fudge | Impeccable | Craft |
+|---|---|---|---|---|---|
+| Greenfield UI, Claude Code API, React DS | Explore on canvas → handoff | Before/after DS changes | Optional character seed | `init` / `document` | Pin + harness note |
+| Greenfield UI, Cursor only | N/A (operator may explore manually) | N/A | Pin link | `init` / `document` | Pin mandatory |
+| Brownfield React, DS in repo | Optional polish on canvas | Re-sync when components change | Skip | `normalize` / `audit` | Light gate |
+| Bedrock / Foundry Claude Code | Not available | **Unavailable** | Pin + repo files | If installed | Full B path |
+| Deck / PPTX only | Claude Design primary | Optional | Rare | N/A | UAT if “product UI” claim |
+| Agent API only | — | — | — | — | `agent-interface-design` |
+
+## Conflicts and how to decide
+
+| Tension | Resolution |
+|---|---|
+| Claude Design canvas vs repo `DESIGN.md` | Canvas explores; repo file + synced components win at implementation unless operator explicitly adopts export-only HTML without code integration. |
+| Handoff bundle vs UAT | Handoff = starting point for code; **evidence-locked-uat** gates material UI acceptance. |
+| Claude Design generic output vs Fudge pin | Set up org design system or pin Fudge **before** broad rollout; admin guide recommends DS-first rollout. |
+| `frontend-design` “BOLD” vs Fudge restraint | Bold within pinned character (unchanged). |
+| Impeccable vs Claude Design | Complementary: Claude Design for visual exploration/system sync on Claude harness; Impeccable for terminal command passes on repo files. |
+| Purple SaaS / AI slop | All layers agree it is a failure mode. |
+| Skill estate budget (D8) | Do not add Claude Design or Impeccable into `epistemic-skills`; craft links only. |
+
+## What changes in PR #100 (if accepted)
+
+1. **`visual-design-md.md`** — Stack section includes Claude Design branch,
+   `/design-sync` prerequisites, MCP pointer, Bedrock caveat, handoff ≠ UAT.
+2. **This spec** — Canonical alignment doc for all four names plus harness table.
+3. **Handoff** — Operator: approve harness branches; whether wiki documents
+   Claude Design for ZMS fleet Claude Code users.
+4. **Still out of scope:** Vendoring any third-party design tree; new routed
+   skill; `epistemic-calibration` UI.
+
+## Operator decisions needed
+
+1. Approve stack **A vs B** defaults per fleet (Claude Code API vs Cursor-primary).
+2. Whether ZMS standardizes **org design system in Claude Design** before agent UI work.
+3. Impeccable naming in package docs (unchanged recommendation: yes, optional).
+4. Require **handoff bundle + UAT** for any UI merged from Claude Design canvas.
+
+## Open follow-ups
+
+- Fudge section → Stitch `DESIGN.md` mapping table (one page).
+- Fleet runbook: `/design-login` once per user, when to re-run `/design-sync`,
+  MCP scope (`user` vs `project`).
+- Project PR template when a surface uses Claude Design handoff (paths, anchors).

--- a/docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md
+++ b/docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md
@@ -158,4 +158,4 @@ Avoid: pasting tokens into each repo’s `DESIGN.md` without a single upstream.
 
 1. Diff this doc against `zms-labs-design` README, ADRs, and any existing skills.
 2. Update [`visual-design-md.md`](../../../plugins/epistemic-skills/reference/craft/visual-design-md.md) with the **canonical pin URL/path** for ZMS.
-3. Optionally add `zms-labs-design` to the Cloud Agent environment `repos` array.
+3. Optionally add `zms-labs-design` to the [Cloud Agent environment](https://cursor.com/dashboard/cloud-agents/environments/e/688d12dd-9109-11f1-ba66-0e7d0216e441) repos (see `epistemic-calibration/.cursor/environment.json` `repositoryDependencies`).

--- a/docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md
+++ b/docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md
@@ -1,0 +1,161 @@
+# ZMS Labs design — fleet placement & skill decision
+
+**Date:** 2026-08-07  
+**Status:** draft — **blocked on reading** [`ZMS-Labs/zms-labs-design`](https://github.com/ZMS-Labs/zms-labs-design)  
+**Extends:** PR [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100), [`2026-08-07-visual-design-stack-alignment.md`](2026-08-07-visual-design-stack-alignment.md)
+
+## Access note (this session)
+
+From the Cloud Agent environment (`cursor` GitHub integration):
+
+- `gh repo view ZMS-Labs/zms-labs-design` → **404**
+- Anonymous `git ls-remote` → **repository not found**
+- Public HTTP fetch of the repo URL → **404**
+
+So either the repository is **private** and the agent app lacks org/repo access, or it is **not created yet** under that exact name. This document coheres PR #100 with the **intended** role of `zms-labs-design` as the org design home. **Reconcile against the real README/philosophy** once the repo is cloned (add it to the [Cloud environment](https://cursor.com/dashboard/cloud-agents) repos + grant the Cursor GitHub App access to `zms-labs-design`).
+
+---
+
+## Intended philosophy (coherence with PR #100)
+
+PR #100 argues: human-facing visual work needs a **pinned direction** before pixels;
+acceptance stays with `evidence-locked-uat`; machine contracts stay with
+`agent-interface-design`. That is **epistemic choreography**, not a design system.
+
+**`zms-labs-design` (intended seat)** should own what PR #100 deliberately refuses
+to put in `epistemic-skills`:
+
+| Concern | Owner | Rationale |
+|---|---|---|
+| Brand, tokens, components, typography, motion rules | **`zms-labs-design`** | Durable product/org artifact; versioned; human + agent consumable |
+| When to pin direction / hand off to UAT | **`epistemic-skills` craft** (`visual-design-md`) | Portable method; link, don’t vendor |
+| Canvas exploration + org DS in Anthropic cloud | **Claude Design** + `/design-sync` | Harness product; sync **from** `zms-labs-design` when React DS exists |
+| Terminal polish / anti-slop passes | **Impeccable** (optional per harness) | Third-party; reads repo `DESIGN.md` |
+| Greenfield character before ZMS DS exists | **Fudge** (link only) | External reference seed |
+| “It works on screen” / material UI claims | **`evidence-locked-uat`** | Epistemic acceptance |
+
+**One sentence:** `zms-labs-design` is the **organization’s visual source of truth**;
+`epistemic-skills` teaches **when and how agents must bind to that truth** (or an
+explicit interim pin) before building and before claiming done.
+
+### What should live in `zms-labs-design` (target shape)
+
+Pending repo content, expect at least:
+
+1. **Canonical `DESIGN.md`** (and/or Stitch-style packet) — what every ZMS human UI repo should cite or submodule.
+2. **`PRODUCT.md` template or org default** — strategy layer Impeccable/Claude Design expect.
+3. **Implementable design system** — tokens, components; if React, the **sync source** for Claude Design `/design-sync`.
+4. **Consumption contract** — how product repos pin a version (git submodule, npm package, copied hash-pinned excerpt).
+5. **Explicit non-goals** — not epistemic disciplines, not fleet health, not calibration science (`epistemic-calibration` stays no-UI).
+
+### What should *not* move into `epistemic-skills`
+
+- Full Fudge tree, Impeccable bundle, or Claude Design
+- ZMS brand tokens (duplicates `zms-labs-design` and breaks portability thesis)
+- A second copy of org `DESIGN.md` that can drift
+
+---
+
+## (a) Does a skill deserve to exist — and in which repo?
+
+Use the **subject test** (v5 design): `epistemic-skills` owns **claims that must bear
+load** about work, reasoning, or running systems. Visual taste and token compliance
+are **workflow substrate**, not an epistemic moment — same reason
+`agent-interface-design` was demoted to **craft**.
+
+### Decision table
+
+| Candidate | Verdict | Where |
+|---|---|---|
+| New **routed** `visual-design` / `design-system` skill in **`epistemic-skills`** | **No** | Description-byte budget (D8); duplicates craft + UAT; wrong subject |
+| **`visual-design-md` craft** in `epistemic-skills` | **Yes** (thin) | Points to org DS + stack; no ZMS tokens inside portable core |
+| **ZMS-specific “apply our DS” skill** (normalize, token lint, component names) | **Yes, if needed** | **`zms-labs-design`** (or a tiny plugin *published from* that repo) — not copied into every app repo |
+| **Impeccable** | **No new org skill** | Install per harness/project; already ~1.2k description bytes in estate |
+| **`evidence-locked-uat`** in product repos | **Already in `epistemic-skills`** | Same package everywhere; do not fork |
+| **Per-repo design skill** in each ZMS-Labs app | **No** | Drift, budget burn, inconsistent triggers |
+
+### Recommended rule for “any repo within ZMS-Labs”
+
+- **Every repo** that ships human UI: **depends on** `zms-labs-design` (pin) + loads **`epistemic-skills`** (unchanged).
+- **At most one** org-owned design-application skill/package: lives with **`zms-labs-design`**, not N copies.
+- **Zero** new routed visual skills in `epistemic-skills` unless the subject test changes (e.g. you need *epistemic* gates on design *claims* — that is still `evidence-locked-uat` / `gauntlet`, not a design skill).
+
+### If `zms-labs-design` already ships agent skills
+
+Map each skill to:
+
+- **Application** (use tokens) → keep in `zms-labs-design`
+- **Acceptance** (prove UI) → invoke `evidence-locked-uat` from `epistemic-skills`
+- **Exploration** (canvas) → Claude Design + handoff, not a repo skill
+
+---
+
+## (b) Leveraging design across repos, fleets, services, clusters
+
+Think in **layers**, not “install design everywhere.”
+
+```text
+                    ┌─────────────────────────────┐
+                    │   zms-labs-design (Git)      │
+                    │   DESIGN.md · tokens · DS    │
+                    └──────────────┬──────────────┘
+           pin / submodule / package │
+     ┌─────────────┬───────────────┼───────────────┬─────────────┐
+     ▼             ▼               ▼               ▼             ▼
+ product repos  Claude Design   Claude Code    Cursor fleet   (future)
+ (UI apps)      org DS          /design-sync   Impeccable     surfaces
+     │             │               │               │
+     └─────────────┴─────── build in repo ────────┘
+                           │
+                           ▼
+              epistemic-skills: evidence-locked-uat
+                           │
+     ┌─────────────────────┴─────────────────────┐
+     ▼                                           ▼
+ headless services / jobs                   K8s clusters
+ (no visual-design-md)                      health · triage · watch
+```
+
+### By surface type
+
+| Surface | Design leverage | Epistemic package |
+|---|---|---|
+| **Human UI repos** (wiki, canvas chrome, operator tools) | Pin `zms-labs-design`; optional Fudge only pre-DS; Impeccable or Claude path per harness | `visual-design-md` craft + `evidence-locked-uat` |
+| **Libraries / APIs / agents** | `agent-interface-design` only | No visual craft |
+| **Homelab / fleet ops** | `LOCAL.md` overrides; site-specific diagnostics stay out of portable DS | `health` · `triage` · `watch` (v5) |
+| **Clusters (K8s)** | Dashboards only if product-owned; DS from `zms-labs-design` | Runtime truth ≠ pixel polish |
+| **Claude Code fleet** | `/design-login`; `/design-sync` from DS rooted in `zms-labs-design`; handoff bundles land in product repos | Same `epistemic-skills` install |
+| **Cursor / cloud agents** | Environment lists repos; add `zms-labs-design` to agent environment; craft points to pinned DS path | No `/design-sync` unless API path |
+
+### Distribution patterns (pick one primary)
+
+1. **Git submodule** `vendor/zms-labs-design` + CI check that `DESIGN.md` hash matches tag.
+2. **Published package** (`@zms-labs/design-tokens`) consumed by apps; `DESIGN.md` generated or copied at release.
+3. **Claude Design org default** fed by periodic `/design-sync` from the package’s React layer.
+
+Avoid: pasting tokens into each repo’s `DESIGN.md` without a single upstream.
+
+### Fleet-wide agent instructions
+
+| Layer | What to configure once |
+|---|---|
+| **Org** | Claude Design enabled; design system sourced from `zms-labs-design`; admin role for publish |
+| **`epistemic-skills`** | Approve craft; one line in README/wiki: “ZMS UI pins `zms-labs-design` @ ref” |
+| **`zms-labs-design`** | Version tags; consumption doc; optional ZMS design skill/plugin |
+| **Each UI repo** | `PRODUCT.md` local; `DESIGN.md` = pointer or re-export; UAT in CI for material UI |
+| **Harness** | Impeccable in `.cursor/skills` where Cursor; Claude MCP where Code |
+
+---
+
+## Operator decisions (unblocks implementation)
+
+1. **Confirm `zms-labs-design` exists and grant** Cursor GitHub App + Cloud Environment repo access.
+2. **Approve:** no routed visual skill in `epistemic-skills`; org design skill only in `zms-labs-design` if needed.
+3. **Choose distribution:** submodule vs npm vs sync-only Claude Design.
+4. **Merge PR #100 craft** after aligning README in `zms-labs-design` with this split (no contradiction).
+
+## Next step after repo is readable
+
+1. Diff this doc against `zms-labs-design` README, ADRs, and any existing skills.
+2. Update [`visual-design-md.md`](../../../plugins/epistemic-skills/reference/craft/visual-design-md.md) with the **canonical pin URL/path** for ZMS.
+3. Optionally add `zms-labs-design` to the Cloud Agent environment `repos` array.

--- a/plugins/epistemic-skills/reference/craft/visual-design-md.md
+++ b/plugins/epistemic-skills/reference/craft/visual-design-md.md
@@ -1,0 +1,105 @@
+<!-- craft doctrine: visual-design-md — EXPLORATORY DRAFT (2026-08-06).
+     Not approved craft. Proposal lives in
+     docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md.
+     Pattern mirrors agent-interface-design: workflow/craft method, not a
+     routed epistemic skill; no description-byte budget claim. -->
+
+# visual-design-md — pin a visual contract before painting pixels
+
+When work produces a **human-facing** visual surface (landing page, product
+chrome, docs site, operator UI), the failure mode is not only wrong acceptance —
+it is an ungrounded visual invention: purple-on-white SaaS defaults, card soup,
+or a first viewport that could belong to any brand.
+
+`agent-interface-design` owns machine contracts and **declines** human UI.
+`evidence-locked-uat` owns acceptance of material UI and **does not** choose
+the look. This craft fills the gap: **encode visual direction as a pinned
+DESIGN.md before implementing layout and chrome.**
+
+## Evidence posture
+
+This craft is **methodological**, not literature-graded. Upstream Fudge guides
+are capture-derived briefs with explicit known gaps; treat missing tokens as
+unknown, not as permission to invent a full system. Do not overclaim that a
+DESIGN.md improves acceptance rates — UAT still owns acceptance.
+
+## Where this sits
+
+| Slot | Skill / craft | Relation |
+|---|---|---|
+| Machine contract to another agent | `reference/craft/agent-interface-design.md` | Twin for agent-consumed schemas; not for human pixels |
+| Visual direction before build | **this craft** | Pins character, hierarchy, and measured relationships |
+| Acceptance of the built surface | `evidence-locked-uat` | Judges the rendered surface; does not pick the reference |
+| High-blast-radius product claims | `gauntlet` | Adversarial review when stakes require it |
+
+## Core moves
+
+1. **Pin one guide.** Before implementing human-facing layout, place or link a
+   `DESIGN.md` at the project root or `docs/design/DESIGN.md`. Prefer a single
+   primary reference over a collage of five.
+2. **Match character, not celebrity.** Choose a Fudge guide (or a
+   project-authored DESIGN.md in the same shape) for the *mood and hierarchy*
+   you need — editorial calm, dense workspace, austere empty canvas, dark
+   workstation — not because the brand is fashionable.
+3. **Adapt; do not clone.** Preserve relationships (scale ratios, accent
+   scarcity, separator-over-shadow, open field vs dense chrome). Do not copy
+   proprietary marks, licensed typefaces you do not have, or trademarked
+   illustration systems.
+4. **Respect known gaps.** If the guide omits color tokens, interaction
+   states, or responsive rules, invent the minimum needed for the task and
+   record that invention in the PR — do not pretend the capture specified it.
+5. **Hand off to acceptance.** Routine presentation check or
+   `evidence-locked-uat` still gates material UI claims. A pinned DESIGN.md is
+   direction, not a PASS.
+
+## Upstream source (link, do not vendor by default)
+
+Collection: [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT).  
+Product: [design.withfudge.com](https://design.withfudge.com/).
+
+Pin by linking the specific `design-md/<domain>.md` file (and optionally
+quoting the Design character / Practical guidance sections into the PR or a
+thin local `DESIGN.md` that cites upstream). Vendor a copy only when offline
+durability is required; if you vendor, keep MIT attribution and a fetch date.
+
+### Character shortlist (pointers only)
+
+| Need | Guide |
+|---|---|
+| Calm editorial tech narrative | [`anthropic.com.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/anthropic.com.md) |
+| Dense product workspace | [`linear.app.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/linear.app.md) |
+| Quiet infrastructure landing | [`stripe.com.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/stripe.com.md) |
+| Austere brand-first empty canvas | [`abc.xyz.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/abc.xyz.md) |
+| Dark developer workstation shell | [`cursor.com.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/cursor.com.md) |
+
+## Use it when
+
+- Starting or substantially redesigning a human-facing visual surface.
+- An agent is about to invent a look without a project design system.
+- Operator frontend constraints exist but no project-local visual packet does.
+
+## Do not use it when
+
+- The surface is agent-consumed only (schemas, MCP, CLI contracts) — use
+  `agent-interface-design`.
+- The change is a routine, reversible presentation tweak with an existing
+  design system already in-tree.
+- You need acceptance evidence — that is `evidence-locked-uat`, not this file.
+- The target is `epistemic-calibration`'s learning loop (no UI required).
+
+## Anti-patterns
+
+| Failure | Fix |
+|---|---|
+| "I'll vibe a purple gradient landing page." | Pin a guide; start from its character and practical guidance. |
+| "I'll merge Linear + Stripe + A24 into one moodboard." | One primary guide; secondary references only for a named subsystem. |
+| "The guide had no hex values, so I invented a 40-token palette." | Invent the minimum; document the gap; keep accent budget small. |
+| "DESIGN.md exists, so UAT is optional." | Direction ≠ acceptance. Run the routine check or UAT as usual. |
+| Vendoring the entire Fudge tree into the plugin. | Link. Curate at most a shortlist of pointers in craft. |
+
+## Falsifiable gate (lightweight)
+
+Before claiming the visual direction is set: a cold reader of the pinned
+DESIGN.md can state (1) the intended character in one sentence, (2) what must
+be preserved, and (3) at least one known gap. If they cannot, the pin is too
+thin or the wrong guide was chosen.

--- a/plugins/epistemic-skills/reference/craft/visual-design-md.md
+++ b/plugins/epistemic-skills/reference/craft/visual-design-md.md
@@ -32,6 +32,30 @@ DESIGN.md improves acceptance rates — UAT still owns acceptance.
 | Acceptance of the built surface | `evidence-locked-uat` | Judges the rendered surface; does not pick the reference |
 | High-blast-radius product claims | `gauntlet` | Adversarial review when stakes require it |
 
+## Stack alignment (Fudge + Claude Design + frontend-design + Impeccable)
+
+These layers are complementary when **ordered** and **harness-aware**; they are
+not competing authorities for the same `DESIGN.md` slot. Full spec:
+[`docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md`](../../../../docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md).
+
+| Layer | Role |
+|---|---|
+| **Claude Design** (product) | Optional explore/handoff on Claude harness — canvas, org design system, export; [Help Center](https://support.claude.com/en/articles/14604416-get-started-with-claude-design) |
+| **`/design-login` + `/design-sync`** | Claude Code only (Anthropic API): sync **React** design system with Claude Design — [commands](https://code.claude.com/docs/en/commands); **not** on Bedrock/Foundry |
+| **Fudge guide** (link or thin cite) | Reference *seed* — character, hierarchy, known gaps |
+| **Project `DESIGN.md` + `PRODUCT.md`** | Build-time truth when [Impeccable](https://impeccable.style) (or equivalent) is installed |
+| **Claude `frontend-design`** | Implementation craft — not the Claude Design canvas; usually via Impeccable |
+| **Impeccable commands** | Optional passes (`audit`, `normalize`, `polish`, …) before acceptance |
+| **This craft** | Gate: direction pinned before pixels; handoff bundle ≠ PASS |
+| **`evidence-locked-uat`** | Acceptance after build |
+
+**Cursor / non-Claude-Design harnesses:** Fudge pin → repo `DESIGN.md` →
+Impeccable/`frontend-design` → UAT. Do not assume `/design-sync` or Claude
+Design MCP.
+
+Do not add Impeccable, Claude Design, or the full Fudge tree to
+`epistemic-skills`; estate description bytes are rivalrous (v5 D8).
+
 ## Core moves
 
 1. **Pin one guide.** Before implementing human-facing layout, place or link a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exploratory draft for how [fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) could fit this package, **aligned** with Impeccable + Anthropic `frontend-design`, **Claude Design** harness integration, and intended **`zms-labs-design`** org placement.

**Future-agent pick-up:** [`docs/handoffs/2026-08-06-fudge-design-md-leverage.md`](https://github.com/ZMS-Labs/epistemic-skills/blob/cursor/fudge-design-md-leverage-b285/docs/handoffs/2026-08-06-fudge-design-md-leverage.md)

| Doc | Purpose |
|---|---|
| [Stack alignment](https://github.com/ZMS-Labs/epistemic-skills/blob/cursor/fudge-design-md-leverage-b285/docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md) | Fudge + Claude Design + frontend-design + Impeccable |
| [ZMS fleet placement](https://github.com/ZMS-Labs/epistemic-skills/blob/cursor/fudge-design-md-leverage-b285/docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md) | Skill decision (a) + leverage (b); **blocked** until `zms-labs-design` is agent-readable |

**Verdict:** Approach A craft in `epistemic-skills`; org DS in `zms-labs-design`; no new routed visual skill in epistemic-skills. Not operator-approved yet.

Not for merge until design is accepted and exploratory markers are removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce8d43d-5fe1-4122-ac3c-515f8ce0b285?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce8d43d-5fe1-4122-ac3c-515f8ce0b285&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

