### PR TITLE
fix: v5.0.0 shipped manifests advertising two deleted skills; harden the guard that missed it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "ZMS Labs"
   },
   "metadata": {
-    "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fourteen self-triggering skills. Composes with workflow layers via the helix tandem entry point.",
+    "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fourteen self-triggering skills. Composes with workflow layers through metacognate's pairing judgment.",
     "version": "5.0.0"
   },
   "plugins": [
     {
       "name": "epistemic-skills",
       "source": "./plugins/epistemic-skills",
-      "description": "The full collection in one install: using-epistemic-skills + helix + recon + resolve + write-goal + outsource + gauntlet + evidence-locked-uat + decision-ledger + open-questions + context-audit."
+      "description": "The full collection in one install: metacognate (the entry point) + context-audit + decision-ledger + did-it-land + evidence-locked-uat + gauntlet + health + open-questions + outsource + recon + resolve + triage + watch + write-goal."
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -4,14 +4,14 @@
     "name": "ZMS Labs"
   },
   "metadata": {
-    "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fourteen self-triggering skills. Composes with workflow layers via the helix tandem entry point.",
+    "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fourteen self-triggering skills. Composes with workflow layers through metacognate's pairing judgment.",
     "version": "5.0.0"
   },
   "plugins": [
     {
       "name": "epistemic-skills",
       "source": "./plugins/epistemic-skills",
-      "description": "The full collection in one install: using-epistemic-skills + helix + recon + resolve + write-goal + outsource + gauntlet + evidence-locked-uat + decision-ledger + open-questions + context-audit."
+      "description": "The full collection in one install: metacognate (the entry point) + context-audit + decision-ledger + did-it-land + evidence-locked-uat + gauntlet + health + open-questions + outsource + recon + resolve + triage + watch + write-goal."
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.0.0",
   "author": {
     "name": "ZMS Labs",

--- a/.github/scripts/check_no_phantom_skills.py
+++ b/.github/scripts/check_no_phantom_skills.py
@@ -35,9 +35,23 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 SKILLS_DIR = REPO / "plugins" / "epistemic-skills" / "skills"
 
-# Retired in v4.0.0 (the consolidation release), with the survivor that absorbed
-# each one. Kept so a firing surface can never hand a boundary to a dead name.
+# Retired skills, with the survivor that absorbed each one. Kept so a firing
+# surface can never hand a boundary to a dead name.
+#
+# THIS MAP IS THE GUARD'S OWN HAND-MAINTAINED INVENTORY, AND IT DRIFTED. It listed
+# only the v4.0.0 retirements. v5.0.0 deleted ``using-epistemic-skills`` and
+# ``helix`` and nobody added them here, so the check that exists precisely to catch
+# "manifest advertises retired skill to installers" was never told about the
+# release's own deletions — and v5.0.0 shipped with eight manifests advertising
+# both, plus a GEMINI.md instructing users to start with a skill that is not in
+# the package.
+#
+# Adding a skill costs nothing here. DELETING one obliges an entry in this map, in
+# the same commit. That obligation is now enforced: see check_retired_map_covers_
+# deletions below, which fails when a name the RETIRED map has never heard of
+# appears in an installer-facing surface.
 RETIRED = {
+    # v4.0.0 — the consolidation release
     "blindspot-pass": "recon (brief mode)",
     "wayfinding": "recon (initiative mode)",
     "harvest-before-adopt": "recon (candidate mode)",
@@ -47,7 +61,30 @@ RETIRED = {
     "continuity-verify": "decision-ledger (resume mode)",
     "agent-interface-design": "reference/craft/ doctrine (no longer routed)",
     "intent-traced-merge": "reference/craft/ doctrine (no longer routed)",
+    # v5.0.0 — the loop release. Both seats deleted; metacognate replaces them.
+    "using-epistemic-skills": "metacognate (the sole entry point)",
+    "helix": "metacognate (Tier 2 pairing judgment, not a pair table)",
 }
+
+# Installer-facing surfaces: what a user reads or a package manager consumes when
+# deciding what this package contains. A retired name here is worse than a stale
+# doc — it sends someone to look for something that is not installed.
+#
+# ``**/*plugin*.json`` matches on FILENAME, so it never matched ``marketplace.json``
+# despite it sitting inside ``.claude-plugin/``. Both marketplace files went
+# unscanned through every release. The glob's scope was its blind spot.
+INSTALLER_JSON_GLOBS = (
+    "**/*plugin*.json",
+    "**/marketplace.json",
+    "*extension*.json",
+)
+
+# Root instruction files are read by an agent at session start. A retired skill
+# named here is an instruction to use something that does not exist. Prose, not
+# paths — SKILL_PATH_RE deliberately only matches ``skills/<name>/`` references,
+# which is why GEMINI.md's "Start with the `using-epistemic-skills` skill" was
+# invisible to this check while the file was being scanned.
+ROOT_INSTRUCTION_FILES = ("GEMINI.md", "AGENTS.md", "CLAUDE.md", "README.md")
 
 # Anchored to the full package-relative path on purpose. A bare ``skills/(\w+)/``
 # also matches every GitHub URL for this repo — ``.../epistemic-skills/tree/main``
@@ -86,19 +123,59 @@ def check_firing_surfaces(defects: list[str]) -> None:
                     f"skill '{dead}' — route to {survivor}"
                 )
 
-    for manifest in sorted(REPO.glob("**/*plugin*.json")) + sorted(REPO.glob("*extension*.json")):
-        if ".git" in manifest.parts or "node_modules" in manifest.parts:
+    seen: set[Path] = set()
+    for pattern in INSTALLER_JSON_GLOBS:
+        for manifest in sorted(REPO.glob(pattern)):
+            if ARCHIVE_PARTS.intersection(manifest.parts) or "node_modules" in manifest.parts:
+                continue
+            if manifest in seen:
+                continue
+            seen.add(manifest)
+            try:
+                blob = json.dumps(json.loads(manifest.read_text(encoding="utf-8")))
+            except (json.JSONDecodeError, OSError):
+                continue
+            for dead, survivor in RETIRED.items():
+                if dead in blob:
+                    defects.append(
+                        f"{manifest.relative_to(REPO)}: manifest advertises retired "
+                        f"skill '{dead}' to installers — route to {survivor}"
+                    )
+
+    # Root instruction files, checked as PROSE. An agent reading "Start with the
+    # `using-epistemic-skills` skill" at session start will go looking for a skill
+    # that is not installed. Historical framing is allowed and required — these
+    # files legitimately describe what was removed and why.
+    # Historical framing is ALLOWED and necessary — these files legitimately record
+    # what was removed, when, and why. The vocabulary below was widened after the
+    # first version flagged two correct README sentences: a "Craft doctrine (not
+    # disciplines) ... v4.0.0 demotion" note, and a version-history line describing
+    # what 3.4.0 added. Both name retired skills accurately. A guard that punishes
+    # accurate history teaches people to delete history.
+    historical = re.compile(
+        r"retired|replaced|former|absorbed|deleted|no longer|superseded|historical|"
+        r"used to|previously|removed in|renamed|demot|doctrine|preserved|archived|"
+        r"consolidat|deprecat|\bv?\d+\.\d+\.\d+\b|version \d|\badds?\b|\badded\b",
+        re.I,
+    )
+    for name in ROOT_INSTRUCTION_FILES:
+        source = REPO / name
+        if not source.is_file():
             continue
         try:
-            blob = json.dumps(json.loads(manifest.read_text(encoding="utf-8")))
-        except (json.JSONDecodeError, OSError):
+            lines = source.read_text(encoding="utf-8").splitlines()
+        except OSError:
             continue
-        for dead, survivor in RETIRED.items():
-            if dead in blob:
-                defects.append(
-                    f"{manifest.relative_to(REPO)}: manifest advertises retired "
-                    f"skill '{dead}' to installers — route to {survivor}"
-                )
+        for number, line in enumerate(lines, 1):
+            if historical.search(line):
+                continue
+            for dead, survivor in RETIRED.items():
+                if re.search(rf"(?<![a-z0-9-]){re.escape(dead)}(?![a-z0-9-])", line, re.I):
+                    defects.append(
+                        f"{name}:{number}: instructs an agent to use retired skill "
+                        f"'{dead}' — route to {survivor}"
+                    )
+                    break
 
 
 def check_path_references(defects: list[str]) -> None:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,18 +1,24 @@
 # Epistemic Skills
 
-Harness-agnostic epistemic disciplines for agentic coding. **Start with the
-`using-epistemic-skills` skill** — it applies the routine-work fast path first,
-then routes positive triggers. It never does the work itself.
+Harness-agnostic epistemic disciplines for agentic coding. **`metacognate` is the
+only skill you invoke by name** — every other member fires on its own frontmatter
+`description`. It never does the work itself.
 
-Routine reversible, local, directly-checkable, non-precedential work proceeds
-with the target artifact plus nearest test/example, the change, and the bounded
-check. It emits no router/Helix skip inventory or process-only artifact.
+`metacognate` owns exactly one decision: what would have to be true for this to be
+right, and which of those you cannot currently answer. The unanswerable one names
+the discipline. If every one is answerable, the correct output is silence.
+
+Routine reversible, local, directly-checkable, non-precedential work proceeds with
+the target artifact plus nearest test/example, the change, and the bounded check.
+It emits no skip inventory and no process-only artifact. **Declining is the most
+common correct outcome**, and silence is a success state rather than a skipped step.
 
 Running a workflow-skill layer (such as superpowers) alongside this collection?
-Read the `helix` skill only when a positive pairing trigger remains after the
-routine gate; it pairs the workflow stage with the required epistemic discipline.
+Pairing is a judgment `metacognate` makes at the moment it is needed, not a
+separate seat and not a stage-to-skill table. Either strand may interrupt the
+other, and control returns to the point of interruption.
 
-Skills live under `skills/<name>/SKILL.md` (fourteen skills: entry point + thirteen disciplines
-+ the helix tandem entry point). Role-agents for the gauntlet live under `agents/`.
+Skills live under `skills/<name>/SKILL.md` (**fourteen skills: entry point + thirteen disciplines**).
+Role-agents for the gauntlet live under `agents/`.
 Prefer loading a skill by its frontmatter `description` trigger rather than
 pasting this file into every turn.

--- a/docs/release/RELEASE-5.0.0.md
+++ b/docs/release/RELEASE-5.0.0.md
@@ -3,14 +3,22 @@
 **Date:** 2026-08-06. **Breaking.** Fourteen skills: one entry point,
 `metacognate`, and thirteen disciplines.
 
-> **PUBLISHED.** Release-gate items 4, 5 and 6 are met on the exact tagged commit —
-> the deterministic suite, CodeQL, and the full-history secret scan all passed there,
-> verified at job and step level.
+> **PUBLISHED**, with two gate items not fully satisfied. Read the gate table before
+> relying on this release's assurances.
 >
-> **Item 8 — an independent Gauntlet publication review reaching GO — was WAIVED by
-> the repository owner and was never run.** There is no GO verdict for 5.0.0. This is
-> stated here rather than in a footnote because the alternative is a release record
-> that reads as though the gate passed.
+> Items 4 and 5 are met on the exact tagged commit — version surfaces, the
+> deterministic suite, and CodeQL all passed there, verified at job and step level.
+>
+> **Item 6 is only PARTIALLY met.** The full-history secret scan passed; the
+> public-content/provenance review it also requires was never performed. The tag
+> annotation says item 6 was met — that is an overclaim, corrected below and
+> uncorrectable in the tag itself.
+>
+> **Item 8 was WAIVED by the repository owner and never run.** No adversarial
+> publication review, no GO verdict. Item 7 was never assessed as a gate row.
+>
+> These are stated at the top rather than in a footnote, because the alternative is a
+> release record that reads as though the gate passed.
 
 ## What changed and why
 
@@ -142,8 +150,9 @@ the exact commit `3a18cd3`, verified at job and step level rather than by run la
 |---|---|
 | 4 — version surfaces aligned, link-existence checked | **met.** All ten surfaces agree on 5.0.0. Version-pinned URLs were checked individually: `.../using-epistemic-skills/reference/routine-fast-path.md` does not exist in the v5 tree, so that link was repointed to the file's new home rather than blind-bumped — the P1 class caught in v3.2.0. |
 | 5 — deterministic suite, DCO, manifest parity, committed-JSON, CodeQL | **met** on `3a18cd3`. `epistemic-flexibility` job `stdlib-checks` succeeded across 45 steps — 44 success and one correctly skipped (`Durable ledger append-only against merge base`, which needs a PR merge base and has none on a dispatch run). CodeQL `Analyze (actions)`, `(javascript-typescript)` and `(python)` all succeeded on the same commit. |
-| 6 — redacted full-history secret scan | **met** on `3a18cd3`. `release-security` job `full-history-secret-scan` succeeded, including its own positive control step *"Prove the scanner detects a planted secret"* — so the clean result is a measurement, not a scanner that finds nothing. |
-| 8 — independent Gauntlet publication review reaching GO | **WAIVED, not met.** Explicitly waived by the repository owner on 2026-08-06 ("i approve the release and we don't need the full gauntlet"). No Gauntlet publication review was run for 5.0.0, and no GO verdict exists. Recorded as waived rather than satisfied, because a release record that reads as if a gate passed when it was skipped is worse than no record. |
+| 6 — redacted full-history secret scan **and public-content/provenance review of the release diff** | **PARTIALLY MET.** The scan half passed on `3a18cd3` and again on the tagged commit: `release-security` job `full-history-secret-scan` succeeded, including its own positive control step *"Prove the scanner detects a planted secret"* — so the clean result is a measurement, not a scanner that finds nothing. **The public-content/provenance-review half was never performed and no v5.0.0-dated review document exists.** See *Correction* below. |
+| 7 — supported harness surfaces exercised live or assigned an honest verification tier; known limitations recorded | **NOT TRACKED IN THIS TABLE.** Addressed narratively in *Evidence posture* above (clean-room run, UNESTABLISHED behavioural status, known limitations) but never assessed as a gate row. Recorded here as untracked rather than silently omitted. |
+| 8 — **Helix routing is recorded** and an independent Gauntlet publication review reaches GO | **WAIVED, not met — both halves.** Explicitly waived by the repository owner on 2026-08-06 ("i approve the release and we don't need the full gauntlet"). No Gauntlet publication review was run for 5.0.0 and no GO verdict exists. The first half is additionally **unsatisfiable as written**: `RELEASING.md` item 8 still requires recording "Helix routing", and this release *deleted* Helix. That text needs updating in `RELEASING.md` itself. |
 
 ### How items 5 and 6 became reachable
 
@@ -164,6 +173,34 @@ Runner assignment was intermittently failing throughout — jobs auto-cancelled 
 run-level `failure`. **Re-dispatching succeeds**; that, not waiting, is the lever. Quota
 was never the cause (29,752 of 50,000 included minutes, $0 billable) and neither was
 queue depth (3 runs in flight org-wide). Diagnosis in issue #95.
+
+### Correction — this table overclaimed item 6, and the tag records the overclaim
+
+The v5.0.0 tag annotation and the first version of this table both state
+`item 6 ... MET`. That was wrong, and the way it was wrong is worth naming.
+
+`RELEASING.md` item 6 reads, in full:
+
+> A redacted full-history secret scan passes, **and public-content/provenance review
+> covers the release diff.**
+
+Only the first clause was checked. The gate row was written from the name of the CI
+job that passed rather than from the text of the requirement, so a two-part item was
+recorded as met on one part. **The provenance review was never performed.**
+
+This is the oracle-adequacy failure — confirming that a check ran green rather than
+that the check covers the claim — committed in the same document that defines it, on
+the same day, by the agent writing that definition. It was caught by an independent
+reviewer reading `RELEASING.md` against this table, not by anyone re-reading their own
+work.
+
+**The tag cannot be corrected.** `v5.0.0` is annotated, pushed, and immutable, and
+`RELEASING.md` forbids moving or reusing a published version tag. Its annotation will
+permanently assert that item 6 was met. This section is the correction of record; the
+GitHub Release body carries it too.
+
+Item 7 was likewise absent from the original table rather than assessed. It is now
+listed as untracked.
 
 ### On the waiver of item 8
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.0.0",
   "contextFileName": "GEMINI.md"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://antigravity.google/schemas/v1/plugin.json",
   "name": "epistemic-skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing."
+  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table."
 }

--- a/plugins/epistemic-skills/.claude-plugin/plugin.json
+++ b/plugins/epistemic-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.0.0",
   "author": {
     "name": "ZMS Labs"

--- a/plugins/epistemic-skills/.codex-plugin/plugin.json
+++ b/plugins/epistemic-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "version": "5.0.0",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "Epistemic Skills",
     "shortDescription": "Evidence-grounded methods for agentic work",
-    "longDescription": "An entry point plus thirteen composable disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, plus the helix tandem entry point.",
+    "longDescription": "An entry point plus thirteen composable disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
     "developerName": "ZMS Labs",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/epistemic-skills/.cursor-plugin/plugin.json
+++ b/plugins/epistemic-skills/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, with the helix tandem layer for workflow-skill pairing.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus thirteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.0.0",
   "author": {
     "name": "ZMS Labs"


### PR DESCRIPTION
**v5.0.0 is published and its install metadata names skills that release deleted.** Found by a reviewer reading the tagged tree, not by CI.

## What shipped broken

| File | Says |
|---|---|
| `.claude-plugin/marketplace.json` | `using-epistemic-skills + helix + recon + …` |
| `.cursor-plugin/marketplace.json` | same member list |
| 6 more plugin/extension manifests | "with the helix tandem layer for workflow-skill pairing" |
| `GEMINI.md` | **"Start with the `using-epistemic-skills` skill"**, "Read the `helix` skill" |

The marketplace list is the worst: it advertises the install as containing two deleted seats **and omits all five skills v5.0.0 added**. `GEMINI.md` is close behind — a fresh Gemini CLI session following its own instructions goes looking for two skills that aren't in the package. It also carried the README's double-count: *"fourteen skills: entry point + thirteen disciplines + the helix tandem entry point"* is fifteen.

## Why the guard missed it — three compounding gaps

`check_no_phantom_skills.py` exists precisely to catch *"manifest advertises retired skill to installers"*. It passed.

1. **Its `RETIRED` map is its own hand-maintained inventory, and it drifted.** It listed the nine v4.0.0 retirements. v5.0.0 deleted `using-epistemic-skills` and `helix` and nobody added them — so the guard had never heard of the names it needed to catch. *That is the exact disease this package documents, inside the guard against it.*
2. `**/*plugin*.json` matches on **filename**, so it never matched `marketplace.json` despite it living in `.claude-plugin/`. Both marketplace files went unscanned through every release.
3. The `.md` scan matches `skills/<name>/` **paths**, not prose. `GEMINI.md` was being read and its instructions were invisible.

## Negative control

Run **before** repairing any content: the hardened guard fails on the tree that shipped, reporting 16 surfaces.

Two then proved **false positives** — `README.md:202` (*"Craft doctrine (not disciplines) … v4.0.0 demotion"*) and `README.md:374` (version history) are both accurate. I widened the historical vocabulary until those cleared while all four `GEMINI.md` defects were retained: **14 real, 0 false**. A guard that punishes accurate history teaches people to delete history.

Two more defects surfaced while fixing `GEMINI.md`, both caught by the suite rather than by reading: `outsource/tests` requires the literal `"fourteen skills"`, and `sync_skill_surfaces` requires `N skills: entry point + M disciplines` **on one line**.

## The more serious half — the release record overclaimed

`RELEASING.md` item 6 reads, in full:

> A redacted full-history secret scan passes, **and public-content/provenance review covers the release diff.**

**Only the first clause was ever checked.** The gate row was written from the name of the CI job that passed rather than from the text of the requirement, so a two-part item was recorded as MET on one part. The provenance review was never performed.

That is the oracle-adequacy failure — confirming a check ran green rather than that it covers the claim — committed in the same document that defines it, on the same day, by the agent writing that definition. An independent reviewer reading `RELEASING.md` against the table caught it. Re-reading my own work did not.

**The tag cannot be fixed.** `v5.0.0` is annotated, pushed, immutable, and `RELEASING.md` forbids moving or reusing it. Its annotation will permanently assert item 6 was met. The notes now carry the correction of record: item 6 → **PARTIALLY MET**, item 7 → recorded as **never assessed** rather than silently omitted, item 8 → shown as the two-part requirement it is, whose first half (*"Helix routing is recorded"*) this release made unsatisfiable by deleting Helix.

## Verification

```
full gate loop            0 non-usage failures
check_no_phantom_skills   green, 11 retired names (was 9)
sync_skill_surfaces       14 skills, 13 disciplines
check_description_budget  8200 / 8200
check_json_artifacts      227 artifacts
```

## Follow-up not in this PR

`RELEASING.md` item 8 still requires recording "Helix routing" for a skill this release deleted. That text needs owner judgment about what replaces it, so I have flagged rather than rewritten it.

Corrections ship under a new semantic version per `RELEASING.md`. **This is v5.0.1 material — I have not tagged anything.**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121zdSgSmJv3gRwgrmwXRrZ