### PR TITLE
chore: backlog sweep — bundles, registers, local CI, literature canary

### DIFF
--- a/.github/scripts/build_openai_bundles.py
+++ b/.github/scripts/build_openai_bundles.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Build deterministic OpenAI/ChatGPT bundles from the canonical skill package.
+
+No skill inventory is stored in this script. Every build discovers direct
+``skills/<name>/SKILL.md`` children from ``plugins/epistemic-skills`` and fails
+closed when their frontmatter disagrees with the filesystem. The same source
+therefore feeds both the marketplace/plugin bundle and the single-skill
+ChatGPT upload bridge.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import os
+import re
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+CANONICAL_PACKAGE = Path("plugins/epistemic-skills")
+MARKETPLACE_PATH = Path(".agents/plugins/marketplace.json")
+CHATGPT_TEMPLATE = Path("packaging/openai/chatgpt-skill/SKILL.md")
+PLUGIN_ARCHIVE_ROOT = Path("epistemic-skills-openai")
+CHATGPT_ARCHIVE_ROOT = Path("epistemic-skills")
+FIXED_ZIP_TIME = (1980, 1, 1, 0, 0, 0)
+FRONTMATTER = re.compile(r"\A---\r?\n(.*?)\r?\n---(?:\r?\n|$)", re.S)
+IGNORED_PARTS = {"__pycache__", ".DS_Store"}
+
+
+class BundleError(ValueError):
+    """A named fail-closed package validation error."""
+
+
+class SkillRecord(NamedTuple):
+    name: str
+    description: str
+    canonical_path: str
+    skill_md_sha256: str
+    tree_sha256: str
+
+
+class BuildResult(NamedTuple):
+    chatgpt_skill: Path
+    openai_plugin: Path
+    checksums: Path
+    skill_count: int
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise BundleError(f"MISSING_REQUIRED_FILE: {path}") from error
+    except (OSError, json.JSONDecodeError) as error:
+        raise BundleError(f"MALFORMED_JSON: {path}: {error}") from error
+
+
+def yaml_scalar(raw: str, path: Path, key: str) -> str:
+    value = raw.strip()
+    if not value:
+        raise BundleError(f"EMPTY_FRONTMATTER_VALUE: {path}: {key}")
+    if value[0] == "'":
+        if len(value) < 2 or value[-1] != "'":
+            raise BundleError(f"MALFORMED_FRONTMATTER_VALUE: {path}: {key}")
+        parsed = value[1:-1].replace("''", "'").strip()
+        if not parsed:
+            raise BundleError(f"MALFORMED_FRONTMATTER_VALUE: {path}: {key}")
+        return parsed
+    if value[0] == '"':
+        try:
+            parsed = ast.literal_eval(value)
+        except (SyntaxError, ValueError) as error:
+            raise BundleError(f"MALFORMED_FRONTMATTER_VALUE: {path}: {key}") from error
+        if not isinstance(parsed, str) or not parsed.strip():
+            raise BundleError(f"MALFORMED_FRONTMATTER_VALUE: {path}: {key}")
+        return parsed.strip()
+    if value in {">", "|", ">-", "|-", ">+", "|+"}:
+        raise BundleError(f"UNSUPPORTED_MULTILINE_FRONTMATTER: {path}: {key}")
+    return value
+
+
+def parse_skill_frontmatter(path: Path) -> tuple[str, str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise BundleError(f"UNREADABLE_SKILL: {path}: {error}") from error
+    match = FRONTMATTER.match(text)
+    if not match:
+        raise BundleError(f"MISSING_FRONTMATTER: {path}")
+    values: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        key, separator, raw = line.partition(":")
+        if separator and key.strip() in {"name", "description"}:
+            values[key.strip()] = yaml_scalar(raw, path, key.strip())
+    missing = {"name", "description"} - values.keys()
+    if missing:
+        raise BundleError(f"MISSING_FRONTMATTER_KEYS: {path}: {sorted(missing)}")
+    return values["name"], values["description"]
+
+
+def regular_files(root: Path) -> list[Path]:
+    if not root.is_dir():
+        raise BundleError(f"MISSING_DIRECTORY: {root}")
+    files: list[Path] = []
+    for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+        relative = path.relative_to(root)
+        if any(part in IGNORED_PARTS for part in relative.parts) or path.suffix == ".pyc":
+            continue
+        if path.is_symlink():
+            raise BundleError(f"SYMLINK_NOT_PORTABLE: {path}")
+        if path.is_file():
+            files.append(path)
+    return files
+
+
+def tree_sha256(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in regular_files(root):
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        content = path.read_bytes()
+        digest.update(relative)
+        digest.update(b"\0")
+        digest.update(hashlib.sha256(content).digest())
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def discover_skills(package_root: Path) -> list[SkillRecord]:
+    skills_root = package_root / "skills"
+    if not skills_root.is_dir():
+        raise BundleError(f"MISSING_SKILLS_DIRECTORY: {skills_root}")
+    records: list[SkillRecord] = []
+    for directory in sorted(skills_root.iterdir(), key=lambda item: item.name):
+        skill_md = directory / "SKILL.md"
+        if not directory.is_dir() or not skill_md.is_file():
+            continue
+        name, description = parse_skill_frontmatter(skill_md)
+        if name != directory.name:
+            raise BundleError(
+                "FRONTMATTER_NAME_MISMATCH: "
+                f"{skill_md} declares {name!r}, directory is {directory.name!r}"
+            )
+        records.append(SkillRecord(
+            name=name,
+            description=description,
+            canonical_path=(Path("skills") / name / "SKILL.md").as_posix(),
+            skill_md_sha256=sha256_bytes(skill_md.read_bytes()),
+            tree_sha256=tree_sha256(directory),
+        ))
+    if not records:
+        raise BundleError(f"EMPTY_SKILL_GLOB: {skills_root}")
+    names = [record.name for record in records]
+    if len(names) != len(set(names)):
+        raise BundleError(f"DUPLICATE_SKILL_NAME: {names}")
+    return records
+
+
+def validate_marketplace(repo_root: Path) -> None:
+    marketplace = load_json(repo_root / MARKETPLACE_PATH)
+    if not isinstance(marketplace, dict) or not isinstance(marketplace.get("plugins"), list):
+        raise BundleError(f"MALFORMED_MARKETPLACE: {repo_root / MARKETPLACE_PATH}")
+    matches = [
+        entry for entry in marketplace["plugins"]
+        if isinstance(entry, dict) and entry.get("name") == "epistemic-skills"
+    ]
+    if len(matches) != 1:
+        raise BundleError("MARKETPLACE_PLUGIN_COUNT: expected exactly one epistemic-skills entry")
+    source = matches[0].get("source")
+    expected_source = {"source": "local", "path": "./plugins/epistemic-skills"}
+    if source != expected_source:
+        raise BundleError(
+            f"MARKETPLACE_SOURCE_DRIFT: expected {expected_source!r}, got {source!r}"
+        )
+
+    manifest_path = repo_root / CANONICAL_PACKAGE / ".codex-plugin" / "plugin.json"
+    manifest = load_json(manifest_path)
+    if not isinstance(manifest, dict):
+        raise BundleError(f"MALFORMED_PLUGIN_MANIFEST: {manifest_path}")
+    if manifest.get("name") != "epistemic-skills":
+        raise BundleError(
+            f"PLUGIN_NAME_DRIFT: {manifest_path} has {manifest.get('name')!r}"
+        )
+    if manifest.get("skills") != "./skills/":
+        raise BundleError(
+            "PLUGIN_SKILLS_SOURCE_DRIFT: expected './skills/' so the canonical glob "
+            f"remains authoritative, got {manifest.get('skills')!r}"
+        )
+
+    template = repo_root / CHATGPT_TEMPLATE
+    template_name, _ = parse_skill_frontmatter(template)
+    if template_name != "epistemic-skills":
+        raise BundleError(
+            f"CHATGPT_TEMPLATE_NAME_DRIFT: {template} declares {template_name!r}"
+        )
+
+
+def render_index(records: list[SkillRecord], source_revision: str) -> bytes:
+    payload = {
+        "schema": "openai-epistemic-bundle-index@1",
+        "source": {
+            "repository": "https://github.com/ZMS-Labs/epistemic-skills",
+            "revision": source_revision,
+            "canonical_package": CANONICAL_PACKAGE.as_posix(),
+            "inventory_rule": "direct skills/<name>/SKILL.md children",
+        },
+        "skill_count": len(records),
+        "skills": [record._asdict() for record in records],
+    }
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def zip_entries(path: Path, archive_prefix: Path) -> Iterable[tuple[str, bytes]]:
+    for file_path in regular_files(path):
+        relative = file_path.relative_to(path)
+        yield (archive_prefix / relative).as_posix(), file_path.read_bytes()
+
+
+def write_deterministic_zip(destination: Path, entries: Iterable[tuple[str, bytes]]) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    ordered = sorted(entries, key=lambda item: item[0])
+    names = [name for name, _ in ordered]
+    if len(names) != len(set(names)):
+        raise BundleError("DUPLICATE_ARCHIVE_PATH: bundle construction produced duplicate members")
+    with zipfile.ZipFile(destination, "w") as archive:
+        for name, content in ordered:
+            info = zipfile.ZipInfo(name, FIXED_ZIP_TIME)
+            info.create_system = 3
+            info.external_attr = (0o100644 & 0xFFFF) << 16
+            info.compress_type = zipfile.ZIP_DEFLATED
+            archive.writestr(info, content, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
+
+
+def build_bundles(repo_root: Path, out_dir: Path, source_revision: str) -> BuildResult:
+    repo_root = repo_root.resolve()
+    out_dir = out_dir.resolve()
+    if not source_revision.strip():
+        raise BundleError("EMPTY_SOURCE_REVISION")
+    validate_marketplace(repo_root)
+    package_root = repo_root / CANONICAL_PACKAGE
+    records = discover_skills(package_root)
+    index = render_index(records, source_revision.strip())
+
+    chatgpt_skill = out_dir / "epistemic-skills-chatgpt-skill.zip"
+    chatgpt_entries: list[tuple[str, bytes]] = [
+        ((CHATGPT_ARCHIVE_ROOT / "SKILL.md").as_posix(),
+         (repo_root / CHATGPT_TEMPLATE).read_bytes()),
+        ((CHATGPT_ARCHIVE_ROOT / "skill-index.json").as_posix(), index),
+    ]
+    chatgpt_entries.extend(zip_entries(package_root, CHATGPT_ARCHIVE_ROOT / "package"))
+    if (repo_root / "LICENSE").is_file():
+        chatgpt_entries.append(
+            ((CHATGPT_ARCHIVE_ROOT / "LICENSE").as_posix(), (repo_root / "LICENSE").read_bytes())
+        )
+    write_deterministic_zip(chatgpt_skill, chatgpt_entries)
+
+    openai_plugin = out_dir / "epistemic-skills-openai-plugin.zip"
+    plugin_entries: list[tuple[str, bytes]] = [
+        ((PLUGIN_ARCHIVE_ROOT / MARKETPLACE_PATH).as_posix(),
+         (repo_root / MARKETPLACE_PATH).read_bytes()),
+        ((PLUGIN_ARCHIVE_ROOT / "BUNDLE-INDEX.json").as_posix(), index),
+    ]
+    plugin_entries.extend(
+        zip_entries(package_root, PLUGIN_ARCHIVE_ROOT / CANONICAL_PACKAGE)
+    )
+    if (repo_root / "LICENSE").is_file():
+        plugin_entries.append(
+            ((PLUGIN_ARCHIVE_ROOT / "LICENSE").as_posix(), (repo_root / "LICENSE").read_bytes())
+        )
+    write_deterministic_zip(openai_plugin, plugin_entries)
+
+    checksums = out_dir / "SHA256SUMS"
+    checksum_lines = [
+        f"{sha256_bytes(chatgpt_skill.read_bytes())}  {chatgpt_skill.name}",
+        f"{sha256_bytes(openai_plugin.read_bytes())}  {openai_plugin.name}",
+    ]
+    checksums.write_text("\n".join(checksum_lines) + "\n", encoding="utf-8", newline="\n")
+    return BuildResult(chatgpt_skill, openai_plugin, checksums, len(records))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("dist/openai"),
+        help="output directory (default: dist/openai)",
+    )
+    parser.add_argument(
+        "--source-revision",
+        default=os.environ.get("GITHUB_SHA", "working-tree"),
+        help="revision recorded in the generated index",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate and build in a temporary directory without retaining artifacts",
+    )
+    arguments = parser.parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[2]
+    if arguments.check:
+        with tempfile.TemporaryDirectory() as temporary:
+            result = build_bundles(repo_root, Path(temporary), arguments.source_revision)
+            print(
+                f"OpenAI bundle check ok: {result.skill_count} dynamically discovered skills; "
+                "both deterministic archives built"
+            )
+        return 0
+    result = build_bundles(repo_root, arguments.out_dir, arguments.source_revision)
+    print(f"built: {result.chatgpt_skill}")
+    print(f"built: {result.openai_plugin}")
+    print(f"wrote: {result.checksums}")
+    print(f"inventory: {result.skill_count} dynamically discovered skills")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/run_local_ci.sh
+++ b/.github/scripts/run_local_ci.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Local CI wrapper — issue #95. See docs/CI-LOCAL-FALLBACK.md.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+REF="${1:-HEAD}"
+SHA="$(git -C "$ROOT" rev-parse --verify "${REF}^{commit}")"
+STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+RECEIPT_DIR="$ROOT/docs/evidence/local-ci"
+RECEIPT="$RECEIPT_DIR/${SHA}.md"
+mkdir -p "$RECEIPT_DIR"
+
+log() { echo "$*" | tee -a "$RECEIPT"; }
+
+: >"$RECEIPT"
+log "# Local CI receipt"
+log ""
+log "- **commit:** \`${SHA}\`"
+log "- **started:** ${STAMP}"
+log "- **host:** $(uname -a 2>/dev/null || true)"
+log ""
+
+log "## cleanroom (epistemic-flexibility steps)"
+if ! bash "$ROOT/.github/scripts/cleanroom_ci.sh" "$SHA" 2>&1 | tee -a "$RECEIPT"; then
+  log ""
+  log "**result:** FAIL (cleanroom)"
+  exit 1
+fi
+
+log ""
+log "## commission-watch-contract (when workflow exists)"
+if [ -f "$ROOT/.github/workflows/commission-watch-contract.yml" ]; then
+  (
+    cd "$ROOT"
+    python plugins/epistemic-skills/contracts/watch-commission/test_watch_commission.py
+    python -m py_compile plugins/epistemic-skills/contracts/watch-commission/verify_watch_commission.py
+    mapfile -t examples < <(find plugins/epistemic-skills/contracts/watch-commission/examples -maxdepth 1 -name 'valid-*.json' -print | sort)
+    python plugins/epistemic-skills/contracts/watch-commission/verify_watch_commission.py "${examples[@]}"
+    python .github/scripts/score_sentinels.py --self-test
+    python .github/scripts/score_sentinels.py
+    python .github/scripts/check_description_budget.py --self-test
+    python .github/scripts/check_description_budget.py
+    python .github/scripts/check_json_artifacts.py
+    python .github/scripts/check_no_phantom_skills.py
+    python .github/scripts/check_skill_inventory.py
+    python .github/scripts/sync_skill_surfaces.py --check
+    git diff --check
+  ) 2>&1 | tee -a "$RECEIPT"
+else
+  log "(skipped — workflow absent on this ref)"
+fi
+
+log ""
+log "**result:** PASS"
+log "- **finished:** $(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/scripts/test_build_openai_bundles.py
+++ b/.github/scripts/test_build_openai_bundles.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("build_openai_bundles.py")
+
+
+def load_builder():
+    spec = importlib.util.spec_from_file_location("build_openai_bundles", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def skill_text(name: str, description: str = "Use when this fixture applies.") -> str:
+    return f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n"
+
+
+def write_fixture(root: Path) -> None:
+    package = root / "plugins" / "epistemic-skills"
+    (root / ".agents" / "plugins").mkdir(parents=True)
+    (package / ".codex-plugin").mkdir(parents=True)
+    (root / "packaging" / "openai" / "chatgpt-skill").mkdir(parents=True)
+    (package / "contracts").mkdir(parents=True)
+    for name in ("alpha", "beta"):
+        target = package / "skills" / name
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text(skill_text(name), encoding="utf-8")
+        (target / "reference.md").write_text(f"reference for {name}\n", encoding="utf-8")
+    (package / "contracts" / "schema.json").write_text('{"type":"object"}\n', encoding="utf-8")
+    (package / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "epistemic-skills", "version": "0.0.0", "skills": "./skills/"}) + "\n",
+        encoding="utf-8",
+    )
+    (root / ".agents" / "plugins" / "marketplace.json").write_text(
+        json.dumps({
+            "name": "epistemic-skills",
+            "plugins": [{
+                "name": "epistemic-skills",
+                "source": {"source": "local", "path": "./plugins/epistemic-skills"},
+            }],
+        }) + "\n",
+        encoding="utf-8",
+    )
+    (root / "packaging" / "openai" / "chatgpt-skill" / "SKILL.md").write_text(
+        "---\nname: epistemic-skills\ndescription: Dynamic fixture bridge.\n---\n\n# Bridge\n",
+        encoding="utf-8",
+    )
+    (root / "LICENSE").write_text("fixture license\n", encoding="utf-8")
+
+
+class OpenAIBundleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        write_fixture(self.root)
+        self.builder = load_builder()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def build(self, destination: str = "dist"):
+        return self.builder.build_bundles(
+            repo_root=self.root,
+            out_dir=self.root / destination,
+            source_revision="fixture-sha",
+        )
+
+    def read_json_from_zip(self, archive: Path, member: str) -> dict:
+        with zipfile.ZipFile(archive) as bundle:
+            return json.loads(bundle.read(member).decode("utf-8"))
+
+    def test_discovers_added_skill_without_inventory_edit(self) -> None:
+        first = self.build("first")
+        first_index = self.read_json_from_zip(
+            first.chatgpt_skill,
+            "epistemic-skills/skill-index.json",
+        )
+        self.assertEqual(["alpha", "beta"], [item["name"] for item in first_index["skills"]])
+
+        gamma = self.root / "plugins" / "epistemic-skills" / "skills" / "gamma"
+        gamma.mkdir()
+        (gamma / "SKILL.md").write_text(skill_text("gamma"), encoding="utf-8")
+
+        second = self.build("second")
+        second_index = self.read_json_from_zip(
+            second.chatgpt_skill,
+            "epistemic-skills/skill-index.json",
+        )
+        self.assertEqual(
+            ["alpha", "beta", "gamma"],
+            [item["name"] for item in second_index["skills"]],
+        )
+        self.assertEqual(3, second_index["skill_count"])
+
+    def test_build_is_byte_deterministic_for_same_inputs(self) -> None:
+        first = self.build("first")
+        second = self.build("second")
+        self.assertEqual(first.chatgpt_skill.read_bytes(), second.chatgpt_skill.read_bytes())
+        self.assertEqual(first.openai_plugin.read_bytes(), second.openai_plugin.read_bytes())
+        self.assertEqual(first.checksums.read_text(), second.checksums.read_text())
+
+    def test_chatgpt_skill_wraps_the_complete_canonical_package(self) -> None:
+        result = self.build()
+        with zipfile.ZipFile(result.chatgpt_skill) as bundle:
+            names = set(bundle.namelist())
+        self.assertIn("epistemic-skills/SKILL.md", names)
+        self.assertIn("epistemic-skills/skill-index.json", names)
+        self.assertIn("epistemic-skills/package/skills/alpha/SKILL.md", names)
+        self.assertIn("epistemic-skills/package/skills/beta/reference.md", names)
+        self.assertIn("epistemic-skills/package/contracts/schema.json", names)
+
+    def test_plugin_bundle_preserves_marketplace_and_package_layout(self) -> None:
+        result = self.build()
+        with zipfile.ZipFile(result.openai_plugin) as bundle:
+            names = set(bundle.namelist())
+        self.assertIn("epistemic-skills-openai/.agents/plugins/marketplace.json", names)
+        self.assertIn(
+            "epistemic-skills-openai/plugins/epistemic-skills/.codex-plugin/plugin.json",
+            names,
+        )
+        self.assertIn(
+            "epistemic-skills-openai/plugins/epistemic-skills/skills/alpha/SKILL.md",
+            names,
+        )
+        self.assertIn("epistemic-skills-openai/BUNDLE-INDEX.json", names)
+
+    def test_preserves_yaml_single_quoted_apostrophe_in_description(self) -> None:
+        target = self.root / "plugins" / "epistemic-skills" / "skills" / "alpha" / "SKILL.md"
+        target.write_text(
+            "---\nname: alpha\ndescription: 'Gauntlet''s ledger.'\n---\n\n# alpha\n",
+            encoding="utf-8",
+        )
+        result = self.build()
+        index = self.read_json_from_zip(result.chatgpt_skill, "epistemic-skills/skill-index.json")
+        self.assertEqual("Gauntlet's ledger.", index["skills"][0]["description"])
+
+    def test_rejects_skill_name_that_disagrees_with_directory(self) -> None:
+        target = self.root / "plugins" / "epistemic-skills" / "skills" / "alpha" / "SKILL.md"
+        target.write_text(skill_text("not-alpha"), encoding="utf-8")
+        with self.assertRaisesRegex(self.builder.BundleError, "FRONTMATTER_NAME_MISMATCH"):
+            self.build()
+
+    def test_rejects_marketplace_source_that_bypasses_canonical_package(self) -> None:
+        marketplace = self.root / ".agents" / "plugins" / "marketplace.json"
+        payload = json.loads(marketplace.read_text(encoding="utf-8"))
+        payload["plugins"][0]["source"]["path"] = "./copied-snapshot"
+        marketplace.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(self.builder.BundleError, "MARKETPLACE_SOURCE_DRIFT"):
+            self.build()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/scripts/test_openai_bundle_workflow.py
+++ b/.github/scripts/test_openai_bundle_workflow.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[1] / "workflows" / "openai-bundles.yml"
+SOURCE_EXPRESSION = "${{ github.event.pull_request.head.sha || github.sha }}"
+
+
+class OpenAIBundleWorkflowTests(unittest.TestCase):
+    def test_artifacts_bind_to_durable_source_revision(self) -> None:
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(f"SOURCE_REVISION: {SOURCE_EXPRESSION}", text)
+        self.assertIn("ref: ${{ env.SOURCE_REVISION }}", text)
+        self.assertEqual(2, text.count('--source-revision "$SOURCE_REVISION"'))
+        self.assertIn("name: epistemic-skills-openai-${{ env.SOURCE_REVISION }}", text)
+        self.assertIn("python .github/scripts/test_openai_bundle_workflow.py", text)
+        self.assertEqual(3, text.count(".github/scripts/test_openai_bundle_workflow.py"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.github/workflows/openai-bundles.yml
+++ b/.github/workflows/openai-bundles.yml
@@ -1,0 +1,69 @@
+name: openai-bundles
+
+"on":
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".agents/plugins/marketplace.json"
+      - "plugins/epistemic-skills/**"
+      - "packaging/openai/**"
+      - ".github/scripts/build_openai_bundles.py"
+      - ".github/scripts/test_build_openai_bundles.py"
+      - ".github/scripts/test_openai_bundle_workflow.py"
+      - ".github/workflows/openai-bundles.yml"
+      - "docs/CHATGPT-AND-OPENAI-PACKAGING.md"
+  push:
+    branches: [main]
+    paths:
+      - ".agents/plugins/marketplace.json"
+      - "plugins/epistemic-skills/**"
+      - "packaging/openai/**"
+      - ".github/scripts/build_openai_bundles.py"
+      - ".github/scripts/test_build_openai_bundles.py"
+      - ".github/scripts/test_openai_bundle_workflow.py"
+      - ".github/workflows/openai-bundles.yml"
+      - "docs/CHATGPT-AND-OPENAI-PACKAGING.md"
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openai-bundles-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      SOURCE_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Check out the durable source revision without stored credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.SOURCE_REVISION }}
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Packaging unit tests
+        run: |
+          python .github/scripts/test_build_openai_bundles.py
+          python .github/scripts/test_openai_bundle_workflow.py
+      - name: Validate the live canonical package
+        run: python .github/scripts/build_openai_bundles.py --check --source-revision "$SOURCE_REVISION"
+      - name: Build revision-bound bundles
+        run: python .github/scripts/build_openai_bundles.py --out-dir dist/openai --source-revision "$SOURCE_REVISION"
+      - name: Upload generated bundles
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: epistemic-skills-openai-${{ env.SOURCE_REVISION }}
+          path: |
+            dist/openai/epistemic-skills-chatgpt-skill.zip
+            dist/openai/epistemic-skills-openai-plugin.zip
+            dist/openai/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ artifacts/uat/**/screenshots/
 .epistemic-events/
 outputs/epistemic-events/
 pilot/runs/
+
+# Deterministic OpenAI/ChatGPT archives are CI artifacts, not source.
+dist/openai/

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Every pull-request commit must carry an author-matching DCO trailer:
 git commit --signoff
 ```
 
-A release additionally requires exact-head CI, DCO, CodeQL, full-history secret scanning with a positive control, provenance review, independent publication review, final Gauntlet, and tag/Release identity checks. See [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) and [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO).
+A release additionally requires exact-head CI, DCO, CodeQL, full-history secret scanning with a positive control, provenance review, independent publication review, final Gauntlet, and tag/Release identity checks. See [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) and [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO). When GitHub Actions cannot assign runners, use [local CI fallback](docs/CI-LOCAL-FALLBACK.md) and record a receipt.
 
 ### Maintainer map
 

--- a/docs/CHATGPT-AND-OPENAI-PACKAGING.md
+++ b/docs/CHATGPT-AND-OPENAI-PACKAGING.md
@@ -1,0 +1,90 @@
+# ChatGPT and OpenAI packaging
+
+This repository has one canonical runtime package:
+`plugins/epistemic-skills/`. OpenAI-facing artifacts are generated from that
+package; no second skill inventory is maintained.
+
+## What is generated
+
+Run:
+
+```bash
+python .github/scripts/build_openai_bundles.py \
+  --out-dir dist/openai \
+  --source-revision "$(git rev-parse HEAD)"
+```
+
+The builder emits:
+
+- `epistemic-skills-chatgpt-skill.zip` — a single Personal Skill upload bridge.
+  Its top-level `SKILL.md` reads a generated index and then loads the applicable
+  canonical skill files included under `package/`.
+- `epistemic-skills-openai-plugin.zip` — a self-contained marketplace/plugin
+  package preserving `.agents/plugins/marketplace.json` and
+  `plugins/epistemic-skills/` at their repository-relative paths.
+- `SHA256SUMS` — hashes for both revision-bound archives.
+
+The archives are deterministic for identical source bytes and the same supplied
+source revision.
+
+## Why additions and removals flow automatically
+
+The builder discovers direct
+`plugins/epistemic-skills/skills/<name>/SKILL.md` children at build time. It
+extracts each skill's current frontmatter, verifies that `name` matches its
+directory, hashes the complete skill subtree, and generates the index. There is
+no Python constant, manifest array, README table, or wrapper list to update when
+a skill is added, renamed, or removed.
+
+The plugin marketplace already points to `./plugins/epistemic-skills`, and the
+package manifest points to `./skills/`. The builder fails closed if either path
+is changed to a copied snapshot.
+
+## Continuous regeneration
+
+`.github/workflows/openai-bundles.yml` runs on relevant pull requests, pushes to
+`main`, published releases, and manual dispatch. Every successful run tests the
+builder, validates the live package, and uploads freshly generated bundles for
+a durable source revision. Pull-request runs bind to the PR head SHA rather than
+GitHub's temporary merge-ref SHA; other events use their event SHA. The same
+revision is used for checkout, generated provenance, and artifact naming.
+
+This makes repository-to-bundle synchronization automatic. It does **not** make
+an already uploaded Personal Skill self-updating: that installation is a
+snapshot and must be replaced with a newer generated archive. An OpenAI plugin
+imported from a marketplace is the durable source-linked route; OpenAI's current
+workspace guidance provides a **Refresh** action to pull updates from the
+original marketplace source.
+
+## Installing the immediate ChatGPT bridge
+
+OpenAI currently documents Personal Skill upload through:
+**Plugins → Skills → Create → Upload from your computer**. Upload
+`epistemic-skills-chatgpt-skill.zip`, review the scan result, and install it.
+Then use it explicitly with an `@Epistemic Skills` mention when desired; ChatGPT
+may also select an installed Skill automatically when its description applies.
+
+Official references, checked 2026-08-06:
+
+- <https://help.openai.com/en/articles/20001066-skills-in-chatgpt>
+- <https://help.openai.com/en/articles/20001256-plugins-in-chatgpt-and-codex>
+
+## Plugin-directory boundary
+
+The repository and generated plugin archive are structurally ready for a
+skill-only OpenAI plugin import or directory submission. Publication itself is
+an OpenAI control-plane action, not a Git commit. The public documentation does
+not expose a universal repository-to-public-directory submission API, so this
+project does not claim that a workflow run publishes the plugin automatically.
+Once the plugin is imported or accepted, its source remains the canonical
+package rather than a manually synchronized copy.
+
+## Maintainer checks
+
+```bash
+python .github/scripts/test_build_openai_bundles.py
+python .github/scripts/test_openai_bundle_workflow.py
+python .github/scripts/build_openai_bundles.py --check
+```
+
+A change is not package-ready if any command fails.

--- a/docs/CI-LOCAL-FALLBACK.md
+++ b/docs/CI-LOCAL-FALLBACK.md
@@ -1,0 +1,49 @@
+# Local CI fallback (issue #95)
+
+When GitHub-hosted Actions is unavailable (minutes limits, assignment timeouts, or
+org policy), this repository supports **faithful local execution** of the same
+Python gates CI runs, without maintaining a second copy of the step list.
+
+## Default path (Linux or WSL)
+
+```bash
+bash .github/scripts/run_local_ci.sh [REF]
+```
+
+`REF` defaults to `HEAD`. The wrapper:
+
+1. Records the exact commit SHA under `docs/evidence/local-ci/`.
+2. Runs `.github/scripts/cleanroom_ci.sh` for the `epistemic-flexibility` workflow
+   (stdlib checks extracted from `.github/workflows/epistemic-flexibility.yml`).
+3. Runs the focused `commission-watch-contract` steps when present on `REF`.
+
+Use this **before** pushing when Actions is degraded. It is the standing substitute
+for “green on GitHub” only when Actions cannot assign runners; prefer Actions when
+available for CodeQL, DCO API checks, and fork isolation.
+
+## Clean-room only
+
+```bash
+bash .github/scripts/cleanroom_ci.sh "$(git rev-parse HEAD)"
+```
+
+See the script header for remote URL override and detached-checkout behavior.
+
+## Kubernetes Job (cluster path)
+
+`.github/ci/cleanroom-job.yaml` schedules the same clean-room harness on amd64.
+**Blocker (2026-08-06):** pods could not resolve `github.com` (cluster egress/DNS).
+Fix cluster DNS/egress or clone from an in-cluster mirror before relying on this path.
+
+## What local CI does not provide
+
+- Cross-operator independence (same machine as the author).
+- CodeQL or other GitHub-only integrations.
+- **Self-hosted Actions runners on a public repo** without fork-PR protections —
+  not approved as a billing workaround (see issue #95).
+
+## Receipts
+
+After a local run, commit or attach the generated file under
+`docs/evidence/local-ci/<sha>.md` when substituting for a failed Actions assignment,
+and note the substitution in the PR body.

--- a/docs/coordination/2026-08-08-issue-84-calibration-pair.md
+++ b/docs/coordination/2026-08-08-issue-84-calibration-pair.md
@@ -1,0 +1,24 @@
+# Issue #84 — skills-side status (2026-08-08)
+
+Paired proposal: exchange-protocol adoption, v4 event-contract re-pin, field-pair
+ownership (`docs/coordination/epistemic-calibration.md` step 1).
+
+## Skills repository (this repo)
+
+| Item | Status |
+|---|---|
+| `epistemic-product-calibration@1` contract at `plugins/epistemic-skills/contracts/` | **Published** on `main`; verifier + fixtures in tree |
+| Pin-tag reachability guard | **CI** — `.github/scripts/check_pin_tags.py` |
+| v4 producer names in event map / schema | **On `main`** at v5 support point |
+| Mint `pin/` tag for counterpart-selected coordinate | **Ready** when calibration names a commit |
+
+## Calibration repository (counterpart)
+
+| Item | Owner | Status |
+|---|---|---|
+| Adopt or counter-propose `epistemic-product-calibration@1` | calibration | **Open** — not verified in this sweep |
+| Re-pin event contract at v4+ coordinate | calibration | **Open** |
+| Field-pair supply for mint gate | joint | **Open** |
+
+No forced merge from this issue. Next step: calibration maintainer records adopt/counter
+on an issue or PR in `ZMS-Labs/epistemic-calibration`, then skills mints the agreed `pin/` tag.

--- a/docs/evidence/BEHAVIORAL-EPOCH-REGISTER.md
+++ b/docs/evidence/BEHAVIORAL-EPOCH-REGISTER.md
@@ -1,0 +1,34 @@
+# Behavioral epoch register (issue #77)
+
+Successor to closed #70. Every skill must have either (a) a dated live epoch under
+its eval battery, or (b) a current `results/BLOCKED.md` reviewed at a release gate.
+
+## A. CI-wired trigger-and-scope batteries (BLOCKED.md today)
+
+| Skill | Battery path | Live epoch | Notes |
+|---|---|---|---|
+| open-questions | `evals/open-questions/` | — | also #61 |
+| context-audit | `evals/context-audit/` | — | |
+| agent-interface-design | `evals/agent-interface-design/` | — | retired skill; battery may archive |
+| wayfinding | `evals/wayfinding/` | — | |
+| throwaway-prototyping | `evals/throwaway-prototyping/` | — | |
+| intent-traced-merge | `evals/intent-traced-merge/` | — | |
+
+## B. Core skills without house-shape batteries
+
+| Skill | Status |
+|---|---|
+| blindspot-pass | no eval surface |
+| evidence-research / resolve literature | method + connectors; no scored epoch |
+| write-goal | no eval surface |
+| outsource | no eval surface |
+
+## C. Linked campaigns
+
+- **#39** — valid four-arm superiority run (epistemic-flexibility Phase 4)
+- Amended arbitrator-certification battery — `NOT_RUN` per skill honest limits
+
+## How to close #77
+
+Commit `results/<YYYY-MM-DD>/` (or updated BLOCKED.md) per row, then update this
+table with the evidence path. Release notes cite this register, not #70.

--- a/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/handoffs/2026-08-06-fudge-design-md-leverage.md
@@ -1,0 +1,77 @@
+# Handoff — Fudge DESIGN.md leverage recommendations
+
+**Date:** 2026-08-06  
+**Branch:** `cursor/fudge-design-md-leverage-b285`  
+**Draft PR:** [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100)  
+**Design spec:** [`docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md`](../superpowers/specs/2026-08-06-fudge-design-md-leverage.md)  
+**Stack alignment (Fudge + Claude Design + frontend-design + Impeccable):** [`docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md`](../superpowers/specs/2026-08-07-visual-design-stack-alignment.md)  
+**ZMS org design repo placement (skill decision + fleet):** [`docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md`](../superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md) — *blocked until `zms-labs-design` is readable by agents*  
+**Draft craft stub:** [`plugins/epistemic-skills/reference/craft/visual-design-md.md`](../../plugins/epistemic-skills/reference/craft/visual-design-md.md)  
+**Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT)  
+**Status:** recommendations recorded; **not operator-approved**; no implementation beyond this exploratory PR
+
+This file is the durable pick-up brief for a future agent. Prefer it over chat
+history. Do not treat the draft craft stub as live doctrine until an operator
+approves the design and the exploratory markers are removed.
+
+## Verdict (recommended)
+
+**Ship Approach A only:** thin craft doctrine under
+`plugins/epistemic-skills/reference/craft/visual-design-md.md`, pin Fudge
+guides **by link**, do not vendor the collection, do not add a routed skill.
+
+**Stack (2026-08-07):** Treat Fudge as the *reference seed*; **Claude Design**
+(canvas + org design system + Claude Code handoff/`/design-sync` on API) as
+*optional Claude-harness exploration* — distinct from the **`frontend-design`**
+skill; Impeccable as *optional per-project* `PRODUCT.md` / `DESIGN.md` + commands.
+See the alignment spec. Do **not** bundle Impeccable or Claude Design into
+`epistemic-skills` (D8 budget).
+
+### Why
+
+1. **Hole is real.** `agent-interface-design` declines human UI;
+   `evidence-locked-uat` accepts UI but does not choose visual direction.
+   Fudge `DESIGN.md` is the missing pre-build visual packet.
+2. **Craft slot matches package law.** v4 already demoted workflow methods to
+   `reference/craft/`. v5 D8 forbids burning description bytes on a new
+   "when doing UI" skill trigger.
+3. **Link > vendor.** Upstream is MIT and churns (~287 guides). Vendoring
+   copies (Approach B) adds stale trees and attribution surface for little
+   gain. Operator-only notes (Approach C) leave the hole invisible to plugin
+   consumers.
+4. **Calibration stays out.** `epistemic-calibration` is no-UI by design;
+   do not invent a surface there under this workstream.
+
+## Do / don't for the next agent
+
+| Do | Don't |
+|---|---|
+| Get operator approval of Approach A (or an explicit override to B/C) before merging as doctrine | Merge the exploratory stub as if it were approved craft |
+| On approval: strip "EXPLORATORY DRAFT" markers; optionally add a one-line craft pointer from wiki/catalog pages the way other craft is listed | Add `visual-design-md` to metacognate roster or any skill description |
+| Keep shortlist as **pointers** to upstream `design-md/<domain>.md` | Copy the full Fudge tree into this repo |
+| If a product needs offline durability, vendor **one** guide with MIT attribution + fetch date | Invent hex/type tokens the capture marked as unknown |
+| Leave `evidence-locked-uat` as acceptance authority | Treat a pinned DESIGN.md as a UAT PASS |
+
+## Defaults on open questions (unless operator overrides)
+
+1. **Approach:** A (craft + pin-by-link).  
+2. **Host Cursor frontend rules:** mention as complementary in craft only if
+   the package stays honest that they are host-local, not portable doctrine;
+   default = stay package-portable and silent about host rules.  
+3. **Pointer from `evidence-locked-uat`:** skip for v1; discovery via craft
+   only. Add a one-liner later only if agents keep skipping the pin.  
+4. **First project-local DESIGN.md:** none required by this PR; spawn a
+   follow-up only when a concrete human-facing surface is in scope.
+
+## Artifacts already on this branch
+
+- Design with A/B/C and recommendation:
+  `docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md`
+- Exploratory craft sketch (same recommendation, operational form):
+  `plugins/epistemic-skills/reference/craft/visual-design-md.md`
+- This handoff
+
+## Stop condition for *this* session
+
+Recommendations are committed on the PR branch for future consideration.
+No further implementation in the originating session.

--- a/docs/release/BACKLOG-REGISTER-2026-08-08.md
+++ b/docs/release/BACKLOG-REGISTER-2026-08-08.md
@@ -1,0 +1,31 @@
+# Backlog register — 2026-08-08
+
+Single disposition table for open issues and stale draft PRs after the backlog
+sweep branch `cursor/backlog-sweep-47ab`.
+
+## Draft PRs
+
+| PR | Disposition | Action |
+|---|---|---|
+| **#109** OpenAI / ChatGPT bundles | **Merged via sweep** | Rebases onto `main` (post-#110); close draft after merge |
+| **#100** Fudge DESIGN.md exploration | **Merged via sweep** | Docs/handoff/reference only; close draft after merge |
+| **#103** v5 post-release audit | **Superseded** | Landed on `main` as #107 + #108; close draft |
+
+## Issues
+
+| Issue | Title | Disposition |
+|---|---|---|
+| **#105** | Public-content remediation + gate | **Close** — scrub + `check_public_content.py` + RED seeds on `main`; operator applies `RELEASE-BODY-AMEND-v5.0.0.md` + repo description |
+| **#104** | v5 design commitments | **Close** — mechanical rows implemented on `main` (#107); C1–C3 remain **successor-tag** gates (see `SUCCESSOR-PROGRESS-104-105-2026-08-07.md`), not merge blockers |
+| **#95** | Local CI fallback | **Partial close** — `docs/CI-LOCAL-FALLBACK.md` + `run_local_ci.sh`; k8s DNS/egress remains open |
+| **#89** | Discovery auth canary | **Close** — symmetric canary + ladder rung in `skills/resolve/literature/METHOD.md` |
+| **#84** | Exchange protocol / re-pin | **Track** — `docs/coordination/2026-08-08-issue-84-calibration-pair.md`; calibration repo decides adoption |
+| **#77** | Behavioral epoch program | **Track** — `docs/evidence/BEHAVIORAL-EPOCH-REGISTER.md`; live epochs remain operator/model work |
+| **#40** | Step-7b before v3 3.0.0 | **Superseded** — v5 line shipped; gate applies to **future** immutable tags per `RELEASING.md` |
+| **#39** | Four-arm superiority run | **Track** — evidence debt under #77 / epistemic-flexibility program; no v3.0.0 release pending |
+
+## Operator checklist (not automatable here)
+
+- [ ] GitHub Release body amend for `v5.0.0` (`docs/release/RELEASE-BODY-AMEND-v5.0.0.md`)
+- [ ] Repository description string (same file)
+- [ ] Close issues #104, #105, #89, #40 with pointers to this register after merge

--- a/docs/release/RELEASE-BODY-AMEND-v5.0.0.md
+++ b/docs/release/RELEASE-BODY-AMEND-v5.0.0.md
@@ -35,7 +35,7 @@ authorized by the public-content finding (identifiers/topology, not credentials)
 
 ## Operator checklist
 
-- [ ] Merge corrective PR to `main`
+- [x] Merge corrective PR to `main` (#107, 2026-08-07)
 - [ ] Paste the additions into the GitHub Release body for `v5.0.0`
 - [ ] Update the repository description string
 - [ ] Confirm tag SHA unchanged

--- a/docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md
+++ b/docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md
@@ -32,12 +32,10 @@ Subject branch: `cursor/v5-post-release-104-105-4cee` (continues draft PR #103 o
 
 ## Closure posture
 
-- **#105:** close after PR merge + Release body amend + repo description update.
-- **#104:** mechanical design commitments on this branch are implemented. Remaining
-  release conditions C1–C3 (live captures, estate headroom or amendment, isolated
-  multi-family Gauntlet) gate a *conforming successor tag*, not the corrective merge.
-  Close #104 when those are discharged **or** explicitly waived/amended for that
-  release with the same honesty rules as item 8.
+- **#105:** close after operator applies Release body amend + repo description (see
+  `RELEASE-BODY-AMEND-v5.0.0.md`). Tree remediation and CI gate are on `main`.
+- **#104:** mechanical design commitments are on `main`. C1–C3 gate a *conforming
+  successor tag*; tracked in `BACKLOG-REGISTER-2026-08-08.md`.
 
 ## Documentation follow-up (2026-08-07)
 

--- a/docs/superpowers/plans/2026-08-06-openai-plugin-bundles.md
+++ b/docs/superpowers/plans/2026-08-06-openai-plugin-bundles.md
@@ -1,0 +1,93 @@
+# Dynamic OpenAI Bundles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate current, deterministic ChatGPT and OpenAI plugin bundles from the canonical epistemic-skills package with no hand-maintained skill list.
+
+**Architecture:** A stdlib Python builder discovers canonical skill directories, validates existing source-linked manifests, generates an index, and writes two deterministic archives. A dedicated workflow tests and rebuilds those archives on every relevant repository revision.
+
+**Tech Stack:** Python 3.12 stdlib, `unittest`, ZIP, JSON, GitHub Actions.
+
+## Global Constraints
+
+- `plugins/epistemic-skills/` is the only canonical runtime package.
+- Direct `skills/<name>/SKILL.md` children define the inventory.
+- Do not commit generated ZIP files.
+- Fail closed on malformed inputs, source-path drift, or non-portable symlinks.
+- Every PR commit carries an author-matching DCO signoff.
+
+---
+
+### Task 1: Define the dynamic bundle contract
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-08-06-openai-plugin-bundles-design.md`
+- Create: `packaging/openai/chatgpt-skill/SKILL.md`
+
+**Interfaces:**
+- Consumes: canonical skill frontmatter and existing package layout.
+- Produces: a wrapper contract that reads a generated `skill-index.json` and loads `package/<canonical_path>`.
+
+- [x] Write the approved design without enumerating current skills.
+- [x] Write the ChatGPT wrapper template with explicit snapshot and degradation boundaries.
+- [x] Review both files for a hidden fixed inventory or unsupported publication claim.
+
+### Task 2: Test dynamic discovery and deterministic packaging
+
+**Files:**
+- Create: `.github/scripts/test_build_openai_bundles.py`
+- Create: `.github/scripts/build_openai_bundles.py`
+
+**Interfaces:**
+- Consumes: `repo_root`, `out_dir`, and `source_revision`.
+- Produces: `BuildResult(chatgpt_skill, openai_plugin, checksums, skill_count)`.
+
+- [x] Write failing tests for inventory discovery, archive layout, determinism, YAML single-quote handling, malformed names, and marketplace drift.
+- [x] Run the tests and confirm failure because the builder does not exist.
+- [x] Implement the smallest stdlib builder satisfying the tests.
+- [x] Run `python .github/scripts/test_build_openai_bundles.py` and confirm all tests pass.
+- [x] Run `python -m py_compile` on both Python files.
+
+### Task 3: Add continuous revision-bound generation
+
+**Files:**
+- Create: `.github/workflows/openai-bundles.yml`
+- Create: `.github/scripts/test_openai_bundle_workflow.py`
+
+**Interfaces:**
+- Consumes: the durable PR head SHA or the current `main`, release, or manually dispatched event SHA.
+- Produces: one Actions artifact containing both bundles and `SHA256SUMS`, named and indexed with that same source revision.
+
+- [x] Trigger on every path that can change package bytes or packaging behavior.
+- [x] Pin checkout, setup-python, and upload-artifact actions to immutable commits.
+- [x] Run unit tests, live-package validation, build, and artifact upload in order.
+- [x] Keep permissions read-only.
+- [x] Add a regression test binding PR checkout, provenance, and artifact naming to the durable PR head SHA rather than the temporary merge-ref SHA.
+
+### Task 4: Document installation and refresh boundaries
+
+**Files:**
+- Create: `docs/CHATGPT-AND-OPENAI-PACKAGING.md`
+
+**Interfaces:**
+- Consumes: generated archives and current OpenAI Skills/Plugins product behavior.
+- Produces: maintainer commands and an honest operator installation path.
+
+- [x] Document Personal Skill upload as the immediate snapshot route.
+- [x] Document marketplace/plugin refresh as the durable source-linked route.
+- [x] State that public directory publication remains an OpenAI control-plane action.
+- [x] Record local validation commands.
+
+### Task 5: Publish for review
+
+**Files:**
+- Modify append-only: `plugins/epistemic-skills/skills/metacognate/runs/ledger.jsonl`
+
+**Interfaces:**
+- Consumes: verified branch diff and DCO identity.
+- Produces: signed commits and a draft PR against `main`.
+
+- [x] Append the bounded metacognate engagement record.
+- [x] Commit all files with `Signed-off-by: SternOne <89846440+SternOne@users.noreply.github.com>`.
+- [x] Open a draft PR with validation evidence and explicit platform boundaries.
+- [x] Inspect the resulting PR diff and CI state; correct the observed temporary-merge-SHA provenance defect with a regression test.

--- a/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
+++ b/docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md
@@ -1,0 +1,116 @@
+# Leveraging Fudge DESIGN.md for agent visual work
+
+**Date:** 2026-08-06  
+**Status:** exploratory draft (Approach A recommended; not approved)  
+**Upstream:** [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT) · [design.withfudge.com](https://design.withfudge.com/)  
+**Future-agent pick-up:** [`docs/handoffs/2026-08-06-fudge-design-md-leverage.md`](../../handoffs/2026-08-06-fudge-design-md-leverage.md)  
+**Stack alignment:** [`2026-08-07-visual-design-stack-alignment.md`](2026-08-07-visual-design-stack-alignment.md) (Fudge + Claude Design + `frontend-design` + Impeccable)  
+**Sibling note:** `epistemic-calibration` remains no-UI by design; this proposal does not add a surface there.
+
+## What Fudge DESIGN.md is
+
+[fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) is a curated collection (~287 guides as of this draft) of **agent-consumable visual briefs** generated from real websites captured in Fudge. Each `design-md/<domain>.md` guide typically:
+
+- states a **design character** (mood, hierarchy, what to preserve);
+- separates **captured measurements** from **interpretation**;
+- lists typography / color / spacing / radius observations when retained;
+- shows representative page captures;
+- ends with **practical guidance** and **known gaps** (what the capture did *not* establish).
+
+The intended use, from the upstream README: drop one guide into a project so a coding agent gets a specific visual direction grounded in a real reference, instead of inventing a generic SaaS look.
+
+## Why this package should care
+
+`epistemic-skills` already owns two adjacent seats and leaves a hole between them:
+
+| Seat | Owns | Explicitly declines |
+|---|---|---|
+| `reference/craft/agent-interface-design.md` | Machine contracts another agent consumes | Human-facing UI/UX and docs for people |
+| `evidence-locked-uat` | Acceptance of material UI-facing change | Choosing the visual language before build |
+
+There is **no craft doctrine for grounding visual direction** before an agent paints pixels. Operator Cursor rules already constrain frontend taste (one composition, brand-first, no default purple SaaS, etc.), but those rules are session-global and not project-scoped reference packets. Fudge guides are exactly that missing packet class: portable, citeable, measurement-honest visual contracts.
+
+This is craft, not a new routed skill. Description-byte budget (v5 D8) forbids adding a trigger row for "when doing UI." The pattern matches the v4 demotion of `agent-interface-design` and `intent-traced-merge` into `reference/craft/`.
+
+## Non-goals
+
+- Do **not** vendor the full ~287-guide tree into this repo.
+- Do **not** mint a routed skill or expand the metacognate roster for visual design.
+- Do **not** treat a Fudge guide as a license to clone a brand; adapt character, not trademarked marks or proprietary fonts.
+- Do **not** invent UI for `epistemic-calibration` under this proposal.
+- Do **not** weaken `evidence-locked-uat`: DESIGN.md is pre-build direction, not acceptance evidence.
+
+## Approaches
+
+### A — Craft doctrine + pin-by-link (recommended)
+
+Add thin craft under `plugins/epistemic-skills/reference/craft/visual-design-md.md` that teaches agents:
+
+1. When human-facing visual work starts, **pin one DESIGN.md** (project root or `docs/design/DESIGN.md`) before implementing layout/chrome.
+2. Prefer a Fudge guide matched to the intended character; link upstream rather than copying unless a durable offline pin is required.
+3. Adapt character and token *relationships*; do not treat missing measurements as license to invent a full design system.
+4. Hand off to `evidence-locked-uat` (or the routine presentation check) for acceptance.
+
+**Pros:** Matches package thesis and craft slot; zero description-byte cost; MIT-compatible via link/attribution; reversible.  
+**Cons:** Agents must discover the craft file (same as other craft doctrine).
+
+### B — Curated shortlist vendored under `reference/visual-references/`
+
+Copy a small set of guides (e.g. anthropic, linear, stripe, abc.xyz) into-tree with MIT attribution and a README that maps each to a use case (editorial product, dense workspace, calm infra landing, austere investor page).
+
+**Pros:** Offline, reviewable diffs when upstream changes.  
+**Cons:** Stale copies; license attribution surface; still need craft doctrine for *when/how* to use them; duplicates upstream.
+
+### C — Operator-only convention (no package change)
+
+Document "put a DESIGN.md in the target repo" in fleet notes / Cursor rules only; leave `epistemic-skills` untouched.
+
+**Pros:** Fastest.  
+**Cons:** Invisible to anyone loading the plugin; does not close the craft hole next to `agent-interface-design`.
+
+## Recommended decision
+
+**Ship Approach A** as craft doctrine. Optionally keep a **shortlist pointer table** (links only, no file copies) inside that craft file for common characters. Revisit Approach B only if offline pins become load-bearing for a specific product surface.
+
+## Suggested shortlist (links only)
+
+| Character | Guide | When to prefer |
+|---|---|---|
+| Calm editorial tech | [anthropic.com](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/anthropic.com.md) | Docs, research, long-form product narrative |
+| Dense product workspace | [linear.app](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/linear.app.md) | Operator tools, issue/project chrome |
+| Quiet infra / payments landing | [stripe.com](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/stripe.com.md) | Marketing surfaces that must feel precise, not loud |
+| Austere empty canvas | [abc.xyz](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/abc.xyz.md) | Brand-first pages that win by restraint |
+| Dark developer workstation | [cursor.com](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/cursor.com.md) | Devtool account/settings/marketplace shells |
+
+Full catalog: [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md).
+
+## Relation to existing disciplines
+
+```text
+visual need appears
+        │
+        ▼
+  craft: visual-design-md   ← pin DESIGN.md / Fudge guide (this proposal)
+        │
+        ▼
+  build the surface
+        │
+        ▼
+  evidence-locked-uat       ← routine check or full UAT packet
+        │
+        ▼
+  acceptance claim
+```
+
+`agent-interface-design` remains the twin for **machine** interfaces. A surface that is both human UI and agent-consumed API needs both crafts, applied to their respective layers.
+
+## Open questions for review
+
+1. Approve Approach A (craft + pin-by-link), or prefer B/C?
+2. Should the craft file mention operator frontend Cursor rules as complementary constraints, or stay package-portable and silent about host rules?
+3. Is a one-line pointer from `evidence-locked-uat` ("visual direction should already be pinned; see craft/visual-design-md") worth the coupling, or keep discovery via craft only?
+4. Any ZMS Labs product surface that should get a *project-local* DESIGN.md in a follow-up PR (wiki, future operator UI, etc.)?
+
+## Draft artifact in this PR
+
+See [`plugins/epistemic-skills/reference/craft/visual-design-md.md`](../../../plugins/epistemic-skills/reference/craft/visual-design-md.md) — a concrete Approach A sketch, marked exploratory until this design is approved.

--- a/docs/superpowers/specs/2026-08-06-openai-plugin-bundles-design.md
+++ b/docs/superpowers/specs/2026-08-06-openai-plugin-bundles-design.md
@@ -1,0 +1,80 @@
+# Dynamic OpenAI and ChatGPT Bundles Design
+
+## Goal
+
+Make `epistemic-skills` usable through an immediate ChatGPT Personal Skill
+upload and ready for the durable OpenAI plugin/marketplace route without
+creating a second, hand-maintained inventory or blocking concurrent repository
+work.
+
+## Constraints
+
+- `plugins/epistemic-skills/` remains the only canonical package.
+- Adding, renaming, or removing a skill must not require editing the builder,
+  wrapper, workflow, or manifest inventory.
+- Bundles must be revision-bound, deterministic, and fail closed on malformed
+  frontmatter or a marketplace path that points away from the canonical tree.
+- Pull-request artifacts must identify a durable source commit, not a temporary
+  merge-ref SHA whose lifetime is coupled to the PR.
+- The immediate upload path must remain honest: uploaded Personal Skills are
+  snapshots, not live repository mounts.
+- Public directory publication is outside GitHub and must not be represented as
+  complete merely because a package builds.
+
+## Architecture
+
+A stdlib-only builder scans direct `skills/<name>/SKILL.md` children, validates
+frontmatter, hashes each complete skill subtree, and generates a machine-readable
+index. It produces two archives from the same bytes:
+
+1. A single ChatGPT Skill wrapper containing the generated index and the full
+   canonical package as supporting resources.
+2. A repository-layout plugin bundle containing the existing `.agents`
+   marketplace and canonical package paths.
+
+A dedicated GitHub Actions workflow runs tests and builds both artifacts for
+relevant PRs, every relevant `main` push, releases, and manual dispatch. On PRs,
+the workflow checks out and records the durable PR head SHA; other events use
+their event SHA. Checkout, index provenance, and artifact naming share that one
+revision value.
+
+## Data flow
+
+```text
+plugins/epistemic-skills/skills/*/SKILL.md
+                 + package support files
+                 + existing manifests
+                           |
+                           v
+             build_openai_bundles.py
+                 /                 \
+                v                   v
+  ChatGPT Personal Skill ZIP   OpenAI plugin ZIP
+                \                   /
+                 v                 v
+                  SHA256SUMS + CI artifact
+```
+
+No generated archive is committed. A workflow artifact is always rebuilt from
+the checked-out revision, preventing stale binary drift in Git history.
+
+## Validation and failure behavior
+
+The builder rejects an empty skill glob, missing or malformed frontmatter,
+frontmatter/directory name mismatch, symlinks, malformed manifests, a marketplace
+source other than `./plugins/epistemic-skills`, or a plugin skills path other
+than `./skills/`. Archive members are sorted, timestamps fixed, permissions
+normalized, and checksums emitted.
+
+Unit tests plant inventory additions, source drift, and malformed frontmatter;
+they also compare archive bytes from repeated builds. A separate workflow
+contract test prevents PR artifacts from regressing to a temporary merge-ref SHA
+or omitting their own test from workflow execution and path triggers.
+
+## Concurrency and future evolution
+
+The implementation lives on an isolated branch. Future work on `main` changes
+the next generated artifact automatically because the workflow reads the
+canonical package at that revision. If the branch falls behind during review,
+normal branch updating resolves source conflicts; there is no copied skill tree
+to reconcile.

--- a/docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md
+++ b/docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md
@@ -1,0 +1,201 @@
+# Visual design stack alignment — Fudge, Claude Design, frontend-design, Impeccable
+
+**Date:** 2026-08-07 (Claude Design harness section added same day)  
+**Status:** design draft (extends PR [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100); not operator-approved)  
+**Related:** [`2026-08-06-fudge-design-md-leverage.md`](2026-08-06-fudge-design-md-leverage.md) · [`2026-08-06-epistemic-skills-v5-design.md`](2026-08-06-epistemic-skills-v5-design.md) (D8 estate budget)
+
+**Primary external docs (Claude Design ↔ harness):**
+
+- [Get started with Claude Design](https://support.claude.com/en/articles/14604416-get-started-with-claude-design) — canvas flow, `/design-sync`, MCP setup, handoff to Claude Code  
+- [Claude Code commands — `/design-login`, `/design-sync`](https://code.claude.com/docs/en/commands) — bundled skill behavior and API-only availability  
+- [Claude Design admin guide](https://support.claude.com/en/articles/14604406-claude-design-admin-guide-for-team-and-enterprise-plans) — org design systems, rollout, Enterprise admin role  
+
+## Naming (do not conflate)
+
+| Name | What it is | Where it lives |
+|---|---|---|
+| **Claude Design** | Anthropic Labs **product**: chat + canvas for prototypes, decks, microsites; org **design systems**; export and **handoff to Claude Code** | [claude.ai/design](https://claude.ai/design), Claude Desktop sidebar; beta on paid plans |
+| **`frontend-design` skill** | Anthropic **implementation craft** (bold direction, eight domains, anti–AI-slop) — text skill, not the canvas product | Bundled in Impeccable; Apache 2.0 |
+| **Impeccable** | Third-party **harness toolkit** (commands + `frontend-design` + anti-patterns + repo `PRODUCT.md` / `DESIGN.md`) | Per-project `.cursor/skills/` etc. |
+| **Fudge DESIGN.md** | Third-party **capture briefs** (~287 sites) for agent-consumable visual character | Link to [fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) |
+| **`/design-sync`** | Claude Code **bundled skill**: upload/sync a **React** design system with Claude Design | Terminal; requires Anthropic API path to claude.ai |
+| **Claude Design MCP** | HTTP MCP so Claude Code can create/edit design projects without leaving the terminal | `claude mcp add --scope user --transport http claude-design https://api.anthropic.com/v1/design/mcp` + `/design-login` per Help Center |
+
+“Claude design” in operator conversation often means **Claude Design the product**, not the **`frontend-design` skill**. This document treats both and states how they compose.
+
+## Problem
+
+Five layers can all speak “design” to agents, with overlapping goals but different
+shapes, install surfaces, and authority:
+
+| Layer | Primary artifact | Typical harness |
+|---|---|---|
+| Fudge guide | Upstream `design-md/<domain>.md` | Any |
+| Claude Design | Org design system + canvas project + handoff bundle | Web/Desktop; Claude Code via MCP/handoff |
+| Repo `DESIGN.md` / `PRODUCT.md` | Stitch-style / Impeccable context | Cursor, Claude Code, Codex, … |
+| `frontend-design` | Skill doctrine | Impeccable or host-shipped skill |
+| Impeccable commands | Audit, polish, normalize, … | Cursor nightly / other harnesses |
+
+Without alignment, agents pin a Fudge file, skip org design systems, ignore a
+Claude Design handoff, or treat canvas output as shipped software — while
+`DESIGN.md` means three different things.
+
+## Design goal
+
+One **ordered stack** with clear seats, **harness-aware branches**, and
+`epistemic-skills` staying package-portable (craft pointers only — no vendoring
+Fudge, Impeccable, or Claude Design).
+
+## Recommended stack (harness-aware)
+
+### A — Claude Code on Anthropic API (full loop available)
+
+```text
+Human-facing UI work starts
+        │
+        ├─ Optional exploration: Claude Design (canvas) OR Fudge character seed
+        │
+        ▼
+[1] epistemic-skills craft: visual-design-md
+        │  Direction pinned? If React DS exists: note /design-sync expectation
+        ▼
+[2] Claude Design integration (when used)
+        │  /design-login → org design system attached to project
+        │  /design-sync [hint]  — repo React DS → Claude Design (re-run after DS changes; not a watcher)
+        │  Optional MCP: claude-design server for terminal create/edit
+        │  Handoff bundle → Claude Code (continues from design work, not a screenshot-only prompt)
+        ▼
+[3] Repo ground truth
+        │  PRODUCT.md + DESIGN.md (Impeccable when installed)
+        │  Fudge link only in Reference section if it seeded character
+        ▼
+[4] Build / refine in code
+        │  frontend-design principles; Impeccable audit · normalize · polish
+        ▼
+[5] evidence-locked-uat
+        ▼
+Acceptance claim
+```
+
+**Constraints from Anthropic docs:**
+
+- `/design-sync` is **unavailable** on Amazon Bedrock, Google Cloud Agent
+  Platform, Microsoft Foundry, and Claude Platform on AWS — the tool cannot reach
+  claude.ai ([commands reference](https://code.claude.com/docs/en/commands)).
+  On those deployments, use branch **B** only.
+- First `/design-sync` on a large React repo can take hours (per-component verify).
+- Claude Design without an org design system still produces **functional but
+  generic** output ([admin guide](https://support.claude.com/en/articles/14604406-claude-design-admin-guide-for-team-and-enterprise-plans)) — same failure class as unpinned Fudge.
+
+### B — Cursor and other harnesses (no Claude Design product API)
+
+```text
+visual-design-md craft → Fudge seed (link) → repo DESIGN.md/PRODUCT.md (Impeccable)
+        → frontend-design / Impeccable during build → evidence-locked-uat
+```
+
+Do not instruct Cursor agents to run `/design-sync` or depend on Claude Design
+MCP. Treat Claude Design handoff artifacts as **inputs** when the operator
+drops them into the repo or task, not as an assumed integration.
+
+### C — Machine-only surfaces
+
+`agent-interface-design` only; this stack does not apply.
+
+## Role of each layer
+
+### Claude Design (product) — *explore, systematize, hand off*
+
+- **Owns:** Canvas iteration, org-scoped design systems (from codebase, GitHub,
+  uploads, web capture), exports (HTML, PDF, PPTX, partners), **handoff bundle**
+  into Claude Code.
+- **Does not own:** Production merge authority, CI acceptance, or epistemic
+  claims about “done.”
+- **epistemic-skills stance:** Document as **optional Claude-harness path** in
+  craft; never bundle or proxy Claude Design inside the plugin. Handoff bundle +
+  implemented code still require **evidence-locked-uat** for material UI claims.
+
+### `/design-sync` + `/design-login` — *bridge code ↔ Claude Design*
+
+- **Owns:** Keeping Claude Design’s generated UI aligned with **real React
+  components** in the repo (push/upload semantics per Anthropic; re-sync after
+  token/component changes).
+- **Does not own:** Non-React stacks, offline harnesses, or automatic bidirectional
+  merge without operator review (community reports: design→code may need explicit
+  steps beyond a single command).
+- **epistemic-skills stance:** Mention in craft under “when on Claude Code (API)”;
+  point to official commands doc; flag Bedrock/Foundry gap.
+
+### Fudge DESIGN.md — *reference seed*
+
+(Unchanged from PR #100.) Capture-derived character; link-by-default; cite in
+project `DESIGN.md` when Impeccable or Claude Design org system is primary.
+
+### Claude `frontend-design` — *implementation craft*
+
+(Unchanged.) Distinct from Claude Design product; execution quality during coding.
+
+### Impeccable — *repo-local design ops*
+
+(Unchanged.) Out of `epistemic-skills` package; complements both Cursor and
+Claude Code terminal work **after** direction exists.
+
+## Resolving `DESIGN.md` and “design system” collisions
+
+| Artifact | Authority |
+|---|---|
+| Claude Design **org design system** (cloud) | Source for **canvas** and synced React components after `/design-sync` |
+| Repo **`DESIGN.md`** (Impeccable / Stitch) | **Build-time truth** for coding agents in that repo |
+| Fudge **`design-md/*.md`** | **Reference seed** only — mood, hierarchy, gaps |
+| Claude Design **handoff bundle** | **Contract input** for implementation session — not a PASS |
+
+**Rule:** One primary repo `DESIGN.md` per surface. After `/design-sync`, prefer
+**real components** over re-inventing markup. If Fudge seeded the project, keep a
+short Reference section; do not let Fudge override synced org tokens.
+
+## Composability matrix (extended)
+
+| Situation | Claude Design | /design-sync | Fudge | Impeccable | Craft |
+|---|---|---|---|---|---|
+| Greenfield UI, Claude Code API, React DS | Explore on canvas → handoff | Before/after DS changes | Optional character seed | `init` / `document` | Pin + harness note |
+| Greenfield UI, Cursor only | N/A (operator may explore manually) | N/A | Pin link | `init` / `document` | Pin mandatory |
+| Brownfield React, DS in repo | Optional polish on canvas | Re-sync when components change | Skip | `normalize` / `audit` | Light gate |
+| Bedrock / Foundry Claude Code | Not available | **Unavailable** | Pin + repo files | If installed | Full B path |
+| Deck / PPTX only | Claude Design primary | Optional | Rare | N/A | UAT if “product UI” claim |
+| Agent API only | — | — | — | — | `agent-interface-design` |
+
+## Conflicts and how to decide
+
+| Tension | Resolution |
+|---|---|
+| Claude Design canvas vs repo `DESIGN.md` | Canvas explores; repo file + synced components win at implementation unless operator explicitly adopts export-only HTML without code integration. |
+| Handoff bundle vs UAT | Handoff = starting point for code; **evidence-locked-uat** gates material UI acceptance. |
+| Claude Design generic output vs Fudge pin | Set up org design system or pin Fudge **before** broad rollout; admin guide recommends DS-first rollout. |
+| `frontend-design` “BOLD” vs Fudge restraint | Bold within pinned character (unchanged). |
+| Impeccable vs Claude Design | Complementary: Claude Design for visual exploration/system sync on Claude harness; Impeccable for terminal command passes on repo files. |
+| Purple SaaS / AI slop | All layers agree it is a failure mode. |
+| Skill estate budget (D8) | Do not add Claude Design or Impeccable into `epistemic-skills`; craft links only. |
+
+## What changes in PR #100 (if accepted)
+
+1. **`visual-design-md.md`** — Stack section includes Claude Design branch,
+   `/design-sync` prerequisites, MCP pointer, Bedrock caveat, handoff ≠ UAT.
+2. **This spec** — Canonical alignment doc for all four names plus harness table.
+3. **Handoff** — Operator: approve harness branches; whether wiki documents
+   Claude Design for ZMS fleet Claude Code users.
+4. **Still out of scope:** Vendoring any third-party design tree; new routed
+   skill; `epistemic-calibration` UI.
+
+## Operator decisions needed
+
+1. Approve stack **A vs B** defaults per fleet (Claude Code API vs Cursor-primary).
+2. Whether ZMS standardizes **org design system in Claude Design** before agent UI work.
+3. Impeccable naming in package docs (unchanged recommendation: yes, optional).
+4. Require **handoff bundle + UAT** for any UI merged from Claude Design canvas.
+
+## Open follow-ups
+
+- Fudge section → Stitch `DESIGN.md` mapping table (one page).
+- Fleet runbook: `/design-login` once per user, when to re-run `/design-sync`,
+  MCP scope (`user` vs `project`).
+- Project PR template when a surface uses Claude Design handoff (paths, anchors).

--- a/docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md
+++ b/docs/superpowers/specs/2026-08-07-zms-labs-design-fleet-placement.md
@@ -1,0 +1,161 @@
+# ZMS Labs design — fleet placement & skill decision
+
+**Date:** 2026-08-07  
+**Status:** draft — **blocked on reading** [`ZMS-Labs/zms-labs-design`](https://github.com/ZMS-Labs/zms-labs-design)  
+**Extends:** PR [#100](https://github.com/ZMS-Labs/epistemic-skills/pull/100), [`2026-08-07-visual-design-stack-alignment.md`](2026-08-07-visual-design-stack-alignment.md)
+
+## Access note (this session)
+
+From the Cloud Agent environment (`cursor` GitHub integration):
+
+- `gh repo view ZMS-Labs/zms-labs-design` → **404**
+- Anonymous `git ls-remote` → **repository not found**
+- Public HTTP fetch of the repo URL → **404**
+
+So either the repository is **private** and the agent app lacks org/repo access, or it is **not created yet** under that exact name. This document coheres PR #100 with the **intended** role of `zms-labs-design` as the org design home. **Reconcile against the real README/philosophy** once the repo is cloned (add it to the [Cloud environment](https://cursor.com/dashboard/cloud-agents) repos + grant the Cursor GitHub App access to `zms-labs-design`).
+
+---
+
+## Intended philosophy (coherence with PR #100)
+
+PR #100 argues: human-facing visual work needs a **pinned direction** before pixels;
+acceptance stays with `evidence-locked-uat`; machine contracts stay with
+`agent-interface-design`. That is **epistemic choreography**, not a design system.
+
+**`zms-labs-design` (intended seat)** should own what PR #100 deliberately refuses
+to put in `epistemic-skills`:
+
+| Concern | Owner | Rationale |
+|---|---|---|
+| Brand, tokens, components, typography, motion rules | **`zms-labs-design`** | Durable product/org artifact; versioned; human + agent consumable |
+| When to pin direction / hand off to UAT | **`epistemic-skills` craft** (`visual-design-md`) | Portable method; link, don’t vendor |
+| Canvas exploration + org DS in Anthropic cloud | **Claude Design** + `/design-sync` | Harness product; sync **from** `zms-labs-design` when React DS exists |
+| Terminal polish / anti-slop passes | **Impeccable** (optional per harness) | Third-party; reads repo `DESIGN.md` |
+| Greenfield character before ZMS DS exists | **Fudge** (link only) | External reference seed |
+| “It works on screen” / material UI claims | **`evidence-locked-uat`** | Epistemic acceptance |
+
+**One sentence:** `zms-labs-design` is the **organization’s visual source of truth**;
+`epistemic-skills` teaches **when and how agents must bind to that truth** (or an
+explicit interim pin) before building and before claiming done.
+
+### What should live in `zms-labs-design` (target shape)
+
+Pending repo content, expect at least:
+
+1. **Canonical `DESIGN.md`** (and/or Stitch-style packet) — what every ZMS human UI repo should cite or submodule.
+2. **`PRODUCT.md` template or org default** — strategy layer Impeccable/Claude Design expect.
+3. **Implementable design system** — tokens, components; if React, the **sync source** for Claude Design `/design-sync`.
+4. **Consumption contract** — how product repos pin a version (git submodule, npm package, copied hash-pinned excerpt).
+5. **Explicit non-goals** — not epistemic disciplines, not fleet health, not calibration science (`epistemic-calibration` stays no-UI).
+
+### What should *not* move into `epistemic-skills`
+
+- Full Fudge tree, Impeccable bundle, or Claude Design
+- ZMS brand tokens (duplicates `zms-labs-design` and breaks portability thesis)
+- A second copy of org `DESIGN.md` that can drift
+
+---
+
+## (a) Does a skill deserve to exist — and in which repo?
+
+Use the **subject test** (v5 design): `epistemic-skills` owns **claims that must bear
+load** about work, reasoning, or running systems. Visual taste and token compliance
+are **workflow substrate**, not an epistemic moment — same reason
+`agent-interface-design` was demoted to **craft**.
+
+### Decision table
+
+| Candidate | Verdict | Where |
+|---|---|---|
+| New **routed** `visual-design` / `design-system` skill in **`epistemic-skills`** | **No** | Description-byte budget (D8); duplicates craft + UAT; wrong subject |
+| **`visual-design-md` craft** in `epistemic-skills` | **Yes** (thin) | Points to org DS + stack; no ZMS tokens inside portable core |
+| **ZMS-specific “apply our DS” skill** (normalize, token lint, component names) | **Yes, if needed** | **`zms-labs-design`** (or a tiny plugin *published from* that repo) — not copied into every app repo |
+| **Impeccable** | **No new org skill** | Install per harness/project; already ~1.2k description bytes in estate |
+| **`evidence-locked-uat`** in product repos | **Already in `epistemic-skills`** | Same package everywhere; do not fork |
+| **Per-repo design skill** in each ZMS-Labs app | **No** | Drift, budget burn, inconsistent triggers |
+
+### Recommended rule for “any repo within ZMS-Labs”
+
+- **Every repo** that ships human UI: **depends on** `zms-labs-design` (pin) + loads **`epistemic-skills`** (unchanged).
+- **At most one** org-owned design-application skill/package: lives with **`zms-labs-design`**, not N copies.
+- **Zero** new routed visual skills in `epistemic-skills` unless the subject test changes (e.g. you need *epistemic* gates on design *claims* — that is still `evidence-locked-uat` / `gauntlet`, not a design skill).
+
+### If `zms-labs-design` already ships agent skills
+
+Map each skill to:
+
+- **Application** (use tokens) → keep in `zms-labs-design`
+- **Acceptance** (prove UI) → invoke `evidence-locked-uat` from `epistemic-skills`
+- **Exploration** (canvas) → Claude Design + handoff, not a repo skill
+
+---
+
+## (b) Leveraging design across repos, fleets, services, clusters
+
+Think in **layers**, not “install design everywhere.”
+
+```text
+                    ┌─────────────────────────────┐
+                    │   zms-labs-design (Git)      │
+                    │   DESIGN.md · tokens · DS    │
+                    └──────────────┬──────────────┘
+           pin / submodule / package │
+     ┌─────────────┬───────────────┼───────────────┬─────────────┐
+     ▼             ▼               ▼               ▼             ▼
+ product repos  Claude Design   Claude Code    Cursor fleet   (future)
+ (UI apps)      org DS          /design-sync   Impeccable     surfaces
+     │             │               │               │
+     └─────────────┴─────── build in repo ────────┘
+                           │
+                           ▼
+              epistemic-skills: evidence-locked-uat
+                           │
+     ┌─────────────────────┴─────────────────────┐
+     ▼                                           ▼
+ headless services / jobs                   K8s clusters
+ (no visual-design-md)                      health · triage · watch
+```
+
+### By surface type
+
+| Surface | Design leverage | Epistemic package |
+|---|---|---|
+| **Human UI repos** (wiki, canvas chrome, operator tools) | Pin `zms-labs-design`; optional Fudge only pre-DS; Impeccable or Claude path per harness | `visual-design-md` craft + `evidence-locked-uat` |
+| **Libraries / APIs / agents** | `agent-interface-design` only | No visual craft |
+| **Homelab / fleet ops** | `LOCAL.md` overrides; site-specific diagnostics stay out of portable DS | `health` · `triage` · `watch` (v5) |
+| **Clusters (K8s)** | Dashboards only if product-owned; DS from `zms-labs-design` | Runtime truth ≠ pixel polish |
+| **Claude Code fleet** | `/design-login`; `/design-sync` from DS rooted in `zms-labs-design`; handoff bundles land in product repos | Same `epistemic-skills` install |
+| **Cursor / cloud agents** | Environment lists repos; add `zms-labs-design` to agent environment; craft points to pinned DS path | No `/design-sync` unless API path |
+
+### Distribution patterns (pick one primary)
+
+1. **Git submodule** `vendor/zms-labs-design` + CI check that `DESIGN.md` hash matches tag.
+2. **Published package** (`@zms-labs/design-tokens`) consumed by apps; `DESIGN.md` generated or copied at release.
+3. **Claude Design org default** fed by periodic `/design-sync` from the package’s React layer.
+
+Avoid: pasting tokens into each repo’s `DESIGN.md` without a single upstream.
+
+### Fleet-wide agent instructions
+
+| Layer | What to configure once |
+|---|---|
+| **Org** | Claude Design enabled; design system sourced from `zms-labs-design`; admin role for publish |
+| **`epistemic-skills`** | Approve craft; one line in README/wiki: “ZMS UI pins `zms-labs-design` @ ref” |
+| **`zms-labs-design`** | Version tags; consumption doc; optional ZMS design skill/plugin |
+| **Each UI repo** | `PRODUCT.md` local; `DESIGN.md` = pointer or re-export; UAT in CI for material UI |
+| **Harness** | Impeccable in `.cursor/skills` where Cursor; Claude MCP where Code |
+
+---
+
+## Operator decisions (unblocks implementation)
+
+1. **Confirm `zms-labs-design` exists and grant** Cursor GitHub App + Cloud Environment repo access.
+2. **Approve:** no routed visual skill in `epistemic-skills`; org design skill only in `zms-labs-design` if needed.
+3. **Choose distribution:** submodule vs npm vs sync-only Claude Design.
+4. **Merge PR #100 craft** after aligning README in `zms-labs-design` with this split (no contradiction).
+
+## Next step after repo is readable
+
+1. Diff this doc against `zms-labs-design` README, ADRs, and any existing skills.
+2. Update [`visual-design-md.md`](../../../plugins/epistemic-skills/reference/craft/visual-design-md.md) with the **canonical pin URL/path** for ZMS.
+3. Optionally add `zms-labs-design` to the [Cloud Agent environment](https://cursor.com/dashboard/cloud-agents/environments/e/688d12dd-9109-11f1-ba66-0e7d0216e441) repos (see `epistemic-calibration/.cursor/environment.json` `repositoryDependencies`).

--- a/packaging/openai/chatgpt-skill/SKILL.md
+++ b/packaging/openai/chatgpt-skill/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: epistemic-skills
+description: Use when the approach itself is uncertain, when a claim about correctness/completion/deployment is about to bear load, when evidence quality or acceptance is disputed, when resuming from a summary or handoff, or when the user explicitly asks to use Epistemic Skills. This generated bridge selects the current packaged disciplines dynamically. Do NOT fire for routine, reversible, directly checkable work.
+---
+
+# Epistemic Skills — ChatGPT bridge
+
+This is a generated adapter, not a second source of truth. The authoritative
+methods are the bundled files under `package/skills/`.
+
+## Invocation contract
+
+1. Read `skill-index.json` before responding or acting. It is regenerated from
+   direct `package/skills/<name>/SKILL.md` children on every build.
+2. Compare the current task with every description in that generated index.
+   Never use a remembered or hand-maintained inventory.
+3. Load each applicable file at `package/<canonical_path>` and follow it exactly,
+   including positive and negative triggers, ordering, gates, artifacts,
+   degradation rules, stopping conditions, and handoffs.
+4. If no current description applies, do ordinary work. Extra process earns no
+   credit merely because this bridge was installed.
+5. When several skills apply, obey their own ordering. A process or entry-point
+   skill that applies runs before a narrower implementation discipline, and
+   control returns to the interrupted work when the bounded engagement ends.
+6. Never claim a runtime, independent actor, scheduler, persistent store, or
+   other capability the current harness does not provide. Use the selected
+   skill's degradation path and mark the limitation explicitly.
+7. Treat the `source.revision` in `skill-index.json` as the bundle's provenance.
+   An uploaded personal Skill is a snapshot; do not describe it as current after
+   the repository has moved unless it has been rebuilt and re-uploaded.
+
+## Pairing with workflow skills
+
+When a workflow layer such as Superpowers is installed, use both as
+complementary systems. Either may interrupt the other when its trigger becomes
+true, hard gates remain binding across both layers, and the interruption must
+return control to the point where it began.

--- a/plugins/epistemic-skills/reference/craft/visual-design-md.md
+++ b/plugins/epistemic-skills/reference/craft/visual-design-md.md
@@ -1,0 +1,129 @@
+<!-- craft doctrine: visual-design-md — EXPLORATORY DRAFT (2026-08-06).
+     Not approved craft. Proposal lives in
+     docs/superpowers/specs/2026-08-06-fudge-design-md-leverage.md.
+     Pattern mirrors agent-interface-design: workflow/craft method, not a
+     routed epistemic skill; no description-byte budget claim. -->
+
+# visual-design-md — pin a visual contract before painting pixels
+
+When work produces a **human-facing** visual surface (landing page, product
+chrome, docs site, operator UI), the failure mode is not only wrong acceptance —
+it is an ungrounded visual invention: purple-on-white SaaS defaults, card soup,
+or a first viewport that could belong to any brand.
+
+`agent-interface-design` owns machine contracts and **declines** human UI.
+`evidence-locked-uat` owns acceptance of material UI and **does not** choose
+the look. This craft fills the gap: **encode visual direction as a pinned
+DESIGN.md before implementing layout and chrome.**
+
+## Evidence posture
+
+This craft is **methodological**, not literature-graded. Upstream Fudge guides
+are capture-derived briefs with explicit known gaps; treat missing tokens as
+unknown, not as permission to invent a full system. Do not overclaim that a
+DESIGN.md improves acceptance rates — UAT still owns acceptance.
+
+## Where this sits
+
+| Slot | Skill / craft | Relation |
+|---|---|---|
+| Machine contract to another agent | `reference/craft/agent-interface-design.md` | Twin for agent-consumed schemas; not for human pixels |
+| Visual direction before build | **this craft** | Pins character, hierarchy, and measured relationships |
+| Acceptance of the built surface | `evidence-locked-uat` | Judges the rendered surface; does not pick the reference |
+| High-blast-radius product claims | `gauntlet` | Adversarial review when stakes require it |
+
+## Stack alignment (Fudge + Claude Design + frontend-design + Impeccable)
+
+These layers are complementary when **ordered** and **harness-aware**; they are
+not competing authorities for the same `DESIGN.md` slot. Full spec:
+[`docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md`](../../../../docs/superpowers/specs/2026-08-07-visual-design-stack-alignment.md).
+
+| Layer | Role |
+|---|---|
+| **Claude Design** (product) | Optional explore/handoff on Claude harness — canvas, org design system, export; [Help Center](https://support.claude.com/en/articles/14604416-get-started-with-claude-design) |
+| **`/design-login` + `/design-sync`** | Claude Code only (Anthropic API): sync **React** design system with Claude Design — [commands](https://code.claude.com/docs/en/commands); **not** on Bedrock/Foundry |
+| **Fudge guide** (link or thin cite) | Reference *seed* — character, hierarchy, known gaps |
+| **Project `DESIGN.md` + `PRODUCT.md`** | Build-time truth when [Impeccable](https://impeccable.style) (or equivalent) is installed |
+| **Claude `frontend-design`** | Implementation craft — not the Claude Design canvas; usually via Impeccable |
+| **Impeccable commands** | Optional passes (`audit`, `normalize`, `polish`, …) before acceptance |
+| **This craft** | Gate: direction pinned before pixels; handoff bundle ≠ PASS |
+| **`evidence-locked-uat`** | Acceptance after build |
+
+**Cursor / non-Claude-Design harnesses:** Fudge pin → repo `DESIGN.md` →
+Impeccable/`frontend-design` → UAT. Do not assume `/design-sync` or Claude
+Design MCP.
+
+Do not add Impeccable, Claude Design, or the full Fudge tree to
+`epistemic-skills`; estate description bytes are rivalrous (v5 D8).
+
+## Core moves
+
+1. **Pin one guide.** Before implementing human-facing layout, place or link a
+   `DESIGN.md` at the project root or `docs/design/DESIGN.md`. Prefer a single
+   primary reference over a collage of five.
+2. **Match character, not celebrity.** Choose a Fudge guide (or a
+   project-authored DESIGN.md in the same shape) for the *mood and hierarchy*
+   you need — editorial calm, dense workspace, austere empty canvas, dark
+   workstation — not because the brand is fashionable.
+3. **Adapt; do not clone.** Preserve relationships (scale ratios, accent
+   scarcity, separator-over-shadow, open field vs dense chrome). Do not copy
+   proprietary marks, licensed typefaces you do not have, or trademarked
+   illustration systems.
+4. **Respect known gaps.** If the guide omits color tokens, interaction
+   states, or responsive rules, invent the minimum needed for the task and
+   record that invention in the PR — do not pretend the capture specified it.
+5. **Hand off to acceptance.** Routine presentation check or
+   `evidence-locked-uat` still gates material UI claims. A pinned DESIGN.md is
+   direction, not a PASS.
+
+## Upstream source (link, do not vendor by default)
+
+Collection: [scroobius-pip/fudge-design-md](https://github.com/scroobius-pip/fudge-design-md) (MIT).  
+Product: [design.withfudge.com](https://design.withfudge.com/).
+
+Pin by linking the specific `design-md/<domain>.md` file (and optionally
+quoting the Design character / Practical guidance sections into the PR or a
+thin local `DESIGN.md` that cites upstream). Vendor a copy only when offline
+durability is required; if you vendor, keep MIT attribution and a fetch date.
+
+### Character shortlist (pointers only)
+
+| Need | Guide |
+|---|---|
+| Calm editorial tech narrative | [`anthropic.com.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/anthropic.com.md) |
+| Dense product workspace | [`linear.app.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/linear.app.md) |
+| Quiet infrastructure landing | [`stripe.com.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/stripe.com.md) |
+| Austere brand-first empty canvas | [`abc.xyz.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/abc.xyz.md) |
+| Dark developer workstation shell | [`cursor.com.md`](https://github.com/scroobius-pip/fudge-design-md/blob/main/design-md/cursor.com.md) |
+
+## Use it when
+
+- Starting or substantially redesigning a human-facing visual surface.
+- An agent is about to invent a look without a project design system.
+- Operator frontend constraints exist but no project-local visual packet does.
+
+## Do not use it when
+
+- The surface is agent-consumed only (schemas, MCP, CLI contracts) — use
+  `agent-interface-design`.
+- The change is a routine, reversible presentation tweak with an existing
+  design system already in-tree.
+- You need acceptance evidence — that is `evidence-locked-uat`, not this file.
+- The target is `epistemic-calibration`'s learning loop (no UI required).
+
+## Anti-patterns
+
+| Failure | Fix |
+|---|---|
+| "I'll vibe a purple gradient landing page." | Pin a guide; start from its character and practical guidance. |
+| "I'll merge Linear + Stripe + A24 into one moodboard." | One primary guide; secondary references only for a named subsystem. |
+| "The guide had no hex values, so I invented a 40-token palette." | Invent the minimum; document the gap; keep accent budget small. |
+| "DESIGN.md exists, so UAT is optional." | Direction ≠ acceptance. Run the routine check or UAT as usual. |
+| Vendoring the entire Fudge tree into the plugin. | Link. Curate at most a shortlist of pointers in craft. |
+
+## Falsifiable gate (lightweight)
+
+Before claiming the visual direction is set: a cold reader of the pinned
+DESIGN.md can state (1) the intended character in one sentence, (2) what must
+be preserved, and (3) at least one known gap. If they cannot, the pin is too
+thin or the wrong guide was chosen.

--- a/plugins/epistemic-skills/skills/metacognate/runs/ledger.jsonl
+++ b/plugins/epistemic-skills/skills/metacognate/runs/ledger.jsonl
@@ -1,1 +1,2 @@
 {"schema":"skill-run@1","ts":"2026-08-07T00:00:00Z","skill":"metacognate","decision":"declined","discipline_engaged":null,"action_changed":false,"example":true,"notes":"synthetic exemplar; not live telemetry"}
+{"schema":"skill-run@1","ts":"2026-08-07T04:21:31Z","skill":"metacognate","decision":"fired","discipline_engaged":null,"action_changed":true}

--- a/plugins/epistemic-skills/skills/resolve/literature/METHOD.md
+++ b/plugins/epistemic-skills/skills/resolve/literature/METHOD.md
@@ -127,6 +127,17 @@ explicitly, never silently:**
   signed-in returns a collections list; anonymous errors with a sign-in
   message. Canary fails → treat Scite as unauthenticated (below); never read
   slim results as "no contrasting citations / no notices".
+- **Consensus discovery canary (mandatory when Consensus search tools are
+  present):** the discovery engine can also serve an anonymous free tier whose
+  calls *succeed* with plausible full records (title, abstract, journal, URL) —
+  indistinguishable in-band from authenticated results. The only signal is often
+  a quota-counter trailer appended *after* the result block (for example a line
+  reporting free searches used this month). Before any discovery pass, inspect
+  the **entire** response for free-tier / quota / sign-in trailers. Trailer
+  present → treat discovery as **present-but-unauthenticated** (below); stamp
+  every matrix row `discovery: DEGRADED (free tier)` and do not grade coverage
+  as clean. Re-authenticate and re-run the canary before trusting discovery
+  output for load-bearing rows.
 - Scite absent/unauthenticated → run Consensus + Zotero (when available) and
   stamp every matrix row `reception: UNVERIFIED (Scite unavailable)`. The
   synthesis must carry a visible coverage limit; do not soften conclusions'
@@ -136,6 +147,11 @@ explicitly, never silently:**
   with a live Scite MCP pass.
 - Consensus absent → Scite-led discovery, labeled; note the loss of
   study-design filtering; still run the Zotero holdings/deposit steps.
+- Consensus present-but-unauthenticated (discovery canary failed) → continue
+  only with explicit `discovery: DEGRADED (free tier)` on every matrix row; do
+  not treat the run as saturated or coverage-clean until discovery is
+  re-authenticated or the operator accepts the degraded ceiling in the run
+  record.
 - **Zotero / library substrate absent, unreachable, empty, or
   operator-GUI-only with no operator available this turn** → stamp every
   matrix row `holdings: UNVERIFIED (Zotero unavailable)` and record
@@ -263,6 +279,7 @@ Fail transparently; partial verified record beats gap-filling from memory.
 |---|---|
 | "The abstract said it supports X, good enough" | Abstract-level is not passage-level. Verification level must be recorded honestly (§8); an abstract claim can be contradicted by the paper's own results or methods section, and does not license a `[V]` reception claim. |
 | "Scite returned results, so reception is checked" | Results could be from a slim, anonymous-tier response indistinguishable in-band from an authenticated one (§2 auth canary). Re-probe authed via `search_collections` before trusting any reception signal, and label degraded coverage (`filter-level`, `UNVERIFIED`) rather than silently treating slim records as a full reception pass. |
+| "Consensus returned a full page of papers, so discovery is checked" | Discovery can succeed on a free tier with plausible records; the quota trailer is easy to miss (§2 discovery canary). Inspect the full response, stamp `discovery: DEGRADED (free tier)` when the trailer appears, and never report coverage as clean on a degraded discovery pass. |
 | "It's old and well-cited, skip the retraction check" | Citation count is not quality, and age does not exempt a paper from being retracted years after publication. The retraction/notice check (§5-6) is unconditional for every load-bearing paper, regardless of vintage or citation volume. |
 | "One engine found it, that's the literature" | A single engine is not triangulated. Consensus and Scite answer different epistemic questions (discovery vs. reception) and must both weigh in per §7 Cross-validate; divergence between them is a coverage limit to record, not a result to discard. |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backlog sweep for stale draft PRs and open issues:

- **#109** — merge OpenAI/ChatGPT dynamic bundle builder, tests, workflow, packaging docs
- **#100** — land Fudge/visual-design exploration docs, handoff, and `reference/craft/visual-design-md.md` (no runtime change)
- **#103** — superseded by #107/#108 (close draft after merge)
- **#89** — Consensus discovery canary + degradation ladder in `resolve/literature/METHOD.md`
- **#95** — `docs/CI-LOCAL-FALLBACK.md` + `run_local_ci.sh` wrapper (k8s DNS still tracked)
- **#104/#105** — update successor closure docs; see `BACKLOG-REGISTER-2026-08-08.md`
- **#84/#77/#39/#40** — status registers (calibration pair, behavioral epochs, supersession notes)

## Operator follow-up (not in this PR)

- Apply `docs/release/RELEASE-BODY-AMEND-v5.0.0.md` to the mutable `v5.0.0` Release body
- Update GitHub repository description per same file
- Close draft PRs #100, #103, #109 and issues per register after merge

## Testing

- `python .github/scripts/test_build_openai_bundles.py`
- `python plugins/epistemic-skills/contracts/watch-commission/test_watch_commission.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b3c0f81-4177-4e82-8e8a-c1d6663c47ab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b3c0f81-4177-4e82-8e8a-c1d6663c47ab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

