### PR TITLE
fix: restore the README count phrasing this session broke, and close the gap that hid it

### DIFF
--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -15,6 +15,11 @@ name: epistemic-flexibility
       - ".ledger/**"
       - ".github/scripts/**"
       - ".github/workflows/epistemic-flexibility.yml"
+      # sync_skill_surfaces.py asserts a required count phrasing IN README.md, so a
+      # README edit can break this gate. Without README.md here, that break does not
+      # trigger the workflow that would catch it -- which is exactly how it reached
+      # main on 2026-08-06. A check's inputs belong in its trigger.
+      - "README.md"
   push:
     branches: [main]
     paths:
@@ -24,6 +29,11 @@ name: epistemic-flexibility
       - ".ledger/**"
       - ".github/scripts/**"
       - ".github/workflows/epistemic-flexibility.yml"
+      # sync_skill_surfaces.py asserts a required count phrasing IN README.md, so a
+      # README edit can break this gate. Without README.md here, that break does not
+      # trigger the workflow that would catch it -- which is exactly how it reached
+      # main on 2026-08-06. A check's inputs belong in its trigger.
+      - "README.md"
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The README is the fast path into the project. The [GitHub Wiki](https://github.c
 
 Most agent-skill collections organize **how work proceeds**: brainstorming, planning, implementation, debugging, review, and verification. epistemic-skills sits beneath that workflow layer and asks a different question: **what would make the target, decision, evidence, handoff, or acceptance claim trustworthy enough to bear load?**
 
-The package provides **fourteen** skills: one entry point and **thirteen** disciplines. Pairing them with a workflow-skill layer such as [superpowers](https://github.com/obra/superpowers) is a judgment the entry point makes at the moment it is needed, not a separate seat. Each method has a positive trigger, an output contract, and a stopping boundary.
+The package provides **fourteen** skills: one entry point, **thirteen** disciplines. Pairing them with a workflow-skill layer such as [superpowers](https://github.com/obra/superpowers) is a judgment the entry point makes at the moment it is needed, not a separate seat. Each method has a positive trigger, an output contract, and a stopping boundary.
 
 It is not:
 


### PR DESCRIPTION
`main` is red. I broke it in #98.

## The break

#98 rewrote the README count sentence to remove the deleted `Helix`. That part was correct. But it also replaced a **comma** with "and", and the comma is load-bearing — `sync_skill_surfaces.py:71` asserts this exact shape against README.md:

```
provides \*\*N\*\* skills: (?:one router|one entry point), \*\*M\*\* disciplines
```

`COUNT_PATTERN_MISSING` on the first run that reached it. Restored to the canonical comma form, keeping the accuracy fix.

## Why it reached main silently — the more useful half

`epistemic-flexibility`'s `paths:` filter did **not** include `README.md`, yet one of its checks **reads** README.md.

So a README-only edit could break this gate without triggering the workflow that enforces it. #98 merged on green CodeQL with `epistemic-flexibility` correctly not running — README.md matched no path in its trigger. **The check had no way to fire on its own input.**

This PR adds `README.md` to both the `pull_request` and `push` filters. A check's inputs belong in its trigger, or the check is only advisory on whichever paths happen to be listed.

## Worth recording

This is the **first failure the manual `workflow_dispatch` from #99 produced** — and it found a real defect within 20 seconds of getting a runner. The gate had been unreachable on demand all session; the moment it became reachable it earned its keep.

And the defect was introduced by the same session that added a CI check to prevent a *different* class of silent breakage. Per-item care with an unexercised gate is how both happened.

## Verification

```
sync_skill_surfaces.py --check   skill surfaces in sync: 14 skills, 13 disciplines
full gate loop                   non-usage failures: 0
check_description_budget.py      8200 bytes / ceiling 8200
check_no_phantom_skills.py       14 live skills, 0 phantoms
README.md in triggers            pull_request: True   push: True
```

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121zdSgSmJv3gRwgrmwXRrZ