### PR TITLE
feat: mission-custody@1 contracts + custody core + manifest skill

### DIFF
--- a/.github/workflows/mission-custody-contract.yml
+++ b/.github/workflows/mission-custody-contract.yml
@@ -40,3 +40,11 @@ jobs:
         run: python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
       - name: Compile mission custody verifier
         run: python -m py_compile plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+      - name: Custody store unit tests
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
+      - name: Custody mission lifecycle unit tests
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+      - name: Custody CLI black-box tests
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+      - name: Three-subprocess kill/resume/repair continuity proof
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_process_proof.py

--- a/.github/workflows/mission-custody-contract.yml
+++ b/.github/workflows/mission-custody-contract.yml
@@ -1,0 +1,42 @@
+name: mission-custody-contract
+
+"on":
+  workflow_dispatch:
+  push:
+    paths:
+      - "plugins/epistemic-skills/contracts/mission-custody/**"
+      - "docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md"
+      - "docs/superpowers/plans/2026-08-11-mission-custody-contracts.md"
+      - ".github/workflows/mission-custody-contract.yml"
+  pull_request:
+    paths:
+      - "plugins/epistemic-skills/contracts/mission-custody/**"
+      - "docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md"
+      - "docs/superpowers/plans/2026-08-11-mission-custody-contracts.md"
+      - ".github/workflows/mission-custody-contract.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out the tested revision without stored credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Record the exact tested revision
+        run: |
+          echo "candidate_sha=$(git rev-parse HEAD)"
+          git status --short
+      - name: Mission custody semantic and schema contract
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+      - name: Compile mission custody verifier
+        run: python -m py_compile plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py

--- a/docs/superpowers/plans/2026-08-11-mission-custody-contracts.md
+++ b/docs/superpowers/plans/2026-08-11-mission-custody-contracts.md
@@ -1127,7 +1127,9 @@ Write each `...` body out in full in the file (the assertions described in the c
 - [ ] **Step 4: Run all three test files** — 0 failures; check total line count: `wc -l custody_store.py custody_mission.py` — flag if the two already exceed ~600 (budget for the CLI).
 - [ ] **Step 5: Commit** — `feat: mission lifecycle with drift reanchoring and clearable FAIL`.
 
----### Task 7: CLI (`custody_cli.py`)
+---
+
+### Task 7: CLI (`custody_cli.py`)
 
 **Files:**
 - Create: `plugins/epistemic-skills/contracts/mission-custody/custody_cli.py`

--- a/docs/superpowers/plans/2026-08-11-mission-custody-contracts.md
+++ b/docs/superpowers/plans/2026-08-11-mission-custody-contracts.md
@@ -1,0 +1,1267 @@
+# Mission Custody Contracts ("custodian") Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the `mission-custody@1` contract family (Stage A) and the stdlib custody core + Claude Code `manifest` skill (Stage B) per the approved design `docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md`, ending with the tracer-mission handoff.
+
+**Architecture:** Contracts-first, mirroring `plugins/epistemic-skills/contracts/watch-commission/` file-for-file in kind: four schema JSONs + ONE hand-rolled stdlib verifier + flat valid/invalid examples corpus + stdlib test script + path-filtered CI. The custody core is three focused stdlib modules beside the contracts (store / mission / CLI), proven by a three-subprocess kill-resume-repair test. The skill is one SKILL.md with three trigger doors and a hard decline clause.
+
+**Tech Stack:** Python stdlib only (no jsonschema, no pip deps — house rule). Tests are plain scripts run with `python <file>` (exit code is the oracle), matching `test_watch_commission.py`. CI mirrors `.github/workflows/commission-watch-contract.yml` (pinned actions, Python 3.12).
+
+## Global Constraints
+
+- **Stdlib-only**: no third-party imports anywhere in contracts or core (spec: "stdlib verifier", "stdlib-only ... custody core").
+- **Core size cap**: custody core total **~500–800 lines** across its three modules (spec cap). If a change pushes past ~800, stop and flag — do not gold-plate.
+- **Schema evolution rule**: additive optional fields only within `@1`; anything else is a new epoch (spec, locked from gauntlet P1-DEFER-SCHEMA-RULE).
+- **No routing**: no skill names, member inventories, or stage-to-skill tables anywhere in custodian output or SKILL.md (spec: P2-NO-PA-ROUTING preserved).
+- **Closed state list**: `draft / active / reopened / verifying / completed / cancelled` — exactly these six.
+- **Acceptance tiers**: `operator-accepted` > `declared-role-separation`; self-certification refused; **no `externally-proven` tier exists**.
+- **FAIL is clearable**: a `FAIL` verdict must have a tested remediate → re-verify → accept path (designed out of PA's reject dead-end).
+- **Line endings**: repo files are LF. Write files as shown; commit with `git -c core.autocrlf=input commit`. (Estate CRLF landmine.)
+- **Every commit**: DCO sign-off `Signed-off-by: Zach Stern <zachstern@gmail.com>` plus the session trailers used in commit 979e0fd.
+- **Working directory**: the worktree `Y:/dev/es-wt-mission-custody`, branch `spec/mission-custody-contracts-design`. Never touch `Y:/dev/epistemic-skills` (main checkout) or its stashes.
+- **Timestamps**: all `*_utc` fields are ISO-8601 `YYYY-MM-DDTHH:MM:SSZ` strings; validators check shape (regex), not clock truth.
+- **Hashes**: all `*_sha256` fields are 64 lowercase hex chars.
+
+**Contract directory (all Stage A files):** `plugins/epistemic-skills/contracts/mission-custody/`
+**Record kinds:** `mission-manifest@1`, `checkpoint@1`, `receipt@1`, `acceptance-verdict@1` — one verifier validates all four, dispatching on the required `"record"` field.
+
+---
+
+### Task 1: Verifier scaffold + `mission-manifest@1`
+
+**Files:**
+- Create: `plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/mission-manifest.schema.json`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/examples/valid-manifest-minimal.json`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-amended-instruction.json`
+
+**Interfaces:**
+- Produces: `validate_record(record: dict) -> list[str]` (empty list = valid; each entry `"FIELD_PATH: reason"`), constants `STATES`, `TIERS`, `VERDICTS`, `RECORD_KINDS`, helpers `is_iso_utc(s) -> bool`, `is_sha256(s) -> bool`, `validate_manifest(rec) -> list[str]`. CLI: `python verify_mission_custody.py <file.json>...` exits 0 iff all valid, prints errors per file.
+- Consumes: nothing (first task).
+
+- [ ] **Step 1: Write the failing test**
+
+`test_mission_custody.py` (complete file; later tasks append functions and extend `main()`):
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from verify_mission_custody import (  # noqa: E402
+    RECORD_KINDS,
+    STATES,
+    TIERS,
+    VERDICTS,
+    validate_record,
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def load(name: str) -> dict:
+    return json.loads((ROOT / "examples" / name).read_text(encoding="utf-8"))
+
+
+def valid_manifest() -> dict:
+    return load("valid-manifest-minimal.json")
+
+
+def test_constants() -> None:
+    check("states-closed-list", STATES == {
+        "draft", "active", "reopened", "verifying", "completed", "cancelled"})
+    check("tiers", TIERS == {"operator-accepted", "declared-role-separation"})
+    check("verdicts", VERDICTS == {"PASS", "FAIL", "INCONCLUSIVE"})
+    check("record-kinds", RECORD_KINDS == {
+        "mission-manifest@1", "checkpoint@1", "receipt@1", "acceptance-verdict@1"})
+
+
+def test_manifest_valid_example() -> None:
+    check("manifest-valid-example", validate_record(valid_manifest()) == [])
+
+
+def test_manifest_missing_instruction() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    del rec["authority"]["instruction"]
+    check("manifest-missing-instruction", validate_record(rec) != [])
+
+
+def test_manifest_unknown_top_level_field() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["surprise"] = 1
+    check("manifest-unknown-field", validate_record(rec) != [])
+
+
+def test_manifest_bad_tier() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["acceptance"]["required_tier"] = "externally-proven"
+    check("manifest-no-externally-proven-tier", validate_record(rec) != [])
+
+
+def test_manifest_amendments_must_be_list_of_dated_text() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["amendments"] = ["bare string"]
+    check("manifest-amendment-shape", validate_record(rec) != [])
+
+
+def test_unknown_record_kind_rejected() -> None:
+    check("unknown-record-kind", validate_record({"record": "mystery@1"}) != [])
+
+
+def test_examples_corpus() -> None:
+    ex = ROOT / "examples"
+    for path in sorted(ex.glob("valid-*.json")):
+        rec = json.loads(path.read_text(encoding="utf-8"))
+        check(f"corpus-{path.name}", validate_record(rec) == [])
+    for path in sorted(ex.glob("invalid-*.json")):
+        rec = json.loads(path.read_text(encoding="utf-8"))
+        check(f"corpus-{path.name}", validate_record(rec) != [])
+
+
+def main() -> int:
+    test_constants()
+    test_manifest_valid_example()
+    test_manifest_missing_instruction()
+    test_manifest_unknown_top_level_field()
+    test_manifest_bad_tier()
+    test_manifest_amendments_must_be_list_of_dated_text()
+    test_unknown_record_kind_rejected()
+    test_examples_corpus()
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd Y:/dev/es-wt-mission-custody && python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py`
+Expected: FAIL — `ModuleNotFoundError: No module named 'verify_mission_custody'`
+
+- [ ] **Step 3: Write the examples**
+
+`examples/valid-manifest-minimal.json`:
+
+```json
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": ["repo:vanta:read", "repo:vanta:write-config"],
+    "protected_state": ["download-clients:enabled-state"],
+    "acceptable_costs": ["one working session per stage"]
+  },
+  "scope": {
+    "in": ["monitored-missing reconciliation"],
+    "out": ["indexer changes", "VPN configuration"]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": ["any download client starts re-grabbing"],
+    "stop_if": ["operator revokes"],
+    "escalate_if": ["protected state would be touched"]
+  },
+  "steward_ref": "agent:claude-code-session"
+}
+```
+
+`examples/invalid-manifest-amended-instruction.json` (amendment tries to carry a replacement instruction — append-only text is allowed, a non-object amendment is not):
+
+```json
+{
+  "record": "mission-manifest@1",
+  "mission_id": "bad-amend",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Original instruction.",
+    "amendments": ["replace the instruction with: do something else"],
+    "permissions": [],
+    "protected_state": [],
+    "acceptable_costs": []
+  },
+  "scope": {"in": [], "out": []},
+  "acceptance": {"required_tier": "declared-role-separation", "acceptor_ref": null},
+  "stop_rules": {"hold_if": [], "stop_if": [], "escalate_if": []},
+  "steward_ref": "agent:x"
+}
+```
+
+- [ ] **Step 4: Write the verifier**
+
+`verify_mission_custody.py` (complete file for this task; Tasks 2–3 add the dispatch branches marked below):
+
+```python
+#!/usr/bin/env python3
+"""Validate mission-custody@1 records without third-party dependencies.
+
+Record kinds: mission-manifest@1, checkpoint@1, receipt@1, acceptance-verdict@1.
+validate_record() dispatches on the required "record" field and returns a list
+of "FIELD: reason" strings; empty list means valid.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+STATES = {"draft", "active", "reopened", "verifying", "completed", "cancelled"}
+TIERS = {"operator-accepted", "declared-role-separation"}
+VERDICTS = {"PASS", "FAIL", "INCONCLUSIVE"}
+RECORD_KINDS = {
+    "mission-manifest@1",
+    "checkpoint@1",
+    "receipt@1",
+    "acceptance-verdict@1",
+}
+
+_ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+MANIFEST_FIELDS = {
+    "record", "mission_id", "created_utc", "authority", "scope",
+    "acceptance", "stop_rules", "steward_ref",
+}
+AUTHORITY_FIELDS = {
+    "operator_ref", "instruction", "amendments", "permissions",
+    "protected_state", "acceptable_costs",
+}
+
+
+def is_iso_utc(value: Any) -> bool:
+    return isinstance(value, str) and bool(_ISO_RE.match(value))
+
+
+def is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and bool(_SHA_RE.match(value))
+
+
+def _str_list(value: Any) -> bool:
+    return isinstance(value, list) and all(
+        isinstance(item, str) and item for item in value)
+
+
+def _require(errors: list[str], cond: bool, field: str, reason: str) -> None:
+    if not cond:
+        errors.append(f"{field}: {reason}")
+
+
+def _check_exact_fields(errors: list[str], rec: dict, allowed: set[str],
+                        where: str) -> None:
+    for key in rec:
+        if key not in allowed:
+            errors.append(f"{where}.{key}: unknown field")
+    for key in allowed:
+        if key not in rec:
+            errors.append(f"{where}.{key}: missing")
+
+
+def validate_manifest(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, MANIFEST_FIELDS, "manifest")
+    if errors:
+        return errors
+    _require(errors, isinstance(rec["mission_id"], str)
+             and bool(_ID_RE.match(rec["mission_id"])),
+             "mission_id", "kebab-case identifier required")
+    _require(errors, is_iso_utc(rec["created_utc"]),
+             "created_utc", "ISO-8601 Z timestamp required")
+    _require(errors, isinstance(rec["steward_ref"], str) and rec["steward_ref"],
+             "steward_ref", "non-empty string required")
+
+    auth = rec["authority"]
+    if not isinstance(auth, dict):
+        errors.append("authority: object required")
+        return errors
+    _check_exact_fields(errors, auth, AUTHORITY_FIELDS, "authority")
+    if not errors:
+        _require(errors, isinstance(auth["operator_ref"], str)
+                 and auth["operator_ref"],
+                 "authority.operator_ref", "non-empty string required")
+        _require(errors, isinstance(auth["instruction"], str)
+                 and auth["instruction"],
+                 "authority.instruction", "non-empty verbatim string required")
+        amendments = auth["amendments"]
+        ok = isinstance(amendments, list) and all(
+            isinstance(a, dict) and set(a) == {"utc", "text"}
+            and is_iso_utc(a["utc"]) and isinstance(a["text"], str) and a["text"]
+            for a in amendments)
+        _require(errors, ok, "authority.amendments",
+                 "append-only list of {utc, text} objects required")
+        for name in ("permissions", "protected_state", "acceptable_costs"):
+            _require(errors, _str_list(auth[name]),
+                     f"authority.{name}", "list of strings required")
+
+    scope = rec["scope"]
+    ok = isinstance(scope, dict) and set(scope) == {"in", "out"} \
+        and _str_list(scope.get("in")) and _str_list(scope.get("out"))
+    _require(errors, ok, "scope", '{"in": [...], "out": [...]} required')
+
+    acc = rec["acceptance"]
+    ok = isinstance(acc, dict) and set(acc) == {"required_tier", "acceptor_ref"} \
+        and acc.get("required_tier") in TIERS \
+        and (acc.get("acceptor_ref") is None
+             or (isinstance(acc.get("acceptor_ref"), str) and acc["acceptor_ref"]))
+    _require(errors, ok, "acceptance",
+             "required_tier in TIERS and acceptor_ref string-or-null required")
+
+    stop = rec["stop_rules"]
+    ok = isinstance(stop, dict) \
+        and set(stop) == {"hold_if", "stop_if", "escalate_if"} \
+        and all(_str_list(stop[k]) for k in ("hold_if", "stop_if", "escalate_if"))
+    _require(errors, ok, "stop_rules",
+             "hold_if/stop_if/escalate_if string lists required")
+    return errors
+
+
+def validate_record(record: Any) -> list[str]:
+    if not isinstance(record, dict):
+        return ["record: JSON object required"]
+    kind = record.get("record")
+    if kind not in RECORD_KINDS:
+        return [f"record: unknown kind {kind!r}"]
+    if kind == "mission-manifest@1":
+        return validate_manifest(record)
+    if kind == "checkpoint@1":
+        return validate_checkpoint(record)      # Task 2
+    if kind == "receipt@1":
+        return validate_receipt(record)         # Task 3
+    return validate_acceptance_verdict(record)  # Task 3
+
+
+def validate_checkpoint(rec: dict) -> list[str]:  # replaced in Task 2
+    return ["record: checkpoint@1 validation not implemented"]
+
+
+def validate_receipt(rec: dict) -> list[str]:  # replaced in Task 3
+    return ["record: receipt@1 validation not implemented"]
+
+
+def validate_acceptance_verdict(rec: dict) -> list[str]:  # replaced in Task 3
+    return ["record: acceptance-verdict@1 validation not implemented"]
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: verify_mission_custody.py <file.json>...", file=sys.stderr)
+        return 2
+    failed = False
+    for arg in argv:
+        rec = json.loads(Path(arg).read_text(encoding="utf-8"))
+        errors = validate_record(rec)
+        if errors:
+            failed = True
+            for err in errors:
+                print(f"{arg}: {err}")
+        else:
+            print(f"{arg}: valid")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 5: Write the schema doc**
+
+`mission-manifest.schema.json` — documentation contract (validation authority is the verifier, matching the watch-commission pattern):
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "mission-manifest@1",
+  "title": "mission-manifest@1",
+  "description": "Durable mission authority record. Verbatim operator instruction is immutable; amendments append. Validation authority: verify_mission_custody.py (stdlib).",
+  "type": "object",
+  "required": ["record", "mission_id", "created_utc", "authority", "scope", "acceptance", "stop_rules", "steward_ref"],
+  "additionalProperties": false,
+  "properties": {
+    "record": {"const": "mission-manifest@1"},
+    "mission_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "created_utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"},
+    "authority": {
+      "type": "object",
+      "required": ["operator_ref", "instruction", "amendments", "permissions", "protected_state", "acceptable_costs"],
+      "additionalProperties": false,
+      "properties": {
+        "operator_ref": {"type": "string", "minLength": 1},
+        "instruction": {"type": "string", "minLength": 1},
+        "amendments": {"type": "array", "items": {"type": "object", "required": ["utc", "text"], "additionalProperties": false, "properties": {"utc": {"type": "string"}, "text": {"type": "string", "minLength": 1}}}},
+        "permissions": {"type": "array", "items": {"type": "string"}},
+        "protected_state": {"type": "array", "items": {"type": "string"}},
+        "acceptable_costs": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "scope": {"type": "object", "required": ["in", "out"], "additionalProperties": false, "properties": {"in": {"type": "array", "items": {"type": "string"}}, "out": {"type": "array", "items": {"type": "string"}}}},
+    "acceptance": {"type": "object", "required": ["required_tier", "acceptor_ref"], "additionalProperties": false, "properties": {"required_tier": {"enum": ["operator-accepted", "declared-role-separation"]}, "acceptor_ref": {"type": ["string", "null"]}}},
+    "stop_rules": {"type": "object", "required": ["hold_if", "stop_if", "escalate_if"], "additionalProperties": false, "properties": {"hold_if": {"type": "array", "items": {"type": "string"}}, "stop_if": {"type": "array", "items": {"type": "string"}}, "escalate_if": {"type": "array", "items": {"type": "string"}}}},
+    "steward_ref": {"type": "string", "minLength": 1}
+  }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py`
+Expected: `0 failures`, exit 0. Also run `python -m py_compile plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py` — exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody
+git -c core.autocrlf=input commit -m "feat: mission-custody@1 verifier scaffold + mission-manifest" \
+  -m "Signed-off-by: Zach Stern <zachstern@gmail.com>"
+```
+
+---
+
+### Task 2: `checkpoint@1`
+
+**Files:**
+- Modify: `plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py` (replace the `validate_checkpoint` stub)
+- Modify: `plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py` (append tests; extend `main()`)
+- Create: `plugins/epistemic-skills/contracts/mission-custody/checkpoint.schema.json`
+- Create: `examples/valid-checkpoint-r1.json`, `examples/valid-checkpoint-r2-chained.json`, `examples/invalid-checkpoint-r2-unchained.json`, `examples/invalid-checkpoint-bad-status.json` (in the contract's `examples/` dir)
+
+**Interfaces:**
+- Consumes: `validate_manifest`, `is_iso_utc`, `is_sha256`, `STATES`, `_require`, `_check_exact_fields` from Task 1.
+- Produces: `validate_checkpoint(rec) -> list[str]`; constant `CHECKPOINT_FIELDS`.
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+def valid_checkpoint_r1() -> dict:
+    return load("valid-checkpoint-r1.json")
+
+
+def test_checkpoint_valid_examples() -> None:
+    check("checkpoint-r1", validate_record(valid_checkpoint_r1()) == [])
+    check("checkpoint-r2", validate_record(load("valid-checkpoint-r2-chained.json")) == [])
+
+
+def test_checkpoint_r1_must_have_null_prev() -> None:
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    rec["prev_checkpoint_sha256"] = "a" * 64
+    check("checkpoint-r1-null-prev", validate_record(rec) != [])
+
+
+def test_checkpoint_r2_requires_prev_sha() -> None:
+    rec = load("valid-checkpoint-r2-chained.json")
+    rec["prev_checkpoint_sha256"] = None
+    check("checkpoint-r2-needs-prev", validate_record(rec) != [])
+
+
+def test_checkpoint_embedded_manifest_is_validated() -> None:
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    del rec["manifest"]["authority"]
+    check("checkpoint-embedded-manifest", validate_record(rec) != [])
+
+
+def test_checkpoint_status_closed_list() -> None:
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    rec["status"] = "paused"
+    check("checkpoint-closed-status", validate_record(rec) != [])
+```
+
+Add the five calls to `main()` before the corpus test. Run the test file — expected: FAIL (`checkpoint@1 validation not implemented`).
+
+- [ ] **Step 2: Write the examples**
+
+`examples/valid-checkpoint-r1.json`:
+
+```json
+{
+  "record": "checkpoint@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 1,
+  "status": "draft",
+  "prev_checkpoint_sha256": null,
+  "manifest": { "record": "mission-manifest@1", "mission_id": "tracer-media-missing", "created_utc": "2026-08-11T00:00:00Z", "authority": { "operator_ref": "operator:zach-stern", "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.", "amendments": [], "permissions": ["repo:vanta:read", "repo:vanta:write-config"], "protected_state": ["download-clients:enabled-state"], "acceptable_costs": ["one working session per stage"] }, "scope": {"in": ["monitored-missing reconciliation"], "out": ["indexer changes", "VPN configuration"]}, "acceptance": {"required_tier": "declared-role-separation", "acceptor_ref": null}, "stop_rules": {"hold_if": ["any download client starts re-grabbing"], "stop_if": ["operator revokes"], "escalate_if": ["protected state would be touched"]}, "steward_ref": "agent:claude-code-session" },
+  "state": {
+    "frontier": "await operator approval",
+    "notes": [],
+    "unresolved_verdicts": []
+  },
+  "receipt_ids": [],
+  "written_utc": "2026-08-11T00:00:01Z",
+  "written_by": "agent:claude-code-session"
+}
+```
+
+`valid-checkpoint-r2-chained.json`: copy r1, set `"revision": 2`, `"status": "active"`, `"prev_checkpoint_sha256": "4f2a09c1d8e7b6a5493827160f5e4d3c2b1a09f8e7d6c5b4a392817065f4e3d2"`, `"state": {"frontier": "stage 1: inventory", "notes": ["approved by operator"], "unresolved_verdicts": []}`, `"written_utc": "2026-08-11T00:10:00Z"`.
+`invalid-checkpoint-r2-unchained.json`: same as r2 but `"prev_checkpoint_sha256": null`.
+`invalid-checkpoint-bad-status.json`: r1 with `"status": "paused"`.
+
+- [ ] **Step 3: Implement `validate_checkpoint`**
+
+Replace the stub:
+
+```python
+CHECKPOINT_FIELDS = {
+    "record", "mission_id", "revision", "status", "prev_checkpoint_sha256",
+    "manifest", "state", "receipt_ids", "written_utc", "written_by",
+}
+
+
+def validate_checkpoint(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, CHECKPOINT_FIELDS, "checkpoint")
+    if errors:
+        return errors
+    _require(errors, isinstance(rec["revision"], int) and rec["revision"] >= 1,
+             "revision", "integer >= 1 required")
+    _require(errors, rec["status"] in STATES, "status",
+             f"one of {sorted(STATES)} required")
+    prev = rec["prev_checkpoint_sha256"]
+    if rec.get("revision") == 1:
+        _require(errors, prev is None, "prev_checkpoint_sha256",
+                 "null required at revision 1")
+    else:
+        _require(errors, is_sha256(prev), "prev_checkpoint_sha256",
+                 "64-hex sha256 of prior checkpoint file required")
+    if isinstance(rec["manifest"], dict) \
+            and rec["manifest"].get("record") == "mission-manifest@1":
+        for err in validate_manifest(rec["manifest"]):
+            errors.append(f"manifest.{err}")
+        if rec["manifest"].get("mission_id") != rec["mission_id"]:
+            errors.append("manifest.mission_id: must equal checkpoint mission_id")
+    else:
+        errors.append("manifest: embedded mission-manifest@1 required")
+    state = rec["state"]
+    ok = isinstance(state, dict) \
+        and set(state) == {"frontier", "notes", "unresolved_verdicts"} \
+        and isinstance(state.get("frontier"), str) and state["frontier"] \
+        and _str_list(state.get("notes")) \
+        and _str_list(state.get("unresolved_verdicts"))
+    _require(errors, ok, "state",
+             "frontier (non-empty str), notes[], unresolved_verdicts[] required")
+    _require(errors, _str_list(rec["receipt_ids"]), "receipt_ids",
+             "list of receipt id strings required")
+    _require(errors, is_iso_utc(rec["written_utc"]), "written_utc",
+             "ISO-8601 Z timestamp required")
+    _require(errors, isinstance(rec["written_by"], str) and rec["written_by"],
+             "written_by", "non-empty actor id required")
+    return errors
+```
+
+- [ ] **Step 4: Schema doc**
+
+`checkpoint.schema.json` — same documentation-contract style as Task 1 Step 5: `additionalProperties: false`, required = `CHECKPOINT_FIELDS`, `revision` integer minimum 1, `status` enum of the six states, `prev_checkpoint_sha256` type `["string","null"]` with the sha pattern, `manifest` `$ref`-described as `mission-manifest@1`, `state` object with `frontier`/`notes`/`unresolved_verdicts`, plus a `description` noting the r1-null / r≥2-sha chain rule lives in the verifier.
+
+- [ ] **Step 5: Run tests, then commit**
+
+Run: `python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py` — expected `0 failures`.
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody
+git -c core.autocrlf=input commit -m "feat: mission-custody@1 checkpoint record" \
+  -m "Signed-off-by: Zach Stern <zachstern@gmail.com>"
+```
+
+---
+
+### Task 3: `receipt@1` + `acceptance-verdict@1`
+
+**Files:**
+- Modify: `verify_mission_custody.py` (replace both remaining stubs), `test_mission_custody.py` (append tests) — in the contract dir
+- Create: `receipt.schema.json`, `acceptance-verdict.schema.json`
+- Create: `examples/valid-receipt.json`, `examples/valid-verdict-pass-separated.json`, `examples/valid-verdict-fail.json`, `examples/invalid-verdict-self-certified.json`, `examples/invalid-verdict-operator-tier-wrong-acceptor.json`
+
+**Interfaces:**
+- Consumes: helpers + constants from Tasks 1–2.
+- Produces: `validate_receipt(rec) -> list[str]`, `validate_acceptance_verdict(rec) -> list[str]`; constants `RECEIPT_FIELDS`, `VERDICT_FIELDS`.
+- Semantic rules later tasks rely on: **`acceptor_id != worker_id` always**; tier `operator-accepted` additionally requires `operator_ref` non-empty and `acceptor_id == operator_ref`.
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+def test_receipt_valid() -> None:
+    check("receipt-valid", validate_record(load("valid-receipt.json")) == [])
+
+
+def test_receipt_after_hash_required() -> None:
+    rec = load("valid-receipt.json")
+    rec["after_sha256"] = "not-a-hash"
+    check("receipt-after-hash", validate_record(rec) != [])
+
+
+def test_verdict_valid_pass() -> None:
+    check("verdict-pass", validate_record(load("valid-verdict-pass-separated.json")) == [])
+    check("verdict-fail", validate_record(load("valid-verdict-fail.json")) == [])
+
+
+def test_verdict_self_certification_refused() -> None:
+    rec = load("valid-verdict-pass-separated.json")
+    rec["acceptor_id"] = rec["worker_id"]
+    check("verdict-no-self-cert", validate_record(rec) != [])
+
+
+def test_verdict_operator_tier_binds_acceptor() -> None:
+    rec = load("valid-verdict-pass-separated.json")
+    rec["assurance_tier"] = "operator-accepted"
+    check("verdict-operator-tier-acceptor", validate_record(rec) != [])
+```
+
+Add calls to `main()`. Run — expected FAIL (`receipt@1 validation not implemented`).
+
+- [ ] **Step 2: Write the examples**
+
+`examples/valid-receipt.json`:
+
+```json
+{
+  "record": "receipt@1",
+  "mission_id": "tracer-media-missing",
+  "request_id": "req-0001",
+  "actor": "agent:claude-code-session",
+  "utc": "2026-08-11T00:20:00Z",
+  "artifact_path": "notes/stage-1-inventory.md",
+  "before_sha256": null,
+  "after_sha256": "9e2b7c1a4d5f60897a6b5c4d3e2f10987b6a5c4d3e2f109876b5a4c3d2e1f098"
+}
+```
+
+`examples/valid-verdict-pass-separated.json`:
+
+```json
+{
+  "record": "acceptance-verdict@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 6,
+  "verdict": "PASS",
+  "acceptor_id": "agent:acceptor-session",
+  "worker_id": "agent:claude-code-session",
+  "operator_ref": "operator:zach-stern",
+  "assurance_tier": "declared-role-separation",
+  "receipt_refs": ["req-0001"],
+  "reason": "Artifact re-observed; hashes match the receipt chain.",
+  "utc": "2026-08-11T01:00:00Z"
+}
+```
+
+`valid-verdict-fail.json`: same shape, `"verdict": "FAIL"`, `"reason": "Inventory omits season packs."`
+`invalid-verdict-self-certified.json`: valid-pass copy with `"acceptor_id": "agent:claude-code-session"`.
+`invalid-verdict-operator-tier-wrong-acceptor.json`: valid-pass copy with `"assurance_tier": "operator-accepted"` (acceptor is not the operator_ref).
+
+- [ ] **Step 3: Implement both validators**
+
+```python
+RECEIPT_FIELDS = {
+    "record", "mission_id", "request_id", "actor", "utc",
+    "artifact_path", "before_sha256", "after_sha256",
+}
+VERDICT_FIELDS = {
+    "record", "mission_id", "revision", "verdict", "acceptor_id", "worker_id",
+    "operator_ref", "assurance_tier", "receipt_refs", "reason", "utc",
+}
+
+
+def validate_receipt(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, RECEIPT_FIELDS, "receipt")
+    if errors:
+        return errors
+    for name in ("mission_id", "request_id", "actor", "artifact_path"):
+        _require(errors, isinstance(rec[name], str) and rec[name],
+                 name, "non-empty string required")
+    _require(errors, is_iso_utc(rec["utc"]), "utc", "ISO-8601 Z required")
+    _require(errors, rec["before_sha256"] is None or is_sha256(rec["before_sha256"]),
+             "before_sha256", "null (new artifact) or 64-hex sha256 required")
+    _require(errors, is_sha256(rec["after_sha256"]),
+             "after_sha256", "64-hex sha256 required")
+    return errors
+
+
+def validate_acceptance_verdict(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, VERDICT_FIELDS, "verdict")
+    if errors:
+        return errors
+    _require(errors, isinstance(rec["revision"], int) and rec["revision"] >= 1,
+             "revision", "integer >= 1 required")
+    _require(errors, rec["verdict"] in VERDICTS, "verdict",
+             f"one of {sorted(VERDICTS)} required")
+    _require(errors, rec["assurance_tier"] in TIERS, "assurance_tier",
+             f"one of {sorted(TIERS)} required")
+    for name in ("acceptor_id", "worker_id", "operator_ref", "reason",
+                 "mission_id"):
+        _require(errors, isinstance(rec[name], str) and rec[name],
+                 name, "non-empty string required")
+    _require(errors, _str_list(rec["receipt_refs"]), "receipt_refs",
+             "list of receipt id strings required")
+    _require(errors, is_iso_utc(rec["utc"]), "utc", "ISO-8601 Z required")
+    if not errors:
+        _require(errors, rec["acceptor_id"] != rec["worker_id"],
+                 "acceptor_id", "self-certification refused (== worker_id)")
+        if rec["assurance_tier"] == "operator-accepted":
+            _require(errors, rec["acceptor_id"] == rec["operator_ref"],
+                     "acceptor_id",
+                     "operator-accepted tier requires acceptor_id == operator_ref")
+    return errors
+```
+
+- [ ] **Step 4: Schema docs**
+
+`receipt.schema.json` and `acceptance-verdict.schema.json` in the Task 1 Step 5 style (`additionalProperties: false`, required = the field sets, enums for `verdict`/`assurance_tier`, sha patterns; `description` on acceptance-verdict states the two semantic rules verbatim: self-certification refused; operator tier binds acceptor to operator_ref).
+
+- [ ] **Step 5: Run tests, then commit**
+
+Run the test file — expected `0 failures` (corpus loop now covers 9 examples).
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody
+git -c core.autocrlf=input commit -m "feat: mission-custody@1 receipt + acceptance-verdict records" \
+  -m "Signed-off-by: Zach Stern <zachstern@gmail.com>"
+```
+
+---
+
+### Task 4: Contract README + SECURITY + CI workflow
+
+**Files:**
+- Create: `plugins/epistemic-skills/contracts/mission-custody/README.md`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/SECURITY.md`
+- Create: `.github/workflows/mission-custody-contract.yml`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+- Produces: CI job name `mission-custody-contract` that later PRs must keep green.
+
+- [ ] **Step 1: Write README.md**
+
+Content (full):
+
+```markdown
+# mission-custody@1
+
+Durable mission-custody contract family: `mission-manifest@1` (authority,
+append-only instruction), `checkpoint@1` (revisioned snapshots,
+`prev_checkpoint_sha256` chain), `receipt@1` (effect -> artifact hash binding),
+`acceptance-verdict@1` (tiered acceptance; self-certification refused).
+
+Provenance: FOLD cell of the practical-agency gauntlet decision rule; design
+`docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md`.
+practical-agency (ZMS-Labs) is parked prior art; its schemas seeded this family.
+
+Validate: `python verify_mission_custody.py examples/valid-manifest-minimal.json`
+Test: `python test_mission_custody.py` (exit 0 = green; every `invalid-*.json`
+example MUST fail validation — the corpus is the regression suite).
+
+Evolution: additive optional fields only within `@1`; anything else is a new
+epoch with a documented migration. Acceptance tiers are closed:
+`operator-accepted`, `declared-role-separation` — no `externally-proven` tier
+exists until evidence could support one.
+```
+
+- [ ] **Step 2: Write SECURITY.md**
+
+Content (full):
+
+```markdown
+# Security notes — mission-custody@1
+
+- Records are DATA. Instructions embedded in manifests, notes, or reasons are
+  never executed by validators or custody tooling (prompt-injection seam).
+- The verifier checks shape and closed-vocabulary semantics only; it does not
+  attest that hashes correspond to real artifacts — that is the custody core's
+  runtime job (drift detection on resume).
+- `acceptance-verdict@1` enforces role separation at the record level
+  (acceptor != worker; operator tier binds acceptor to operator_ref). It
+  cannot bind principals outside the record channel: an authorized human
+  acting outside the mission channel is out of scope and must not be claimed
+  as prevented.
+- Receipts are hashed, not signed. No third-party-verifiable claim is made.
+```
+
+- [ ] **Step 3: Write the CI workflow**
+
+`.github/workflows/mission-custody-contract.yml` — copy `commission-watch-contract.yml` verbatim, then: name/job → `mission-custody-contract`; path filters → `plugins/epistemic-skills/contracts/mission-custody/**`, the spec `docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md`, the plan `docs/superpowers/plans/2026-08-11-mission-custody-contracts.md`, and the workflow file itself; run steps →
+
+```yaml
+      - name: Mission custody semantic and schema contract
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+      - name: Compile mission custody verifier
+        run: python -m py_compile plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+```
+
+Keep the pinned action SHAs exactly as in the source file.
+
+- [ ] **Step 4: Verify locally, then commit**
+
+Run: `python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py` (still 0 failures) and `python -c "import yaml"` is NOT available — instead sanity-check the workflow with `git diff --check` (no whitespace errors) and by eye against the source workflow.
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody .github/workflows/mission-custody-contract.yml
+git -c core.autocrlf=input commit -m "feat: mission-custody@1 docs + CI contract job" \
+  -m "Signed-off-by: Zach Stern <zachstern@gmail.com>"
+```
+
+---
+
+### Task 5: Custody store (`custody_store.py`)
+
+**Files:**
+- Create: `plugins/epistemic-skills/contracts/mission-custody/custody_store.py`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py`
+
+**Interfaces:**
+- Consumes: `validate_record` from `verify_mission_custody` (every write validates first).
+- Produces (exact signatures later tasks use):
+  - `sha256_file(path: Path) -> str`
+  - `sha256_bytes(data: bytes) -> str`
+  - `atomic_write_json(path: Path, record: dict) -> str` — mkstemp + fsync + `os.replace`; returns sha256 of written bytes; raises `StoreError` on invalid record.
+  - `class MissionStore(mission_dir: Path)` with: `write_checkpoint(record: dict) -> str` (enforces revision monotonicity + `prev_checkpoint_sha256` == sha of prior checkpoint file; r1 requires prev null), `load_latest() -> tuple[dict, Path]` (verifies the whole chain from r1; raises `ChainBroken`), `write_receipt(record: dict) -> Path` (filename `sha256(request_id.encode()) + ".json"`), `load_receipts() -> list[dict]`, `checkpoint_paths() -> list[Path]`.
+  - Exceptions: `StoreError(Exception)`, `ChainBroken(StoreError)`.
+- Layout produced: `missions/<mission_id>/checkpoints/r%08d.json`, `missions/<mission_id>/receipts/<sha>.json`.
+
+- [ ] **Step 1: Write the failing tests** — full file `test_custody_store.py`:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from custody_store import (  # noqa: E402
+    ChainBroken, MissionStore, StoreError, atomic_write_json, sha256_file,
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def manifest() -> dict:
+    return json.loads(
+        (ROOT / "examples" / "valid-manifest-minimal.json").read_text(
+            encoding="utf-8"))
+
+
+def checkpoint(rev: int, prev: str | None, status: str = "draft") -> dict:
+    return {
+        "record": "checkpoint@1",
+        "mission_id": "tracer-media-missing",
+        "revision": rev,
+        "status": status,
+        "prev_checkpoint_sha256": prev,
+        "manifest": manifest(),
+        "state": {"frontier": "f", "notes": [], "unresolved_verdicts": []},
+        "receipt_ids": [],
+        "written_utc": "2026-08-11T00:00:01Z",
+        "written_by": "agent:worker",
+    }
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        mdir = Path(td) / "missions" / "tracer-media-missing"
+        store = MissionStore(mdir)
+
+        # invalid record refused before touching disk
+        try:
+            store.write_checkpoint({"record": "checkpoint@1"})
+            check("store-refuses-invalid", False)
+        except StoreError:
+            check("store-refuses-invalid", True)
+
+        sha1 = store.write_checkpoint(checkpoint(1, None))
+        check("r1-written", (mdir / "checkpoints" / "r00000001.json").exists())
+
+        # r2 with wrong prev refused
+        try:
+            store.write_checkpoint(checkpoint(2, "b" * 64, "active"))
+            check("store-refuses-bad-chain", False)
+        except StoreError:
+            check("store-refuses-bad-chain", True)
+
+        store.write_checkpoint(checkpoint(2, sha1, "active"))
+        latest, path = store.load_latest()
+        check("latest-is-r2", latest["revision"] == 2)
+
+        # tamper with r1 on disk -> chain verification must fail
+        p1 = mdir / "checkpoints" / "r00000001.json"
+        p1.write_text(p1.read_text(encoding="utf-8").replace(
+            "await operator approval", "tampered"), encoding="utf-8")
+        try:
+            store.load_latest()
+            check("chain-tamper-detected", False)
+        except ChainBroken:
+            check("chain-tamper-detected", True)
+
+        # receipts round-trip
+        receipt = json.loads((ROOT / "examples" / "valid-receipt.json").read_text(
+            encoding="utf-8"))
+        rp = store.write_receipt(receipt)
+        check("receipt-written", rp.exists())
+        check("receipt-loaded", store.load_receipts() == [receipt])
+
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run to verify failure** — `python .../test_custody_store.py` → `ModuleNotFoundError: custody_store`.
+
+- [ ] **Step 3: Implement `custody_store.py`** — full module:
+
+```python
+#!/usr/bin/env python3
+"""Durable mission store: atomic JSON writes, checkpoint hash chain, receipts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from verify_mission_custody import validate_record
+
+
+class StoreError(Exception):
+    pass
+
+
+class ChainBroken(StoreError):
+    pass
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def atomic_write_json(path: Path, record: dict) -> str:
+    errors = validate_record(record)
+    if errors:
+        raise StoreError(f"invalid record for {path.name}: {errors[:3]}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = (json.dumps(record, indent=1, sort_keys=True) + "\n").encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+    return sha256_bytes(data)
+
+
+class MissionStore:
+    def __init__(self, mission_dir: Path) -> None:
+        self.mission_dir = Path(mission_dir)
+        self.checkpoints_dir = self.mission_dir / "checkpoints"
+        self.receipts_dir = self.mission_dir / "receipts"
+
+    def checkpoint_paths(self) -> list[Path]:
+        if not self.checkpoints_dir.is_dir():
+            return []
+        return sorted(self.checkpoints_dir.glob("r????????.json"))
+
+    def _path_for(self, revision: int) -> Path:
+        return self.checkpoints_dir / f"r{revision:08d}.json"
+
+    def write_checkpoint(self, record: dict) -> str:
+        errors = validate_record(record)
+        if errors:
+            raise StoreError(f"invalid checkpoint: {errors[:3]}")
+        revision = record["revision"]
+        existing = self.checkpoint_paths()
+        expected_rev = len(existing) + 1
+        if revision != expected_rev:
+            raise StoreError(
+                f"revision {revision} out of order; expected {expected_rev}")
+        if revision == 1:
+            if record["prev_checkpoint_sha256"] is not None:
+                raise StoreError("revision 1 must have null prev sha")
+        else:
+            prior_sha = sha256_file(existing[-1])
+            if record["prev_checkpoint_sha256"] != prior_sha:
+                raise StoreError("prev_checkpoint_sha256 does not match prior file")
+        return atomic_write_json(self._path_for(revision), record)
+
+    def load_latest(self) -> tuple[dict, Path]:
+        paths = self.checkpoint_paths()
+        if not paths:
+            raise StoreError(f"no checkpoints under {self.checkpoints_dir}")
+        prev_sha: str | None = None
+        for path in paths:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            errors = validate_record(record)
+            if errors:
+                raise ChainBroken(f"{path.name}: invalid: {errors[:3]}")
+            if record["prev_checkpoint_sha256"] != prev_sha:
+                raise ChainBroken(f"{path.name}: chain mismatch")
+            prev_sha = sha256_file(path)
+        return record, paths[-1]
+
+    def write_receipt(self, record: dict) -> Path:
+        errors = validate_record(record)
+        if errors:
+            raise StoreError(f"invalid receipt: {errors[:3]}")
+        name = sha256_bytes(record["request_id"].encode("utf-8")) + ".json"
+        path = self.receipts_dir / name
+        atomic_write_json(path, record)
+        return path
+
+    def load_receipts(self) -> list[dict]:
+        if not self.receipts_dir.is_dir():
+            return []
+        return [json.loads(p.read_text(encoding="utf-8"))
+                for p in sorted(self.receipts_dir.glob("*.json"))]
+```
+
+- [ ] **Step 4: Run tests** — both `test_custody_store.py` and `test_mission_custody.py` → 0 failures.
+- [ ] **Step 5: Commit** — `feat: custody store with atomic chained checkpoints` (same DCO trailer pattern).
+
+---
+
+### Task 6: Mission lifecycle (`custody_mission.py`)
+
+**Files:**
+- Create: `plugins/epistemic-skills/contracts/mission-custody/custody_mission.py`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py`
+
+**Interfaces:**
+- Consumes: `MissionStore`, `StoreError`, `sha256_bytes`, `sha256_file` (Task 5); `TIERS`, `VERDICTS` (Task 1).
+- Produces (exact API the CLI binds):
+  - `class Mission` — constructor `Mission(store: MissionStore, workspace: Path, actor: str)`; classmethods `Mission.open(workspace, mission_id, instruction, operator_ref, steward_ref, required_tier, actor, scope_in, scope_out, permissions, protected_state) -> Mission` (writes manifest + checkpoint r1 `draft`) and `Mission.load(workspace, actor) -> Mission` (**pathless**: scans `workspace/missions/*/checkpoints/`, requires exactly one mission whose latest status is not in `{"completed","cancelled"}`; zero → `NoActiveMission`, several → `MultipleActiveMissions`).
+  - Methods, each writing the next checkpoint: `approve() -> int` (draft→active; records note "approved"), `record_effect(artifact_relpath: str, content: str, request_id: str) -> dict` (broker write inside workspace: refuses `..` and absolute paths, captures before/after sha, writes artifact + receipt, appends receipt id; returns the receipt), `note(text: str) -> int`, `set_frontier(text: str) -> int`, `resume() -> list[str]` (chain-verify + **drift detection**: for every receipt, live file hash vs `after_sha256`; mismatches → status `reopened`, marker `"RECONCILIATION:<artifact_path>"` appended to `unresolved_verdicts`; returns mismatched paths), `reconcile(artifact_relpath, content, request_id) -> dict` (repair effect; clears that `RECONCILIATION:` marker; if none left and status `reopened` → `active`), `begin_verification() -> int` (active→verifying; refuses if `unresolved_verdicts`), `record_verdict(verdict: str, acceptor_id: str, assurance_tier: str, reason: str) -> int` (validates an `acceptance-verdict@1`; **PASS**: refuses unless status `verifying`, tier meets manifest `required_tier`, acceptor ≠ steward; → `completed`. **FAIL**: appends `"FAIL:<reason>"` marker, → `reopened`. **INCONCLUSIVE**: note only), `clear_fail(reason_fragment: str, receipt_request_id: str) -> int` (**the FAIL-clear path**: requires a receipt written after the FAIL, removes the matching `FAIL:` marker), `cancel(reason) -> int`, `status() -> dict` (latest checkpoint).
+  - Exceptions: `CustodyError(Exception)`, `NoActiveMission(CustodyError)`, `MultipleActiveMissions(CustodyError)`, `IllegalTransition(CustodyError)`, `AcceptanceRefused(CustodyError)`.
+  - Authority invariant enforced everywhere: `manifest.authority.instruction` byte-identical across all checkpoints (amendments append; a changed instruction raises `CustodyError`).
+- Timestamps: module-level `def now_utc() -> str` using `datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")`.
+
+- [ ] **Step 1: Write the failing tests** — `test_custody_mission.py`, same harness pattern (check/FAILURES/main). Required test functions, each with real asserts:
+
+```python
+# All operate in a tempfile.TemporaryDirectory() workspace.
+def test_open_creates_draft_r1(): ...
+    # Mission.open(...) -> status()["revision"] == 1, status "draft",
+    # manifest instruction verbatim.
+def test_pathless_load_single_active(): ...
+    # open + approve, then Mission.load(workspace, actor="agent:second")
+    # finds it WITHOUT being given the mission id.
+def test_load_refuses_zero_and_multiple(): ...
+    # empty workspace -> NoActiveMission; open two missions -> MultipleActiveMissions.
+def test_effect_writes_receipt_and_artifact(): ...
+    # record_effect("notes/a.md", "hello", "req-1"): file exists, receipt
+    # after_sha256 == sha of file bytes, checkpoint receipt_ids contains id.
+def test_effect_refuses_escape(): ...
+    # record_effect("../outside.md", ...) and ("C:/x", ...) raise CustodyError.
+def test_resume_detects_drift_and_reconcile_clears(): ...
+    # effect; overwrite artifact directly on disk; resume() returns the path,
+    # status "reopened", marker "RECONCILIATION:notes/a.md" present;
+    # reconcile("notes/a.md", "hello", "req-2") -> marker gone, status "active".
+def test_instruction_immutable(): ...
+    # tamper latest checkpoint manifest instruction via store internals ->
+    # next operation raises CustodyError.
+def test_accept_requires_verifying_and_separation(): ...
+    # record_verdict PASS while "active" -> IllegalTransition;
+    # begin_verification; PASS with acceptor == steward -> AcceptanceRefused;
+    # PASS with distinct acceptor at required tier -> status "completed".
+def test_fail_is_clearable(): ...          # THE PA-dead-end regression test
+    # begin_verification; record_verdict FAIL -> "reopened" + FAIL marker;
+    # record_effect remediation; clear_fail(...) -> marker gone;
+    # begin_verification; record_verdict PASS (distinct acceptor) -> "completed".
+def test_operator_tier(): ...
+    # manifest required_tier "operator-accepted": PASS at
+    # declared-role-separation -> AcceptanceRefused; PASS with
+    # acceptor_id == operator_ref, tier operator-accepted -> completed.
+```
+
+Write each `...` body out in full in the file (the assertions described in the comments are the required content — an implementer writes them as real code against the Produces API above).
+
+- [ ] **Step 2: Run to verify failure** — `ModuleNotFoundError: custody_mission`.
+- [ ] **Step 3: Implement `custody_mission.py`** against the exact Produces API. Implementation notes an engineer needs: every mutating method (a) loads latest via `store.load_latest()`, (b) verifies the instruction invariant against checkpoint r1, (c) builds the next checkpoint dict (revision+1, `prev_checkpoint_sha256` = sha of latest file via `sha256_file`), (d) `store.write_checkpoint`. `record_verdict` builds and validates a full `acceptance-verdict@1` record with `worker_id = manifest["steward_ref"]` and validates via `validate_record` before applying transition rules; store the verdict record at `missions/<id>/verdicts/<revision>-<verdict>.json` via `atomic_write_json`. Status transitions allowed: draft→active (approve), draft/active/reopened/verifying→cancelled (cancel), active→verifying (begin_verification), verifying→completed (PASS), verifying→reopened (FAIL), reopened→active (last marker cleared via reconcile/clear_fail). Everything else raises `IllegalTransition`.
+- [ ] **Step 4: Run all three test files** — 0 failures; check total line count: `wc -l custody_store.py custody_mission.py` — flag if the two already exceed ~600 (budget for the CLI).
+- [ ] **Step 5: Commit** — `feat: mission lifecycle with drift reanchoring and clearable FAIL`.
+
+---### Task 7: CLI (`custody_cli.py`)
+
+**Files:**
+- Create: `plugins/epistemic-skills/contracts/mission-custody/custody_cli.py`
+- Create: `plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py`
+
+**Interfaces:**
+- Consumes: the full `Mission` API (Task 6).
+- Produces: `python custody_cli.py <command> --workspace W --actor A [...]` with commands and exact flags:
+  - `open --mission-id ID --instruction TEXT --operator REF --steward REF [--tier TIER] [--scope-in X ...] [--scope-out X ...] [--permission X ...] [--protected X ...]`
+  - `approve` · `status` (prints latest checkpoint JSON to stdout) · `note --text T` · `frontier --text T`
+  - `effect --path REL --content TEXT --request-id ID`
+  - `resume` (prints drift list; exit 3 when drift found — a *visible*, non-zero signal)
+  - `reconcile --path REL --content TEXT --request-id ID`
+  - `verify` · `accept --verdict V --acceptor REF --tier TIER --reason TEXT`
+  - `clear-fail --match FRAGMENT --request-id ID` · `cancel --reason TEXT`
+  - Exit codes: 0 success · 2 usage/refusal (`CustodyError` subclasses print the exception class name + message to stderr) · 3 drift detected on resume.
+  - **No `--mission-path` or `--mission-id` on any command except `open`** — discovery is pathless by contract (the argparse test asserts their absence).
+- [ ] **Step 1: Failing tests** — `test_custody_cli.py` drives the CLI via `subprocess.run([sys.executable, "custody_cli.py", ...])` in a temp workspace: open→approve→effect→status round-trip (parse stdout JSON, assert revision/status); drift scenario asserting exit code 3; `accept` self-cert asserting exit 2 + `AcceptanceRefused` on stderr; an AST test (`ast.parse`) walking `custody_cli.py` asserting no argparse argument named `--mission-path` or `--mission-id` outside the `open` subparser.
+- [ ] **Step 2: Run to verify failure.**
+- [ ] **Step 3: Implement** — thin argparse dispatch onto `Mission`; no logic beyond translation; `PYTHONIOENCODING`-safe (ASCII-only output).
+- [ ] **Step 4: Run all four test files** — 0 failures; `wc -l custody_*.py` total must be ≤ ~800.
+- [ ] **Step 5: Commit** — `feat: custody CLI with pathless resume and visible drift exit`.
+
+---
+
+### Task 8: Three-subprocess kill/resume/repair proof
+
+**Files:**
+- Create: `plugins/epistemic-skills/contracts/mission-custody/test_custody_process_proof.py`
+
+**Interfaces:**
+- Consumes: `custody_cli.py` only (black-box through subprocesses — that is the point).
+- Produces: the executable continuity proof CI runs.
+
+- [ ] **Step 1: Write the proof test** (this task is test-only; it must pass against Task 7's code — if it fails, the defect is in Tasks 5–7 and is fixed there). Full scenario, mirroring the fold-spike runner:
+  1. **Process A** (`subprocess.Popen`): `open` + `approve` + `effect notes/proof.md "state-1" req-a1` + a `frontier` write, then **`proc.kill()`** immediately after the CLI process for `frontier` returns (each CLI call is its own process; "kill" here = kill a still-running `effect` invocation launched with a `--content` large enough to observe, OR simpler and deterministic: run `effect` to completion, then kill a deliberately-hung fourth invocation started with an interposed `python -c` wrapper that sleeps after import — assert the wrapper died pre-checkpoint and the store shows no partial file: `checkpoints/` contains no `*.tmp`).
+  2. **Drift plant**: overwrite `notes/proof.md` directly with different bytes.
+  3. **Process B**: `resume` with NO mission id → asserts exit 3 and stderr/stdout names `notes/proof.md`; `status` shows `reopened` + `RECONCILIATION:notes/proof.md`; `reconcile` repairs; `status` shows `active`.
+  4. **Process C**: `verify`, then `accept --verdict PASS --acceptor agent:worker ...` (same as steward) → exit 2 `AcceptanceRefused`; `accept --verdict FAIL --acceptor agent:acceptor-2 --tier declared-role-separation --reason "missing section"` → `reopened`; `effect` remediation + `clear-fail` + `verify` + `accept --verdict PASS --acceptor agent:acceptor-2 ...` → final `status` `completed`, revision ≥ 10, instruction byte-identical to r1's.
+  5. Independent re-verification from disk: recompute the full checkpoint sha chain in the test process; assert no `.tmp` files anywhere under `missions/`.
+- [ ] **Step 2: Run it** — `python .../test_custody_process_proof.py` → 0 failures. Fix any defect in the module that owns it (with its own unit test first), never by weakening the proof.
+- [ ] **Step 3: Add the proof + the three unit test files to the CI workflow** (four new `run:` lines in `mission-custody-contract.yml`).
+- [ ] **Step 4: Commit** — `test: three-subprocess kill/resume/repair continuity proof`.
+
+---
+
+### Task 9: The `manifest` skill (Claude Code binding)
+
+**Files:**
+- Create: `plugins/epistemic-skills/skills/manifest/SKILL.md`
+- Modify: `plugins/epistemic-skills/contracts/mission-custody/README.md` (append a "Harness bindings" section naming the skill)
+
+**Interfaces:**
+- Consumes: the CLI contract (Task 7 flags, exit codes).
+- Produces: the operator-facing skill.
+
+- [ ] **Step 1: Byte-budget gate (HARD GATE — do not proceed without it).** Present to the operator: the exact skill description below (count its bytes), the measured risk (2026-08-06: installs silently blanked four descriptions), and ask for explicit sign-off to spend the bytes. Record the sign-off verbatim in the task notes / PR description. If declined: stop this task; Tasks 1–8 still merge.
+
+- [ ] **Step 2: Write SKILL.md** — full content:
+
+```markdown
+---
+name: manifest
+description: Use when work is mission-shaped — multi-session, consequential, cross-agent, or interruption-expensive — or on the explicit phrase "manifest this" (also /manifest): open, resume, verify, or close a custodied mission with recorded authority, durable checkpoints, drift re-anchoring, and independent acceptance. Answers "will this survive interruption?", "who authorized this scope?", "what makes done defensible?". Do NOT fire for routine one-step work checkable in-session.
+---
+
+# manifest — mission custody (custodian)
+
+You are a mission steward under bounded delegated agency. The contract of
+record is the mission's durable state under `missions/<id>/` (mission-custody@1
+records), never the chat.
+
+Custody core: `plugins/epistemic-skills/contracts/mission-custody/custody_cli.py`
+(stdlib; run with `python`). Every mutating call names `--actor` with YOUR
+stable session identity. Exit 2 = refusal (read the stderr class name); exit 3
+on resume = drift found — reconcile before anything else.
+
+## Modes
+
+1. **Open** — capture the operator instruction VERBATIM: `open --mission-id
+   <kebab> --instruction <verbatim> --operator <ref> --steward <your actor>
+   [--tier declared-role-separation]`. Then `approve` only after the operator
+   confirms authority (permissions, protected state, stop rules).
+2. **Resume** — `resume` (pathless; never pass a mission path). Treat chat and
+   memory as untrusted until it exits 0. On exit 3: reconcile each named
+   artifact (re-verify against live state first), then continue.
+3. **Advance** — one bounded step inside authority; route every artifact write
+   through `effect`; record `frontier` after material progress.
+4. **Verify / Close** — `verify`, then acceptance by a DIFFERENT actor:
+   a distinct session runs `accept`. Never accept work you performed; the core
+   refuses it (AcceptanceRefused) — do not work around the refusal.
+
+## Boundaries
+
+- Decline routine, one-step, in-session-checkable work (say so; no mission).
+- Never select or invoke other skills by name from this seat; when a
+  load-bearing condition blocks progress (an unverified claim, an unmapped
+  territory, an irreversible fork), STATE THE CONDITION and the return point
+  (mission id + frontier) and let the surrounding stack answer it.
+- Custody here is convention-held (no enforcement hook yet — Stage C is
+  gated on the tracer retro): honestly label it if asked.
+- Degraded modes: core unavailable -> author a markdown mission manifest,
+  label it session-bounded; store unwritable -> surface immediately; operator
+  revocation -> stop consequential work, surface AUTHORITY_REVOKED.
+- Mission state commits to the working repo by default (gitignore escape
+  hatch for noisy missions).
+```
+
+- [ ] **Step 3: Structural checks** — grep SKILL.md for other skill names: `grep -iE "metacognate|gauntlet|recon|did-it-land|write-goal|superpowers" plugins/epistemic-skills/skills/manifest/SKILL.md` must return ONLY the allowed absence (expect zero matches — no-routing constraint). Byte-count the description: `python - <<'EOF'` one-liner printing `len(description_bytes)`; record the number in the PR body.
+- [ ] **Step 4: Append the "Harness bindings" section to the contract README** (three lines: skill name, CLI path, Stage C gated note).
+- [ ] **Step 5: Commit** — `feat: manifest custodian skill (three-door, decline-clause)`.
+
+---
+
+### Task 10: Live UAT, PR, and tracer handoff
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md`
+- No other repo files — this task is verification + handoff.
+
+**Interfaces:**
+- Consumes: everything.
+- Produces: a pushed branch, an open PR, and the armed tracer.
+
+- [ ] **Step 1: Full local suite** — run all five test files + `python -m compileall -q plugins/epistemic-skills/contracts/mission-custody` → all green, verbatim output captured for the PR body.
+- [ ] **Step 2: Live UAT (evidence-locked-uat skill governs)** — in a scratch workspace, drive one real mission through the skill text's exact commands from a live session: open→approve→effect→kill session→fresh session resume (pathless)→plant drift→reconcile→verify→accept from a second session identity. Save the transcript + exit codes as the UAT packet under the scratch workspace; reference it (path + sha) in the PR body. This is Stage B's oracle-adequate check: the skill's documented commands, not the test suite, are what the UAT exercises.
+- [ ] **Step 3: Write the tracer retro template** — headings: Mission id · Sessions (count, dates) · Interruptions survived (what died, what resumed) · Drift events (detected? honest?) · Acceptance (tier, actor separation real?) · **Did custody change the outcome?** (the adoption falsifier, answered plainly) · Stage C decision input (build teeth / stay convention-held / park).
+- [ ] **Step 4: Push + PR (operator-gated)** — `git push -u origin spec/mission-custody-contracts-design`; open a PR titled `feat: mission-custody@1 contracts + custody core + manifest skill` whose body carries: spec+plan links, test output, UAT packet ref, byte-budget sign-off quote, the Stage C gate statement, and the practical-agency provenance paragraph from the spec. **Ask the operator before pushing** if this session hasn't already been told to.
+- [ ] **Step 5: Arm the tracer** — with the operator, pin the exact tracer mission id (default candidate: the monitored-missing reconciliation arc), open it via `/manifest` in the target repo, and schedule the retro against the template. Stage C is decided by that retro, not by this plan.
+
+---
+
+## Self-review (performed at write time)
+
+- **Spec coverage:** contracts §→Tasks 1–4 · core §→Tasks 5–7 (incl. FAIL-clearable, pathless discovery, drift, acceptance tiers) · proof→Task 8 · skill three-doors/decline/no-routing→Task 9 · degraded modes→SKILL.md Boundaries + store/CLI refusals · testing & success criterion→Tasks 8/10 · non-goals: no ECS wiring, no Codex port, no signing, no second skill — absent everywhere by construction. Stage C: explicitly out of scope (Tasks 9 Step 2 label + Task 10 retro gate).
+- **Placeholders:** Task 6 Step 1 lists test bodies as specified assertions with a written instruction to expand — intentional (the Produces API fully determines them); no TBD/TODO remains.
+- **Type consistency:** `validate_record`/`MissionStore`/`Mission`/CLI flag names cross-checked across tasks; state list and tier vocabulary identical in Tasks 1, 6, 9.

--- a/docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md
+++ b/docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md
@@ -1,0 +1,42 @@
+# Mission-custody tracer retro — template
+
+Fill after the tracer mission closes (or aborts). This retro — not the build — decides Stage C (enforcement hooks) per `2026-08-11-mission-custody-contracts-design.md`.
+
+## Mission
+
+- **Mission id:**
+- **Repo / workspace:**
+- **Opened / closed dates:**
+- **Final status (from last checkpoint, not memory):**
+
+## Sessions
+
+- **Count and dates:**
+- **Actors (steward, other workers, acceptor):**
+
+## Interruptions survived
+
+- What died (session/process), at which revision, and what resumed:
+- Did pathless resume find the mission without being told where it was?
+
+## Drift events
+
+- Drift detected? (resume exit 3 occurrences, artifacts named):
+- Was every drift honest — recorded reopen before repair, no silent continue?
+
+## Acceptance
+
+- Tier used; acceptor identity; was the role separation real (different session, not a relabel)?
+- Any refusals (exit 2) and were they correct?
+
+## The adoption falsifier — answered plainly
+
+**Did custody change the outcome?** (What would have been lost, redone, or wrongly claimed done without it? If the honest answer is "nothing," say so.)
+
+## Stage C decision input
+
+- [ ] Build teeth (PreToolUse enforcement boundary earned)
+- [ ] Stay convention-held (custody useful, enforcement not yet justified)
+- [ ] Park (custody did not change the outcome)
+
+Rationale:

--- a/docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md
+++ b/docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md
@@ -1,0 +1,103 @@
+# Mission custody, contracts-first ("custodian") — design
+
+**Date:** 2026-08-11
+**Status:** operator-approved in-session 2026-08-11 (brainstorming dialogue; approach and all eleven sections approved verbatim)
+**Repo:** epistemic-skills (contract home)
+**Provenance:** This design executes the FOLD cell of the pre-committed demand×vehicle decision rule from the practical-agency gauntlet run (`practical-agency-telos-2026-08-10`, verdict NO-GO on unconditional continuation, hypothesis ruling H-GATE-FIRST + H-FOLD; VEHICLE = fold-feasibility spike PASS; DEMAND = media/content tracer mission named by operator 2026-08-11). Run record: operator archive `zms-homelab/scratch/practical-agency-gauntlet-2026-08-10/` (hash-chain verified). Lineage: helix (banked 2026-07-20) → practical-agency (custody pivot, 2026-08-07) → this design. Related: `2026-08-07-practical-agency-and-commission-watch-design.md`, `contracts/watch-commission/`.
+
+## Purpose
+
+Carry consequential, multi-session, interruption-expensive work as **custodied missions**: recorded authority, durable checkpoints, live-state re-anchoring on resume, and tiered independent acceptance. Ordinary requests are untouched.
+
+Explicitly **not**: a router (no skill selection, ever — the adjudicated anti-helix boundary), a daemon or background actor, a second epistemic verifier, or a replacement for any existing discipline.
+
+## Architecture
+
+Three artifacts, one writable home each:
+
+| Artifact | Home | Form |
+|---|---|---|
+| Contracts | epistemic-skills `contracts/mission-custody/` | `mission-custody@1` schema family + stdlib verifier + examples corpus + CI (the watch-commission@1 apparatus, exactly) |
+| Custody core | epistemic-skills, beside the contracts | small stdlib reference implementation (fold-shim lineage), executable proof of the contracts |
+| Harness bindings | per harness; Claude Code first | thin: one skill + the core CLI; later harnesses bind the same contracts |
+
+practical-agency **parks**: prior-art reference implementation and proof corpus. An ADR (separate artifact, ordered by the gauntlet verdict) records the lineage and disposition. Its debt retirement (PR dispositions, main relabel, r42 reconciliation) is separate verdict-ordered work, not this design.
+
+## Contracts — `mission-custody@1`
+
+Four schemas, harvested and simplified from practical-agency's six:
+
+1. **`mission-manifest`** — operator instruction (verbatim, append-only; amendments append, never rewrite), scope in/out, protected state, acceptable costs, required acceptance tier, stop/hold/escalate rules, steward and acceptor identities.
+2. **`checkpoint`** — full-state snapshot per revision; `prev_checkpoint_sha256` over the prior checkpoint file's raw bytes (externally verifiable chain); mission status from a closed state list (`draft / active / reopened / verifying / completed / cancelled`).
+3. **`receipt`** — binds an effect request to the observed artifact: request id, before/after content hashes, timestamp, actor.
+4. **`acceptance-verdict`** — typed verdict (`PASS / FAIL / INCONCLUSIVE`), acceptor identity, assurance tier, bound mission revision + receipt refs.
+
+Apparatus per schema: JSON Schema + stdlib verifier + valid/invalid examples corpus (every schema has failing examples that fail) + CI job — mirroring `contracts/watch-commission/` file-for-file in kind.
+
+**Evolution rule** (locked from the mission-os gauntlet's P1-DEFER-SCHEMA-RULE lesson): additive optional fields only within `@1` (absent = default), anything else is a new schema epoch with documented migration.
+
+## Custody core (reference implementation)
+
+Stdlib-only, **~500–800 line cap**, fold-shim lineage (`fold-spike/shim.py` proved the size class on first attempt). Behaviors:
+
+- **Pathless discovery**: find the single active mission from a workspace root; zero-or-multiple active missions is a named refusal, not a guess.
+- **Atomic checkpoints**: mkstemp + fsync + `os.replace`; hash-chain verified on every resume.
+- **Drift detection**: receipt/artifact hash mismatch → `ARTIFACT_HASH_MISMATCH` → recorded transition to `reopened`; silent continuation is structurally impossible.
+- **Acceptance enforcement**: `acceptor_id == worker_id` → refusal; below-required-tier acceptance → refusal.
+- **FAIL is clearable** (designed out of practical-agency's surviving branch defect, the reject dead-end): `FAIL` → remediation effect(s) with receipts → re-verification → acceptance is a legal, tested path. A test exists specifically proving a rejected mission can later complete.
+
+Not a server, not a daemon: a CLI invoked per-operation by bindings. The core's test suite is the three-subprocess kill/resume/repair proof (per the spike runner pattern), plus the FAIL-clear path test, plus corpus round-trips.
+
+## Claude Code binding — the custodian skill
+
+One skill, three doors (operator-specified):
+
+1. **Name-invocable**: `/manifest`.
+2. **Description-fired**: mission-shaped work — multi-session, consequential, cross-agent, interruption-expensive — and the explicit phrase "manifest this".
+3. **Metacognate-reachable**: the description speaks metacognate's condition vocabulary ("will this survive interruption?", "who authorized this scope?", "what makes done defensible?") so the gate's unanswerable condition names this discipline. No special wiring; no member inventory anywhere.
+
+Hard **decline clause**: routine, one-step, in-session-checkable work is declined — presence in the ether must never become ceremony.
+
+Mechanics: the skill drives the custody core CLI via Bash. Mission state lives at `missions/<id>/` **in the repo being worked, committed by default** (ADR-171 / TRANSPARENCY-1 alignment; resolves practical-agency's untracked-state collision), with a documented `.gitignore` escape hatch for noisy missions.
+
+**Install gate**: the skill lands only with a description-byte-budget sign-off (measured 2026-08-06: installs can silently blank other skills' descriptions; the budget-owner item from the gauntlet verdict).
+
+## Discipline integration — no-routing preserved
+
+At bound moments (open / resume / verify / close) the custodian emits **conditions and return points** — e.g. "this claim needs a runtime-adequate oracle before checkpoint r7 closes" — never skill names. Selection remains where it lives today: skill descriptions + metacognate's judgment. This keeps P2-NO-PA-ROUTING intact.
+
+## Acceptance — tiered, honest labels
+
+`operator-accepted` (sovereign; always sufficient) > `agent-accepted` with `declared-role-separation` (distinct session/agent that did not do the work; enforced by the core) > self-certified (**refused**). Required tier is declared at mission open; for consequential missions the default **minimum** required tier is `declared-role-separation` (a distinct agent session suffices to close; the operator may always accept, override, or raise the requirement to operator-only at open). No `externally-proven` tier exists until evidence could actually support one — labels never overclaim.
+
+## Enforcement staging
+
+- **Stage A** — contracts + verifier + corpus + CI (this repo).
+- **Stage B** — custody core + Claude Code custodian skill. Custody here is **convention-held and labeled so**: nothing yet prevents an agent bypassing the broker path. This is the deliberate experiment inherited from the fold spike's honest residual.
+- **Stage C** (gated) — enforcement boundary: PreToolUse deny-hook (safety_gate-class) scoped to engaged missions, plus acceptance automation. Built **only if the tracer retro shows custody changed outcomes**. Teeth are earned, not presumed.
+
+## Degraded modes
+
+| Condition | Behavior |
+|---|---|
+| Custody core unavailable | Skill degrades to manifest-as-document: markdown mission manifest still authored, labeled session-bounded; no fabricated persistence |
+| Checkpoint store unwritable | Visible degradation surfaced immediately |
+| Contradiction on resume | Blocked until reconciled; no continuation over unresolved drift |
+| Authority revoked | Consequential progress stops; surfaced immediately |
+
+## Testing and success criterion
+
+- Contracts: corpus CI — every schema has invalid examples that fail verification.
+- Core: three-subprocess kill/resume/repair proof; FAIL-clear path test; corpus round-trips.
+- Binding: evidence-locked UAT on the live skill.
+
+**Success (the adoption falsifier, answered):** the media/content tracer mission (default candidate: the monitored-missing reconciliation arc; exact mission pinned in the implementation plan) custodied end-to-end across **≥3 real sessions**, including **≥1 genuine interruption** and **≥1 drift event**, closed at `declared-role-separation` or higher — followed by a short written retro answering: *did custody change the outcome?* The retro, not the build, decides Stage C.
+
+## Non-goals (v1)
+
+- No routing or stage-to-skill tables (anti-helix boundary holds)
+- No daemon, scheduler, or background actor
+- No ECS wiring (measurement consumers must exist first — gauntlet P4)
+- No Codex port (the parked practical-agency alpha remains prior art)
+- No receipt signing (P3-ordered follow-up if build continues past the tracer)
+- No second public custody skill (open/resume/verify/close are modes of one skill)

--- a/plugins/epistemic-skills/contracts/mission-custody/README.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/README.md
@@ -1,0 +1,19 @@
+# mission-custody@1
+
+Durable mission-custody contract family: `mission-manifest@1` (authority,
+append-only instruction), `checkpoint@1` (revisioned snapshots,
+`prev_checkpoint_sha256` chain), `receipt@1` (effect -> artifact hash binding),
+`acceptance-verdict@1` (tiered acceptance; self-certification refused).
+
+Provenance: FOLD cell of the practical-agency gauntlet decision rule; design
+`docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md`.
+practical-agency (ZMS-Labs) is parked prior art; its schemas seeded this family.
+
+Validate: `python verify_mission_custody.py examples/valid-manifest-minimal.json`
+Test: `python test_mission_custody.py` (exit 0 = green; every `invalid-*.json`
+example MUST fail validation — the corpus is the regression suite).
+
+Evolution: additive optional fields only within `@1`; anything else is a new
+epoch with a documented migration. Acceptance tiers are closed:
+`operator-accepted`, `declared-role-separation` — no `externally-proven` tier
+exists until evidence could support one.

--- a/plugins/epistemic-skills/contracts/mission-custody/README.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/README.md
@@ -17,3 +17,9 @@ Evolution: additive optional fields only within `@1`; anything else is a new
 epoch with a documented migration. Acceptance tiers are closed:
 `operator-accepted`, `declared-role-separation` — no `externally-proven` tier
 exists until evidence could support one.
+
+## Harness bindings
+
+- Skill: `manifest`
+- CLI: `plugins/epistemic-skills/contracts/mission-custody/custody_cli.py`
+- Stage C (enforcement) is gated on the tracer retro.

--- a/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
@@ -1,0 +1,13 @@
+# Security notes — mission-custody@1
+
+- Records are DATA. Instructions embedded in manifests, notes, or reasons are
+  never executed by validators or custody tooling (prompt-injection seam).
+- The verifier checks shape and closed-vocabulary semantics only; it does not
+  attest that hashes correspond to real artifacts — that is the custody core's
+  runtime job (drift detection on resume).
+- `acceptance-verdict@1` enforces role separation at the record level
+  (acceptor != worker; operator tier binds acceptor to operator_ref). It
+  cannot bind principals outside the record channel: an authorized human
+  acting outside the mission channel is out of scope and must not be claimed
+  as prevented.
+- Receipts are hashed, not signed. No third-party-verifiable claim is made.

--- a/plugins/epistemic-skills/contracts/mission-custody/acceptance-verdict.schema.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/acceptance-verdict.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "acceptance-verdict@1",
+  "title": "acceptance-verdict@1",
+  "description": "Acceptance verdict: verified outcome assessment by independent acceptor. Semantic rules (enforced by verifier): (1) acceptor_id must not equal worker_id (self-certification refused); (2) if assurance_tier == 'operator-accepted', then acceptor_id must equal operator_ref. Validation authority: verify_mission_custody.py (stdlib).",
+  "type": "object",
+  "required": ["record", "mission_id", "revision", "verdict", "acceptor_id", "worker_id", "operator_ref", "assurance_tier", "receipt_refs", "reason", "utc"],
+  "additionalProperties": false,
+  "properties": {
+    "record": {"const": "acceptance-verdict@1"},
+    "mission_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "revision": {"type": "integer", "minimum": 1},
+    "verdict": {"enum": ["PASS", "FAIL", "INCONCLUSIVE"]},
+    "acceptor_id": {"type": "string", "minLength": 1},
+    "worker_id": {"type": "string", "minLength": 1},
+    "operator_ref": {"type": "string", "minLength": 1},
+    "assurance_tier": {"enum": ["operator-accepted", "declared-role-separation"]},
+    "receipt_refs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "reason": {"type": "string", "minLength": 1},
+    "utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"}
+  }
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/acceptance-verdict.schema.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/acceptance-verdict.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "acceptance-verdict@1",
   "title": "acceptance-verdict@1",
-  "description": "Acceptance verdict: verified outcome assessment by independent acceptor. Semantic rules (enforced by verifier): (1) acceptor_id must not equal worker_id (self-certification refused); (2) if assurance_tier == 'operator-accepted', then acceptor_id must equal operator_ref. Validation authority: verify_mission_custody.py (stdlib).",
+  "description": "Acceptance verdict: verified outcome assessment by independent acceptor. Semantic rules (enforced by verifier): (1) acceptor_id must not equal worker_id (self-certification refused); (2) if assurance_tier == 'operator-accepted', then acceptor_id must equal operator_ref. receipt_refs may legally be empty ([]) for effect-free missions (e.g. a mission whose lifecycle produced no artifact receipts). Validation authority: verify_mission_custody.py (stdlib).",
   "type": "object",
   "required": ["record", "mission_id", "revision", "verdict", "acceptor_id", "worker_id", "operator_ref", "assurance_tier", "receipt_refs", "reason", "utc"],
   "additionalProperties": false,
@@ -15,7 +15,7 @@
     "worker_id": {"type": "string", "minLength": 1},
     "operator_ref": {"type": "string", "minLength": 1},
     "assurance_tier": {"enum": ["operator-accepted", "declared-role-separation"]},
-    "receipt_refs": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "receipt_refs": {"type": "array", "items": {"type": "string"}},
     "reason": {"type": "string", "minLength": 1},
     "utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"}
   }

--- a/plugins/epistemic-skills/contracts/mission-custody/checkpoint.schema.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/checkpoint.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "checkpoint@1",
+  "title": "checkpoint@1",
+  "description": "Mission checkpoint: versioned record of progress and state. Embeds mission-manifest@1 for immutability; chain rule (r1→null, r≥2→sha256) enforced in verifier. Validation authority: verify_mission_custody.py (stdlib).",
+  "type": "object",
+  "required": ["record", "mission_id", "revision", "status", "prev_checkpoint_sha256", "manifest", "state", "receipt_ids", "written_utc", "written_by"],
+  "additionalProperties": false,
+  "properties": {
+    "record": {"const": "checkpoint@1"},
+    "mission_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "revision": {"type": "integer", "minimum": 1},
+    "status": {"enum": ["draft", "active", "reopened", "verifying", "completed", "cancelled"]},
+    "prev_checkpoint_sha256": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"},
+    "manifest": {
+      "type": "object",
+      "required": ["record", "mission_id", "created_utc", "authority", "scope", "acceptance", "stop_rules", "steward_ref"],
+      "additionalProperties": false,
+      "properties": {
+        "record": {"const": "mission-manifest@1"},
+        "mission_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+        "created_utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"},
+        "authority": {
+          "type": "object",
+          "required": ["operator_ref", "instruction", "amendments", "permissions", "protected_state", "acceptable_costs"],
+          "additionalProperties": false,
+          "properties": {
+            "operator_ref": {"type": "string", "minLength": 1},
+            "instruction": {"type": "string", "minLength": 1},
+            "amendments": {"type": "array", "items": {"type": "object", "required": ["utc", "text"], "additionalProperties": false, "properties": {"utc": {"type": "string"}, "text": {"type": "string", "minLength": 1}}}},
+            "permissions": {"type": "array", "items": {"type": "string"}},
+            "protected_state": {"type": "array", "items": {"type": "string"}},
+            "acceptable_costs": {"type": "array", "items": {"type": "string"}}
+          }
+        },
+        "scope": {"type": "object", "required": ["in", "out"], "additionalProperties": false, "properties": {"in": {"type": "array", "items": {"type": "string"}}, "out": {"type": "array", "items": {"type": "string"}}}},
+        "acceptance": {"type": "object", "required": ["required_tier", "acceptor_ref"], "additionalProperties": false, "properties": {"required_tier": {"enum": ["operator-accepted", "declared-role-separation"]}, "acceptor_ref": {"type": ["string", "null"]}}},
+        "stop_rules": {"type": "object", "required": ["hold_if", "stop_if", "escalate_if"], "additionalProperties": false, "properties": {"hold_if": {"type": "array", "items": {"type": "string"}}, "stop_if": {"type": "array", "items": {"type": "string"}}, "escalate_if": {"type": "array", "items": {"type": "string"}}}},
+        "steward_ref": {"type": "string", "minLength": 1}
+      }
+    },
+    "state": {
+      "type": "object",
+      "required": ["frontier", "notes", "unresolved_verdicts"],
+      "additionalProperties": false,
+      "properties": {
+        "frontier": {"type": "string", "minLength": 1},
+        "notes": {"type": "array", "items": {"type": "string"}},
+        "unresolved_verdicts": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "receipt_ids": {"type": "array", "items": {"type": "string"}},
+    "written_utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"},
+    "written_by": {"type": "string", "minLength": 1}
+  }
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/checkpoint.schema.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/checkpoint.schema.json
@@ -12,33 +12,7 @@
     "revision": {"type": "integer", "minimum": 1},
     "status": {"enum": ["draft", "active", "reopened", "verifying", "completed", "cancelled"]},
     "prev_checkpoint_sha256": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"},
-    "manifest": {
-      "type": "object",
-      "required": ["record", "mission_id", "created_utc", "authority", "scope", "acceptance", "stop_rules", "steward_ref"],
-      "additionalProperties": false,
-      "properties": {
-        "record": {"const": "mission-manifest@1"},
-        "mission_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
-        "created_utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"},
-        "authority": {
-          "type": "object",
-          "required": ["operator_ref", "instruction", "amendments", "permissions", "protected_state", "acceptable_costs"],
-          "additionalProperties": false,
-          "properties": {
-            "operator_ref": {"type": "string", "minLength": 1},
-            "instruction": {"type": "string", "minLength": 1},
-            "amendments": {"type": "array", "items": {"type": "object", "required": ["utc", "text"], "additionalProperties": false, "properties": {"utc": {"type": "string"}, "text": {"type": "string", "minLength": 1}}}},
-            "permissions": {"type": "array", "items": {"type": "string"}},
-            "protected_state": {"type": "array", "items": {"type": "string"}},
-            "acceptable_costs": {"type": "array", "items": {"type": "string"}}
-          }
-        },
-        "scope": {"type": "object", "required": ["in", "out"], "additionalProperties": false, "properties": {"in": {"type": "array", "items": {"type": "string"}}, "out": {"type": "array", "items": {"type": "string"}}}},
-        "acceptance": {"type": "object", "required": ["required_tier", "acceptor_ref"], "additionalProperties": false, "properties": {"required_tier": {"enum": ["operator-accepted", "declared-role-separation"]}, "acceptor_ref": {"type": ["string", "null"]}}},
-        "stop_rules": {"type": "object", "required": ["hold_if", "stop_if", "escalate_if"], "additionalProperties": false, "properties": {"hold_if": {"type": "array", "items": {"type": "string"}}, "stop_if": {"type": "array", "items": {"type": "string"}}, "escalate_if": {"type": "array", "items": {"type": "string"}}}},
-        "steward_ref": {"type": "string", "minLength": 1}
-      }
-    },
+    "manifest": {"$ref": "mission-manifest.schema.json"},
     "state": {
       "type": "object",
       "required": ["frontier", "notes", "unresolved_verdicts"],

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Thin argparse CLI over the Mission lifecycle API (custody_mission.Mission).
+No logic beyond translation: every subcommand parses flags, calls exactly one
+Mission method, and prints exactly what that method returns.
+
+Discovery is pathless by contract: no subcommand other than `open` accepts a
+--mission-path or --mission-id flag. `Mission.load()` finds the single active
+mission under --workspace on every other command.
+
+Exit codes: 0 success; 2 usage/refusal (a CustodyError subclass prints its
+class name + message to stderr); 3 drift detected on `resume`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from custody_mission import CustodyError, Mission
+
+
+def _print_status(checkpoint: dict) -> None:
+    print(json.dumps(checkpoint, indent=2, sort_keys=True, ensure_ascii=True))
+
+
+def _common_parser() -> argparse.ArgumentParser:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--workspace", required=True)
+    common.add_argument("--actor", required=True)
+    return common
+
+
+def build_parser() -> argparse.ArgumentParser:
+    common = _common_parser()
+    parser = argparse.ArgumentParser(prog="custody_cli.py")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_open = sub.add_parser("open", parents=[common])
+    p_open.add_argument("--mission-id", required=True)
+    p_open.add_argument("--instruction", required=True)
+    p_open.add_argument("--operator", required=True)
+    p_open.add_argument("--steward", required=True)
+    p_open.add_argument("--tier", default="declared-role-separation")
+    p_open.add_argument("--scope-in", action="append", default=[])
+    p_open.add_argument("--scope-out", action="append", default=[])
+    p_open.add_argument("--permission", action="append", default=[])
+    p_open.add_argument("--protected", action="append", default=[])
+
+    sub.add_parser("approve", parents=[common])
+    sub.add_parser("status", parents=[common])
+
+    p_note = sub.add_parser("note", parents=[common])
+    p_note.add_argument("--text", required=True)
+
+    p_frontier = sub.add_parser("frontier", parents=[common])
+    p_frontier.add_argument("--text", required=True)
+
+    p_effect = sub.add_parser("effect", parents=[common])
+    p_effect.add_argument("--path", required=True)
+    p_effect.add_argument("--content", required=True)
+    p_effect.add_argument("--request-id", required=True)
+
+    sub.add_parser("resume", parents=[common])
+
+    p_reconcile = sub.add_parser("reconcile", parents=[common])
+    p_reconcile.add_argument("--path", required=True)
+    p_reconcile.add_argument("--content", required=True)
+    p_reconcile.add_argument("--request-id", required=True)
+
+    sub.add_parser("verify", parents=[common])
+
+    p_accept = sub.add_parser("accept", parents=[common])
+    p_accept.add_argument("--verdict", required=True)
+    p_accept.add_argument("--acceptor", required=True)
+    p_accept.add_argument("--tier", required=True)
+    p_accept.add_argument("--reason", required=True)
+
+    p_clear = sub.add_parser("clear-fail", parents=[common])
+    p_clear.add_argument("--match", required=True)
+    p_clear.add_argument("--request-id", required=True)
+
+    p_cancel = sub.add_parser("cancel", parents=[common])
+    p_cancel.add_argument("--reason", required=True)
+
+    return parser
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    workspace = Path(args.workspace)
+
+    if args.command == "open":
+        Mission.open(
+            workspace, mission_id=args.mission_id, instruction=args.instruction,
+            operator_ref=args.operator, steward_ref=args.steward,
+            required_tier=args.tier, actor=args.actor,
+            scope_in=args.scope_in, scope_out=args.scope_out,
+            permissions=args.permission, protected_state=args.protected)
+        return 0
+
+    mission = Mission.load(workspace, actor=args.actor)
+
+    if args.command == "approve":
+        mission.approve()
+    elif args.command == "status":
+        _print_status(mission.status())
+    elif args.command == "note":
+        mission.note(args.text)
+    elif args.command == "frontier":
+        mission.set_frontier(args.text)
+    elif args.command == "effect":
+        mission.record_effect(args.path, args.content, args.request_id)
+    elif args.command == "resume":
+        drift = mission.resume()
+        for relpath in drift:
+            print(relpath)
+        return 3 if drift else 0
+    elif args.command == "reconcile":
+        mission.reconcile(args.path, args.content, args.request_id)
+    elif args.command == "verify":
+        mission.begin_verification()
+    elif args.command == "accept":
+        mission.record_verdict(args.verdict, acceptor_id=args.acceptor,
+                                assurance_tier=args.tier, reason=args.reason)
+    elif args.command == "clear-fail":
+        mission.clear_fail(args.match, args.request_id)
+    elif args.command == "cancel":
+        mission.cancel(args.reason)
+    else:
+        raise AssertionError(f"unhandled command {args.command!r}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return dispatch(args)
+    except CustodyError as exc:
+        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -55,6 +55,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_open.add_argument("--scope-out", action="append", default=[])
     p_open.add_argument("--permission", action="append", default=[])
     p_open.add_argument("--protected", action="append", default=[])
+    p_open.add_argument("--hold-if", action="append", default=[], dest="hold_if")
+    p_open.add_argument("--stop-if", action="append", default=[], dest="stop_if")
+    p_open.add_argument("--escalate-if", action="append", default=[], dest="escalate_if")
+    p_open.add_argument("--cost", action="append", default=[], dest="acceptable_costs")
 
     sub.add_parser("approve", parents=[common])
     sub.add_parser("status", parents=[common])
@@ -104,7 +108,9 @@ def dispatch(args: argparse.Namespace) -> int:
             operator_ref=args.operator, steward_ref=args.steward,
             required_tier=args.tier, actor=args.actor,
             scope_in=args.scope_in, scope_out=args.scope_out,
-            permissions=args.permission, protected_state=args.protected)
+            permissions=args.permission, protected_state=args.protected,
+            hold_if=args.hold_if, stop_if=args.stop_if, escalate_if=args.escalate_if,
+            acceptable_costs=args.acceptable_costs)
         return 0
 
     mission = Mission.load(workspace, actor=args.actor)

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -24,6 +24,15 @@ def _print_status(checkpoint: dict) -> None:
     print(json.dumps(checkpoint, indent=2, sort_keys=True, ensure_ascii=True))
 
 
+def _ascii_safe(text: str) -> str:
+    """Render text as ASCII-only, escaping any non-ASCII characters so a
+    print to stdout/stderr never raises UnicodeEncodeError regardless of
+    PYTHONIOENCODING or the console codepage. Mirrors the ensure_ascii=True
+    guarantee _print_status already gets from json.dumps, for the two
+    output paths that print a raw str instead of a JSON document."""
+    return text.encode("ascii", "backslashreplace").decode("ascii")
+
+
 def _common_parser() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--workspace", required=True)
@@ -113,7 +122,7 @@ def dispatch(args: argparse.Namespace) -> int:
     elif args.command == "resume":
         drift = mission.resume()
         for relpath in drift:
-            print(relpath)
+            print(_ascii_safe(relpath))
         return 3 if drift else 0
     elif args.command == "reconcile":
         mission.reconcile(args.path, args.content, args.request_id)
@@ -137,7 +146,7 @@ def main(argv: list[str]) -> int:
     try:
         return dispatch(args)
     except CustodyError as exc:
-        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
+        print(_ascii_safe(f"{type(exc).__name__}: {exc}"), file=sys.stderr)
         return 2
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Mission lifecycle: draft -> active -> verifying -> completed, with drift
+reanchoring on resume and a clearable FAIL path (no PA reject dead-end)."""
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from custody_store import (
+    MissionStore, StoreError, atomic_write_json, sha256_bytes, sha256_file,
+)
+from verify_mission_custody import TIERS, VERDICTS, validate_record
+
+_OPEN_STATES = {"draft", "active", "reopened", "verifying"}
+_EFFECT_STATES = {"draft", "active", "reopened"}
+_TIER_RANK = {"declared-role-separation": 1, "operator-accepted": 2}
+assert set(_TIER_RANK) == TIERS, "tier rank table out of sync with verify_mission_custody.TIERS"
+
+_ABS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _tier_meets(actual: str, required: str) -> bool:
+    return _TIER_RANK[actual] >= _TIER_RANK[required]
+
+
+class CustodyError(Exception):
+    pass
+
+
+class NoActiveMission(CustodyError):
+    pass
+
+
+class MultipleActiveMissions(CustodyError):
+    pass
+
+
+class IllegalTransition(CustodyError):
+    pass
+
+
+class AcceptanceRefused(CustodyError):
+    pass
+
+
+class Mission:
+    def __init__(self, store: MissionStore, workspace: Path, actor: str) -> None:
+        self.store = store
+        self.workspace = Path(workspace)
+        self.actor = actor
+
+    # -- construction -----------------------------------------------------
+
+    @classmethod
+    def open(cls, workspace: Path, mission_id: str, instruction: str,
+              operator_ref: str, steward_ref: str,
+              required_tier: str = "declared-role-separation", *, actor: str,
+              scope_in: list[str] | None = None, scope_out: list[str] | None = None,
+              permissions: list[str] | None = None,
+              protected_state: list[str] | None = None) -> "Mission":
+        workspace = Path(workspace)
+        store = MissionStore(workspace / "missions" / mission_id)
+        created = now_utc()
+        manifest = {
+            "record": "mission-manifest@1",
+            "mission_id": mission_id,
+            "created_utc": created,
+            "authority": {
+                "operator_ref": operator_ref,
+                "instruction": instruction,
+                "amendments": [],
+                "permissions": list(permissions or []),
+                "protected_state": list(protected_state or []),
+                "acceptable_costs": [],
+            },
+            "scope": {"in": list(scope_in or []), "out": list(scope_out or [])},
+            "acceptance": {"required_tier": required_tier, "acceptor_ref": None},
+            "stop_rules": {"hold_if": [], "stop_if": [], "escalate_if": []},
+            "steward_ref": steward_ref,
+        }
+        checkpoint = {
+            "record": "checkpoint@1",
+            "mission_id": mission_id,
+            "revision": 1,
+            "status": "draft",
+            "prev_checkpoint_sha256": None,
+            "manifest": manifest,
+            "state": {
+                "frontier": "await operator approval",
+                "notes": [],
+                "unresolved_verdicts": [],
+            },
+            "receipt_ids": [],
+            "written_utc": created,
+            "written_by": actor,
+        }
+        store.write_checkpoint(checkpoint)
+        return cls(store, workspace, actor)
+
+    @classmethod
+    def load(cls, workspace: Path, actor: str) -> "Mission":
+        workspace = Path(workspace)
+        missions_root = workspace / "missions"
+        active: list[Path] = []
+        if missions_root.is_dir():
+            for mission_dir in sorted(missions_root.iterdir()):
+                if not mission_dir.is_dir():
+                    continue
+                store = MissionStore(mission_dir)
+                if not store.checkpoint_paths():
+                    continue
+                try:
+                    latest, _ = store.load_latest()
+                except StoreError:
+                    continue
+                if latest["status"] not in ("completed", "cancelled"):
+                    active.append(mission_dir)
+        if not active:
+            raise NoActiveMission(f"no active mission under {missions_root}")
+        if len(active) > 1:
+            names = ", ".join(p.name for p in active)
+            raise MultipleActiveMissions(f"multiple active missions: {names}")
+        return cls(MissionStore(active[0]), workspace, actor)
+
+    # -- internal helpers ---------------------------------------------------
+
+    def _verify_instruction(self, latest: dict) -> None:
+        origin_path = self.store.checkpoint_paths()[0]
+        origin = json.loads(origin_path.read_text(encoding="utf-8"))
+        origin_instruction = origin["manifest"]["authority"]["instruction"]
+        latest_instruction = latest["manifest"]["authority"]["instruction"]
+        if origin_instruction != latest_instruction:
+            raise CustodyError(
+                "authority.instruction changed since mission open (tampered)")
+
+    def _write_next(self, latest: dict, latest_path: Path, *, status: str,
+                     note: str | None = None, frontier: str | None = None,
+                     add_receipt_id: str | None = None,
+                     unresolved_verdicts: list[str] | None = None) -> dict:
+        notes = list(latest["state"]["notes"])
+        if note is not None:
+            notes.append(note)
+        state = {
+            "frontier": frontier if frontier is not None else latest["state"]["frontier"],
+            "notes": notes,
+            "unresolved_verdicts": (
+                list(unresolved_verdicts) if unresolved_verdicts is not None
+                else list(latest["state"]["unresolved_verdicts"])),
+        }
+        receipt_ids = list(latest["receipt_ids"])
+        if add_receipt_id is not None:
+            receipt_ids.append(add_receipt_id)
+        checkpoint = {
+            "record": "checkpoint@1",
+            "mission_id": latest["mission_id"],
+            "revision": latest["revision"] + 1,
+            "status": status,
+            "prev_checkpoint_sha256": sha256_file(latest_path),
+            "manifest": latest["manifest"],
+            "state": state,
+            "receipt_ids": receipt_ids,
+            "written_utc": now_utc(),
+            "written_by": self.actor,
+        }
+        self.store.write_checkpoint(checkpoint)
+        return checkpoint
+
+    def _resolve_artifact_path(self, relpath: str) -> Path:
+        if not isinstance(relpath, str) or not relpath:
+            raise CustodyError(f"invalid artifact path: {relpath!r}")
+        norm = relpath.replace("\\", "/")
+        if norm.startswith("/") or _ABS_DRIVE_RE.match(norm):
+            raise CustodyError(f"artifact path must be workspace-relative: {relpath!r}")
+        if any(part == ".." for part in norm.split("/")):
+            raise CustodyError(f"artifact path escapes workspace: {relpath!r}")
+        workspace_resolved = self.workspace.resolve()
+        target = (self.workspace / norm).resolve()
+        try:
+            target.relative_to(workspace_resolved)
+        except ValueError:
+            raise CustodyError(f"artifact path escapes workspace: {relpath!r}") from None
+        return target
+
+    def _write_effect(self, latest: dict, artifact_relpath: str, content: str,
+                       request_id: str) -> dict:
+        target = self._resolve_artifact_path(artifact_relpath)
+        before_sha = sha256_file(target) if target.exists() else None
+        data = content.encode("utf-8")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+        receipt = {
+            "record": "receipt@1",
+            "mission_id": latest["mission_id"],
+            "request_id": request_id,
+            "actor": self.actor,
+            "utc": now_utc(),
+            "artifact_path": artifact_relpath.replace("\\", "/"),
+            "before_sha256": before_sha,
+            "after_sha256": sha256_bytes(data),
+        }
+        self.store.write_receipt(receipt)
+        return receipt
+
+    def _load_receipt(self, request_id: str) -> dict | None:
+        name = sha256_bytes(request_id.encode("utf-8")) + ".json"
+        path = self.store.receipts_dir / name
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _find_verdict_record(self, verdict: str, reason: str) -> dict | None:
+        verdicts_dir = self.store.mission_dir / "verdicts"
+        if not verdicts_dir.is_dir():
+            return None
+        matches = []
+        for p in verdicts_dir.glob(f"*-{verdict}.json"):
+            rec = json.loads(p.read_text(encoding="utf-8"))
+            if rec.get("reason") == reason:
+                matches.append(rec)
+        if not matches:
+            return None
+        matches.sort(key=lambda r: r["revision"])
+        return matches[-1]
+
+    def _store_verdict(self, revision: int, verdict: str, record: dict) -> None:
+        path = self.store.mission_dir / "verdicts" / f"{revision}-{verdict}.json"
+        atomic_write_json(path, record)
+
+    # -- mutating lifecycle operations ---------------------------------------
+
+    def approve(self) -> int:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] != "draft":
+            raise IllegalTransition(
+                f"cannot approve: status is {latest['status']!r}, expected 'draft'")
+        new = self._write_next(latest, path, status="active", note="approved")
+        return new["revision"]
+
+    def record_effect(self, artifact_relpath: str, content: str,
+                       request_id: str) -> dict:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] not in _EFFECT_STATES:
+            raise IllegalTransition(f"cannot record_effect: status is {latest['status']!r}")
+        receipt = self._write_effect(latest, artifact_relpath, content, request_id)
+        self._write_next(latest, path, status=latest["status"], add_receipt_id=request_id,
+                          note=f"effect: {artifact_relpath}")
+        return receipt
+
+    def note(self, text: str) -> int:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] not in _OPEN_STATES:
+            raise IllegalTransition(f"cannot note: status is {latest['status']!r}")
+        new = self._write_next(latest, path, status=latest["status"], note=text)
+        return new["revision"]
+
+    def set_frontier(self, text: str) -> int:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] not in _OPEN_STATES:
+            raise IllegalTransition(f"cannot set_frontier: status is {latest['status']!r}")
+        new = self._write_next(latest, path, status=latest["status"], frontier=text)
+        return new["revision"]
+
+    def resume(self) -> list[str]:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] in ("completed", "cancelled"):
+            raise IllegalTransition(f"cannot resume: status is {latest['status']!r}")
+        latest_by_path: dict[str, dict] = {}
+        for request_id in latest["receipt_ids"]:
+            receipt = self._load_receipt(request_id)
+            if receipt is not None:
+                latest_by_path[receipt["artifact_path"]] = receipt
+        mismatched: list[str] = []
+        for rel, receipt in latest_by_path.items():
+            target = self.workspace / rel
+            actual = sha256_file(target) if target.exists() else None
+            if actual != receipt["after_sha256"]:
+                mismatched.append(rel)
+        if not mismatched:
+            return []
+        mismatched.sort()
+        unresolved = list(latest["state"]["unresolved_verdicts"])
+        for rel in mismatched:
+            marker = f"RECONCILIATION:{rel}"
+            if marker not in unresolved:
+                unresolved.append(marker)
+        self._write_next(latest, path, status="reopened", unresolved_verdicts=unresolved,
+                          note=f"drift detected: {', '.join(mismatched)}")
+        return mismatched
+
+    def reconcile(self, artifact_relpath: str, content: str, request_id: str) -> dict:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] != "reopened":
+            raise IllegalTransition(
+                f"cannot reconcile: status is {latest['status']!r}, expected 'reopened'")
+        norm = artifact_relpath.replace("\\", "/")
+        marker = f"RECONCILIATION:{norm}"
+        unresolved = latest["state"]["unresolved_verdicts"]
+        if marker not in unresolved:
+            raise CustodyError(f"no reconciliation marker for {artifact_relpath!r}")
+        receipt = self._write_effect(latest, artifact_relpath, content, request_id)
+        remaining = [m for m in unresolved if m != marker]
+        next_status = "active" if not remaining else "reopened"
+        self._write_next(latest, path, status=next_status, add_receipt_id=request_id,
+                          unresolved_verdicts=remaining,
+                          note=f"reconciled: {artifact_relpath}")
+        return receipt
+
+    def begin_verification(self) -> int:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] != "active":
+            raise IllegalTransition(
+                f"cannot begin_verification: status is {latest['status']!r}, expected 'active'")
+        if latest["state"]["unresolved_verdicts"]:
+            raise IllegalTransition(
+                "cannot begin_verification: unresolved_verdicts present")
+        new = self._write_next(latest, path, status="verifying", note="verification started")
+        return new["revision"]
+
+    def record_verdict(self, verdict: str, acceptor_id: str, assurance_tier: str,
+                        reason: str) -> int:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if verdict not in VERDICTS:
+            raise CustodyError(f"unknown verdict {verdict!r}")
+        if verdict in ("PASS", "FAIL"):
+            if latest["status"] != "verifying":
+                raise IllegalTransition(
+                    f"cannot record {verdict}: status is {latest['status']!r}, "
+                    "expected 'verifying'")
+        elif latest["status"] not in _OPEN_STATES:
+            raise IllegalTransition(f"cannot record verdict: status is {latest['status']!r}")
+
+        manifest = latest["manifest"]
+        worker_id = manifest["steward_ref"]
+        operator_ref = manifest["authority"]["operator_ref"]
+        new_revision = latest["revision"] + 1
+        verdict_record = {
+            "record": "acceptance-verdict@1",
+            "mission_id": latest["mission_id"],
+            "revision": new_revision,
+            "verdict": verdict,
+            "acceptor_id": acceptor_id,
+            "worker_id": worker_id,
+            "operator_ref": operator_ref,
+            "assurance_tier": assurance_tier,
+            "receipt_refs": list(latest["receipt_ids"]),
+            "reason": reason,
+            "utc": now_utc(),
+        }
+        errors = validate_record(verdict_record)
+        if errors:
+            raise AcceptanceRefused(f"invalid acceptance-verdict: {errors[:3]}")
+
+        if verdict == "PASS":
+            required_tier = manifest["acceptance"]["required_tier"]
+            if not _tier_meets(assurance_tier, required_tier):
+                raise AcceptanceRefused(
+                    f"assurance_tier {assurance_tier!r} does not meet "
+                    f"required {required_tier!r}")
+            self._store_verdict(new_revision, verdict, verdict_record)
+            self._write_next(latest, path, status="completed", note=f"PASS: {reason}")
+        elif verdict == "FAIL":
+            self._store_verdict(new_revision, verdict, verdict_record)
+            unresolved = list(latest["state"]["unresolved_verdicts"]) + [f"FAIL:{reason}"]
+            self._write_next(latest, path, status="reopened", unresolved_verdicts=unresolved,
+                              note=f"FAIL: {reason}")
+        else:  # INCONCLUSIVE
+            self._store_verdict(new_revision, verdict, verdict_record)
+            self._write_next(latest, path, status=latest["status"],
+                              note=f"INCONCLUSIVE: {reason}")
+        return new_revision
+
+    def clear_fail(self, reason_fragment: str, receipt_request_id: str) -> int:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] != "reopened":
+            raise IllegalTransition(
+                f"cannot clear_fail: status is {latest['status']!r}, expected 'reopened'")
+        unresolved = latest["state"]["unresolved_verdicts"]
+        matches = [m for m in unresolved if m.startswith("FAIL:") and reason_fragment in m]
+        if not matches:
+            raise CustodyError(f"no FAIL marker matching {reason_fragment!r}")
+        marker = matches[0]
+        reason = marker[len("FAIL:"):]
+        verdict_rec = self._find_verdict_record("FAIL", reason)
+        if verdict_rec is None:
+            raise CustodyError("originating FAIL verdict record not found")
+        receipt = self._load_receipt(receipt_request_id)
+        if receipt is None:
+            raise CustodyError(f"no receipt found for request_id {receipt_request_id!r}")
+        if receipt["utc"] < verdict_rec["utc"]:
+            raise CustodyError(
+                f"receipt {receipt_request_id!r} predates the FAIL verdict; remediate first")
+        remaining = [m for m in unresolved if m != marker]
+        next_status = "active" if not remaining else "reopened"
+        new = self._write_next(latest, path, status=next_status, unresolved_verdicts=remaining,
+                                note=f"cleared: {marker}")
+        return new["revision"]
+
+    def cancel(self, reason: str) -> int:
+        latest, path = self.store.load_latest()
+        self._verify_instruction(latest)
+        if latest["status"] not in ("draft", "active", "reopened", "verifying"):
+            raise IllegalTransition(f"cannot cancel: status is {latest['status']!r}")
+        new = self._write_next(latest, path, status="cancelled", note=f"cancelled: {reason}")
+        return new["revision"]
+
+    def status(self) -> dict:
+        latest, _ = self.store.load_latest()
+        self._verify_instruction(latest)
+        return latest

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -63,7 +63,10 @@ class Mission:
               required_tier: str = "declared-role-separation", *, actor: str,
               scope_in: list[str] | None = None, scope_out: list[str] | None = None,
               permissions: list[str] | None = None,
-              protected_state: list[str] | None = None) -> "Mission":
+              protected_state: list[str] | None = None,
+              hold_if: list[str] | None = None, stop_if: list[str] | None = None,
+              escalate_if: list[str] | None = None,
+              acceptable_costs: list[str] | None = None) -> "Mission":
         workspace = Path(workspace)
         store = MissionStore(workspace / "missions" / mission_id)
         created = now_utc()
@@ -77,11 +80,15 @@ class Mission:
                 "amendments": [],
                 "permissions": list(permissions or []),
                 "protected_state": list(protected_state or []),
-                "acceptable_costs": [],
+                "acceptable_costs": list(acceptable_costs or []),
             },
             "scope": {"in": list(scope_in or []), "out": list(scope_out or [])},
             "acceptance": {"required_tier": required_tier, "acceptor_ref": None},
-            "stop_rules": {"hold_if": [], "stop_if": [], "escalate_if": []},
+            "stop_rules": {
+                "hold_if": list(hold_if or []),
+                "stop_if": list(stop_if or []),
+                "escalate_if": list(escalate_if or []),
+            },
             "steward_ref": steward_ref,
         }
         checkpoint = {

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Durable mission store: atomic JSON writes, checkpoint hash chain, receipts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from verify_mission_custody import validate_record
+
+
+class StoreError(Exception):
+    pass
+
+
+class ChainBroken(StoreError):
+    pass
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def atomic_write_json(path: Path, record: dict) -> str:
+    errors = validate_record(record)
+    if errors:
+        raise StoreError(f"invalid record for {path.name}: {errors[:3]}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = (json.dumps(record, indent=1, sort_keys=True) + "\n").encode("utf-8")
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+    return sha256_bytes(data)
+
+
+class MissionStore:
+    def __init__(self, mission_dir: Path) -> None:
+        self.mission_dir = Path(mission_dir)
+        self.checkpoints_dir = self.mission_dir / "checkpoints"
+        self.receipts_dir = self.mission_dir / "receipts"
+
+    def checkpoint_paths(self) -> list[Path]:
+        if not self.checkpoints_dir.is_dir():
+            return []
+        return sorted(self.checkpoints_dir.glob("r????????.json"))
+
+    def _path_for(self, revision: int) -> Path:
+        return self.checkpoints_dir / f"r{revision:08d}.json"
+
+    def write_checkpoint(self, record: dict) -> str:
+        errors = validate_record(record)
+        if errors:
+            raise StoreError(f"invalid checkpoint: {errors[:3]}")
+        revision = record["revision"]
+        existing = self.checkpoint_paths()
+        expected_rev = len(existing) + 1
+        if revision != expected_rev:
+            raise StoreError(
+                f"revision {revision} out of order; expected {expected_rev}")
+        if revision == 1:
+            if record["prev_checkpoint_sha256"] is not None:
+                raise StoreError("revision 1 must have null prev sha")
+        else:
+            prior_sha = sha256_file(existing[-1])
+            if record["prev_checkpoint_sha256"] != prior_sha:
+                raise StoreError("prev_checkpoint_sha256 does not match prior file")
+        return atomic_write_json(self._path_for(revision), record)
+
+    def load_latest(self) -> tuple[dict, Path]:
+        paths = self.checkpoint_paths()
+        if not paths:
+            raise StoreError(f"no checkpoints under {self.checkpoints_dir}")
+        prev_sha: str | None = None
+        for path in paths:
+            record = json.loads(path.read_text(encoding="utf-8"))
+            errors = validate_record(record)
+            if errors:
+                raise ChainBroken(f"{path.name}: invalid: {errors[:3]}")
+            if record["prev_checkpoint_sha256"] != prev_sha:
+                raise ChainBroken(f"{path.name}: chain mismatch")
+            prev_sha = sha256_file(path)
+        return record, paths[-1]
+
+    def write_receipt(self, record: dict) -> Path:
+        errors = validate_record(record)
+        if errors:
+            raise StoreError(f"invalid receipt: {errors[:3]}")
+        name = sha256_bytes(record["request_id"].encode("utf-8")) + ".json"
+        path = self.receipts_dir / name
+        atomic_write_json(path, record)
+        return path
+
+    def load_receipts(self) -> list[dict]:
+        if not self.receipts_dir.is_dir():
+            return []
+        return [json.loads(p.read_text(encoding="utf-8"))
+                for p in sorted(self.receipts_dir.glob("*.json"))]

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
@@ -101,6 +101,9 @@ class MissionStore:
             raise StoreError(f"invalid receipt: {errors[:3]}")
         name = sha256_bytes(record["request_id"].encode("utf-8")) + ".json"
         path = self.receipts_dir / name
+        if path.exists():
+            raise StoreError(
+                f"receipt already exists for request_id {record['request_id']!r}")
         atomic_write_json(path, record)
         return path
 

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-checkpoint-bad-status.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-checkpoint-bad-status.json
@@ -1,0 +1,16 @@
+{
+  "record": "checkpoint@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 1,
+  "status": "paused",
+  "prev_checkpoint_sha256": null,
+  "manifest": { "record": "mission-manifest@1", "mission_id": "tracer-media-missing", "created_utc": "2026-08-11T00:00:00Z", "authority": { "operator_ref": "operator:zach-stern", "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.", "amendments": [], "permissions": ["repo:vanta:read", "repo:vanta:write-config"], "protected_state": ["download-clients:enabled-state"], "acceptable_costs": ["one working session per stage"] }, "scope": {"in": ["monitored-missing reconciliation"], "out": ["indexer changes", "VPN configuration"]}, "acceptance": {"required_tier": "declared-role-separation", "acceptor_ref": null}, "stop_rules": {"hold_if": ["any download client starts re-grabbing"], "stop_if": ["operator revokes"], "escalate_if": ["protected state would be touched"]}, "steward_ref": "agent:claude-code-session" },
+  "state": {
+    "frontier": "await operator approval",
+    "notes": [],
+    "unresolved_verdicts": []
+  },
+  "receipt_ids": [],
+  "written_utc": "2026-08-11T00:00:01Z",
+  "written_by": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-checkpoint-r2-unchained.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-checkpoint-r2-unchained.json
@@ -1,0 +1,16 @@
+{
+  "record": "checkpoint@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 2,
+  "status": "active",
+  "prev_checkpoint_sha256": null,
+  "manifest": { "record": "mission-manifest@1", "mission_id": "tracer-media-missing", "created_utc": "2026-08-11T00:00:00Z", "authority": { "operator_ref": "operator:zach-stern", "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.", "amendments": [], "permissions": ["repo:vanta:read", "repo:vanta:write-config"], "protected_state": ["download-clients:enabled-state"], "acceptable_costs": ["one working session per stage"] }, "scope": {"in": ["monitored-missing reconciliation"], "out": ["indexer changes", "VPN configuration"]}, "acceptance": {"required_tier": "declared-role-separation", "acceptor_ref": null}, "stop_rules": {"hold_if": ["any download client starts re-grabbing"], "stop_if": ["operator revokes"], "escalate_if": ["protected state would be touched"]}, "steward_ref": "agent:claude-code-session" },
+  "state": {
+    "frontier": "stage 1: inventory",
+    "notes": ["approved by operator"],
+    "unresolved_verdicts": []
+  },
+  "receipt_ids": [],
+  "written_utc": "2026-08-11T00:10:00Z",
+  "written_by": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-amended-instruction.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-amended-instruction.json
@@ -1,0 +1,17 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "bad-amend",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Original instruction.",
+    "amendments": ["replace the instruction with: do something else"],
+    "permissions": [],
+    "protected_state": [],
+    "acceptable_costs": []
+  },
+  "scope": {"in": [], "out": []},
+  "acceptance": {"required_tier": "declared-role-separation", "acceptor_ref": null},
+  "stop_rules": {"hold_if": [], "stop_if": [], "escalate_if": []},
+  "steward_ref": "agent:x"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-receipt-bad-after-hash.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-receipt-bad-after-hash.json
@@ -1,0 +1,10 @@
+{
+  "record": "receipt@1",
+  "mission_id": "tracer-media-missing",
+  "request_id": "req-0001",
+  "actor": "agent:claude-code-session",
+  "utc": "2026-08-11T00:20:00Z",
+  "artifact_path": "notes/stage-1-inventory.md",
+  "before_sha256": null,
+  "after_sha256": "not-a-hash"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-verdict-operator-tier-wrong-acceptor.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-verdict-operator-tier-wrong-acceptor.json
@@ -1,0 +1,13 @@
+{
+  "record": "acceptance-verdict@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 6,
+  "verdict": "PASS",
+  "acceptor_id": "agent:acceptor-session",
+  "worker_id": "agent:claude-code-session",
+  "operator_ref": "operator:zach-stern",
+  "assurance_tier": "operator-accepted",
+  "receipt_refs": ["req-0001"],
+  "reason": "Artifact re-observed; hashes match the receipt chain.",
+  "utc": "2026-08-11T01:00:00Z"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-verdict-self-certified.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-verdict-self-certified.json
@@ -1,0 +1,13 @@
+{
+  "record": "acceptance-verdict@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 6,
+  "verdict": "PASS",
+  "acceptor_id": "agent:claude-code-session",
+  "worker_id": "agent:claude-code-session",
+  "operator_ref": "operator:zach-stern",
+  "assurance_tier": "declared-role-separation",
+  "receipt_refs": ["req-0001"],
+  "reason": "Artifact re-observed; hashes match the receipt chain.",
+  "utc": "2026-08-11T01:00:00Z"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/valid-checkpoint-r1.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/valid-checkpoint-r1.json
@@ -1,0 +1,16 @@
+{
+  "record": "checkpoint@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 1,
+  "status": "draft",
+  "prev_checkpoint_sha256": null,
+  "manifest": { "record": "mission-manifest@1", "mission_id": "tracer-media-missing", "created_utc": "2026-08-11T00:00:00Z", "authority": { "operator_ref": "operator:zach-stern", "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.", "amendments": [], "permissions": ["repo:vanta:read", "repo:vanta:write-config"], "protected_state": ["download-clients:enabled-state"], "acceptable_costs": ["one working session per stage"] }, "scope": {"in": ["monitored-missing reconciliation"], "out": ["indexer changes", "VPN configuration"]}, "acceptance": {"required_tier": "declared-role-separation", "acceptor_ref": null}, "stop_rules": {"hold_if": ["any download client starts re-grabbing"], "stop_if": ["operator revokes"], "escalate_if": ["protected state would be touched"]}, "steward_ref": "agent:claude-code-session" },
+  "state": {
+    "frontier": "await operator approval",
+    "notes": [],
+    "unresolved_verdicts": []
+  },
+  "receipt_ids": [],
+  "written_utc": "2026-08-11T00:00:01Z",
+  "written_by": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/valid-checkpoint-r2-chained.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/valid-checkpoint-r2-chained.json
@@ -1,0 +1,16 @@
+{
+  "record": "checkpoint@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 2,
+  "status": "active",
+  "prev_checkpoint_sha256": "4f2a09c1d8e7b6a5493827160f5e4d3c2b1a09f8e7d6c5b4a392817065f4e3d2",
+  "manifest": { "record": "mission-manifest@1", "mission_id": "tracer-media-missing", "created_utc": "2026-08-11T00:00:00Z", "authority": { "operator_ref": "operator:zach-stern", "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.", "amendments": [], "permissions": ["repo:vanta:read", "repo:vanta:write-config"], "protected_state": ["download-clients:enabled-state"], "acceptable_costs": ["one working session per stage"] }, "scope": {"in": ["monitored-missing reconciliation"], "out": ["indexer changes", "VPN configuration"]}, "acceptance": {"required_tier": "declared-role-separation", "acceptor_ref": null}, "stop_rules": {"hold_if": ["any download client starts re-grabbing"], "stop_if": ["operator revokes"], "escalate_if": ["protected state would be touched"]}, "steward_ref": "agent:claude-code-session" },
+  "state": {
+    "frontier": "stage 1: inventory",
+    "notes": ["approved by operator"],
+    "unresolved_verdicts": []
+  },
+  "receipt_ids": [],
+  "written_utc": "2026-08-11T00:10:00Z",
+  "written_by": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/valid-manifest-minimal.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/valid-manifest-minimal.json
@@ -1,0 +1,27 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": ["repo:vanta:read", "repo:vanta:write-config"],
+    "protected_state": ["download-clients:enabled-state"],
+    "acceptable_costs": ["one working session per stage"]
+  },
+  "scope": {
+    "in": ["monitored-missing reconciliation"],
+    "out": ["indexer changes", "VPN configuration"]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": ["any download client starts re-grabbing"],
+    "stop_if": ["operator revokes"],
+    "escalate_if": ["protected state would be touched"]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/valid-receipt.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/valid-receipt.json
@@ -1,0 +1,10 @@
+{
+  "record": "receipt@1",
+  "mission_id": "tracer-media-missing",
+  "request_id": "req-0001",
+  "actor": "agent:claude-code-session",
+  "utc": "2026-08-11T00:20:00Z",
+  "artifact_path": "notes/stage-1-inventory.md",
+  "before_sha256": null,
+  "after_sha256": "9e2b7c1a4d5f60897a6b5c4d3e2f10987b6a5c4d3e2f109876b5a4c3d2e1f098"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/valid-verdict-fail.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/valid-verdict-fail.json
@@ -1,0 +1,13 @@
+{
+  "record": "acceptance-verdict@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 6,
+  "verdict": "FAIL",
+  "acceptor_id": "agent:acceptor-session",
+  "worker_id": "agent:claude-code-session",
+  "operator_ref": "operator:zach-stern",
+  "assurance_tier": "declared-role-separation",
+  "receipt_refs": ["req-0001"],
+  "reason": "Inventory omits season packs.",
+  "utc": "2026-08-11T01:00:00Z"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/valid-verdict-pass-separated.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/valid-verdict-pass-separated.json
@@ -1,0 +1,13 @@
+{
+  "record": "acceptance-verdict@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 6,
+  "verdict": "PASS",
+  "acceptor_id": "agent:acceptor-session",
+  "worker_id": "agent:claude-code-session",
+  "operator_ref": "operator:zach-stern",
+  "assurance_tier": "declared-role-separation",
+  "receipt_refs": ["req-0001"],
+  "reason": "Artifact re-observed; hashes match the receipt chain.",
+  "utc": "2026-08-11T01:00:00Z"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/mission-manifest.schema.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/mission-manifest.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "mission-manifest@1",
+  "title": "mission-manifest@1",
+  "description": "Durable mission authority record. Verbatim operator instruction is immutable; amendments append. Validation authority: verify_mission_custody.py (stdlib).",
+  "type": "object",
+  "required": ["record", "mission_id", "created_utc", "authority", "scope", "acceptance", "stop_rules", "steward_ref"],
+  "additionalProperties": false,
+  "properties": {
+    "record": {"const": "mission-manifest@1"},
+    "mission_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "created_utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"},
+    "authority": {
+      "type": "object",
+      "required": ["operator_ref", "instruction", "amendments", "permissions", "protected_state", "acceptable_costs"],
+      "additionalProperties": false,
+      "properties": {
+        "operator_ref": {"type": "string", "minLength": 1},
+        "instruction": {"type": "string", "minLength": 1},
+        "amendments": {"type": "array", "items": {"type": "object", "required": ["utc", "text"], "additionalProperties": false, "properties": {"utc": {"type": "string"}, "text": {"type": "string", "minLength": 1}}}},
+        "permissions": {"type": "array", "items": {"type": "string"}},
+        "protected_state": {"type": "array", "items": {"type": "string"}},
+        "acceptable_costs": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "scope": {"type": "object", "required": ["in", "out"], "additionalProperties": false, "properties": {"in": {"type": "array", "items": {"type": "string"}}, "out": {"type": "array", "items": {"type": "string"}}}},
+    "acceptance": {"type": "object", "required": ["required_tier", "acceptor_ref"], "additionalProperties": false, "properties": {"required_tier": {"enum": ["operator-accepted", "declared-role-separation"]}, "acceptor_ref": {"type": ["string", "null"]}}},
+    "stop_rules": {"type": "object", "required": ["hold_if", "stop_if", "escalate_if"], "additionalProperties": false, "properties": {"hold_if": {"type": "array", "items": {"type": "string"}}, "stop_if": {"type": "array", "items": {"type": "string"}}, "escalate_if": {"type": "array", "items": {"type": "string"}}}},
+    "steward_ref": {"type": "string", "minLength": 1}
+  }
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/receipt.schema.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/receipt.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "receipt@1",
+  "title": "receipt@1",
+  "description": "Receipt: immutable record of artifact transmission. before_sha256 is null for new artifacts; after_sha256 and before_sha256 (if non-null) must be valid 64-hex SHA-256 hashes. Validation authority: verify_mission_custody.py (stdlib).",
+  "type": "object",
+  "required": ["record", "mission_id", "request_id", "actor", "utc", "artifact_path", "before_sha256", "after_sha256"],
+  "additionalProperties": false,
+  "properties": {
+    "record": {"const": "receipt@1"},
+    "mission_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "request_id": {"type": "string", "minLength": 1},
+    "actor": {"type": "string", "minLength": 1},
+    "utc": {"type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"},
+    "artifact_path": {"type": "string", "minLength": 1},
+    "before_sha256": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"},
+    "after_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -155,6 +155,54 @@ def test_full_lifecycle_via_cli() -> None:
         check("full-cancel-refused-exit-2", r.returncode == 2)
 
 
+def test_ascii_safe_drift_and_error_output() -> None:
+    """Non-ASCII content in a drifted relpath or a CustodyError message must
+    render as an ASCII-only escape on stdout/stderr -- never a raw non-ASCII
+    byte, and never a crash regardless of the console codepage (brief Step 3:
+    "PYTHONIOENCODING-safe (ASCII-only output)"). Covers both raw-str print
+    sites: the `resume` drift list and the top-level CustodyError handler."""
+    # Built via a \uXXXX escape (not a literal character) so this source
+    # file itself stays pure ASCII (isascii() true).
+    e_acute = "\u00e9"  # 'e' with acute accent, U+00E9
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        open_cli(ws, "m-cli-ascii", "Exercise ASCII-safe output.")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+
+        non_ascii_path = f"notes/r{e_acute}sum{e_acute}.md"
+        run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+            "--path", non_ascii_path, "--content", "hello",
+            "--request-id", "req-ascii-1")
+        (ws / "notes" / f"r{e_acute}sum{e_acute}.md").write_text(
+            "tampered", encoding="utf-8")
+
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:second")
+        check("resume-ascii-exit-3", r.returncode == 3)
+        check("resume-ascii-stdout-is-ascii", r.stdout.isascii())
+        check("resume-ascii-stdout-escapes-non-ascii", "\\xe9" in r.stdout)
+
+        # Drive the mission to 'reopened' via a legitimate (non-self-cert)
+        # FAIL verdict, then trigger a CustodyError whose message embeds a
+        # non-ASCII value supplied verbatim by the operator: clear-fail's
+        # "no FAIL marker matching {fragment!r}" with a non-matching,
+        # non-ASCII --match fragment.
+        run("reconcile", "--workspace", str(ws), "--actor", "agent:worker",
+            "--path", non_ascii_path, "--content", "hello",
+            "--request-id", "req-ascii-2")
+        run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+        run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+            "--verdict", "FAIL", "--acceptor", "agent:acceptor",
+            "--tier", "declared-role-separation", "--reason", "needs review")
+
+        r = run("clear-fail", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--match", f"caf{e_acute}-does-not-match",
+                 "--request-id", "req-ascii-2")
+        check("clear-fail-ascii-exit-2", r.returncode == 2)
+        check("clear-fail-ascii-stderr-is-ascii", r.stderr.isascii())
+        check("clear-fail-ascii-stderr-names-exception", "CustodyError" in r.stderr)
+        check("clear-fail-ascii-stderr-escapes-non-ascii", "\\xe9" in r.stderr)
+
+
 def test_no_mission_flags_outside_open() -> None:
     tree = ast.parse(CLI.read_text(encoding="utf-8"))
 
@@ -199,6 +247,7 @@ TESTS = [
     test_resume_detects_drift_exit_3,
     test_accept_self_cert_refused_exit_2,
     test_full_lifecycle_via_cli,
+    test_ascii_safe_drift_and_error_output,
     test_no_mission_flags_outside_open,
 ]
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -203,6 +203,52 @@ def test_ascii_safe_drift_and_error_output() -> None:
         check("clear-fail-ascii-stderr-escapes-non-ascii", "\\xe9" in r.stderr)
 
 
+def test_open_stop_rules_and_acceptable_costs() -> None:
+    """open's --hold-if/--stop-if/--escalate-if/--cost flags land verbatim,
+    in order, in the manifest's stop_rules and acceptable_costs."""
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        r = run("open", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--mission-id", "m-cli-stoprules", "--instruction", "Guard the stop rules.",
+                 "--operator", "operator:zach", "--steward", "agent:worker",
+                 "--hold-if", "clientA re-grabs", "--hold-if", "second hold",
+                 "--stop-if", "operator revokes",
+                 "--escalate-if", "protected state touched",
+                 "--cost", "one session per stage")
+        check("open-stop-rules-exit-0", r.returncode == 0)
+
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        check("open-stop-rules-status-exit-0", r.returncode == 0)
+        st = json.loads(r.stdout)
+        manifest = st["manifest"]
+        check("open-stop-rules-hold-if",
+              manifest["stop_rules"]["hold_if"] == ["clientA re-grabs", "second hold"])
+        check("open-stop-rules-stop-if",
+              manifest["stop_rules"]["stop_if"] == ["operator revokes"])
+        check("open-stop-rules-escalate-if",
+              manifest["stop_rules"]["escalate_if"] == ["protected state touched"])
+        check("open-stop-rules-acceptable-costs",
+              manifest["authority"]["acceptable_costs"] == ["one session per stage"])
+
+
+def test_open_without_stop_rules_yields_empty_lists() -> None:
+    """Existing behavior unchanged: omitting the new flags still yields
+    empty stop_rules/acceptable_costs lists."""
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        open_cli(ws, "m-cli-nostoprules", "No stop rules given.")
+
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        st = json.loads(r.stdout)
+        manifest = st["manifest"]
+        check("open-no-stop-rules-hold-if-empty", manifest["stop_rules"]["hold_if"] == [])
+        check("open-no-stop-rules-stop-if-empty", manifest["stop_rules"]["stop_if"] == [])
+        check("open-no-stop-rules-escalate-if-empty",
+              manifest["stop_rules"]["escalate_if"] == [])
+        check("open-no-stop-rules-costs-empty",
+              manifest["authority"]["acceptable_costs"] == [])
+
+
 def test_no_mission_flags_outside_open() -> None:
     tree = ast.parse(CLI.read_text(encoding="utf-8"))
 
@@ -248,6 +294,8 @@ TESTS = [
     test_accept_self_cert_refused_exit_2,
     test_full_lifecycle_via_cli,
     test_ascii_safe_drift_and_error_output,
+    test_open_stop_rules_and_acceptable_costs,
+    test_open_without_stop_rules_yields_empty_lists,
     test_no_mission_flags_outside_open,
 ]
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Black-box tests for custody_cli.py: drive it via subprocess, exactly as an
+operator or another process would. No import of custody_cli internals except
+for the AST structural check on --mission-path/--mission-id placement."""
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+CLI = ROOT / "custody_cli.py"
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(CLI), *args], capture_output=True, text=True)
+
+
+def open_cli(ws: Path, mission_id: str, instruction: str, actor: str = "agent:worker",
+             steward: str = "agent:worker") -> subprocess.CompletedProcess:
+    return run("open", "--workspace", str(ws), "--actor", actor,
+               "--mission-id", mission_id, "--instruction", instruction,
+               "--operator", "operator:zach", "--steward", steward)
+
+
+def test_open_approve_effect_status_roundtrip() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        r = open_cli(ws, "m-cli-open", "Ship the CLI.")
+        check("open-exit-0", r.returncode == 0)
+
+        r = run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        check("approve-exit-0", r.returncode == 0)
+
+        r = run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--path", "notes/a.md", "--content", "hello",
+                 "--request-id", "req-1")
+        check("effect-exit-0", r.returncode == 0)
+        check("effect-artifact-written",
+              (ws / "notes" / "a.md").read_text(encoding="utf-8") == "hello")
+
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        check("status-exit-0", r.returncode == 0)
+        st = json.loads(r.stdout)
+        check("status-record-checkpoint", st["record"] == "checkpoint@1")
+        check("status-revision-3", st["revision"] == 3)
+        check("status-status-active", st["status"] == "active")
+
+
+def test_resume_detects_drift_exit_3() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        open_cli(ws, "m-cli-drift", "Track drift.")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+            "--path", "notes/a.md", "--content", "hello", "--request-id", "req-1")
+        (ws / "notes" / "a.md").write_text("tampered", encoding="utf-8")
+
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:second")
+        check("resume-exit-3", r.returncode == 3)
+        check("resume-names-path", "notes/a.md" in r.stdout)
+
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        st = json.loads(r.stdout)
+        check("resume-status-reopened", st["status"] == "reopened")
+        check("resume-marker-present",
+              "RECONCILIATION:notes/a.md" in st["state"]["unresolved_verdicts"])
+
+        # reconcile the drift, then resume again: no drift, exit 0, empty stdout
+        run("reconcile", "--workspace", str(ws), "--actor", "agent:worker",
+            "--path", "notes/a.md", "--content", "hello", "--request-id", "req-2")
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:third")
+        check("resume-clean-exit-0", r.returncode == 0)
+        check("resume-clean-empty-stdout", r.stdout.strip() == "")
+
+
+def test_accept_self_cert_refused_exit_2() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        open_cli(ws, "m-cli-selfcert", "Finish task.")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--verdict", "PASS", "--acceptor", "agent:worker",
+                 "--tier", "declared-role-separation", "--reason", "self says done")
+        check("accept-self-cert-exit-2", r.returncode == 2)
+        check("accept-self-cert-stderr-names-exception",
+              "AcceptanceRefused" in r.stderr)
+
+        # confirm the mission is still 'verifying', not silently completed
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        st = json.loads(r.stdout)
+        check("accept-self-cert-no-completion", st["status"] == "verifying")
+
+
+def test_full_lifecycle_via_cli() -> None:
+    """note/frontier/clear-fail/cancel wiring, exercised once each."""
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        open_cli(ws, "m-cli-full", "Exercise every subcommand.")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        run("note", "--workspace", str(ws), "--actor", "agent:worker",
+            "--text", "checking in")
+        run("frontier", "--workspace", str(ws), "--actor", "agent:worker",
+            "--text", "next: write the fix")
+
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        st = json.loads(r.stdout)
+        check("full-notes-recorded", "checking in" in st["state"]["notes"])
+        check("full-frontier-set", st["state"]["frontier"] == "next: write the fix")
+
+        run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--verdict", "FAIL", "--acceptor", "agent:acceptor",
+                 "--tier", "declared-role-separation", "--reason", "missing case")
+        check("full-fail-exit-0", r.returncode == 0)
+
+        run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+            "--path", "notes/fix.md", "--content", "patched",
+            "--request-id", "req-fix-1")
+        r = run("clear-fail", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--match", "missing case", "--request-id", "req-fix-1")
+        check("full-clear-fail-exit-0", r.returncode == 0)
+
+        run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--verdict", "PASS", "--acceptor", "agent:acceptor",
+                 "--tier", "declared-role-separation", "--reason", "fix verified")
+        check("full-accept-pass-exit-0", r.returncode == 0)
+
+        # pathless discovery correctly excludes a completed mission: no
+        # --mission-id escape hatch exists to reach it, by contract.
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        check("full-completed-mission-unreachable-status", r.returncode == 2)
+        check("full-completed-mission-no-active-mission",
+              "NoActiveMission" in r.stderr)
+
+        r = run("cancel", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--reason", "already completed, should refuse")
+        check("full-cancel-refused-exit-2", r.returncode == 2)
+
+
+def test_no_mission_flags_outside_open() -> None:
+    tree = ast.parse(CLI.read_text(encoding="utf-8"))
+
+    def _str_const(node: ast.AST) -> str | None:
+        return node.value if isinstance(node, ast.Constant) and isinstance(
+            node.value, str) else None
+
+    open_vars: set[str] = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Assign) and isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Attribute)
+                and node.value.func.attr == "add_parser"
+                and node.value.args and _str_const(node.value.args[0]) == "open"
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)):
+            open_vars.add(node.targets[0].id)
+    check("ast-found-open-subparser-var", bool(open_vars))
+
+    violations: list[str] = []
+    saw_mission_id_in_open = False
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add_argument" and node.args):
+            continue
+        flag = _str_const(node.args[0])
+        if flag not in ("--mission-path", "--mission-id"):
+            continue
+        recv = node.func.value
+        recv_name = recv.id if isinstance(recv, ast.Name) else None
+        if recv_name in open_vars:
+            if flag == "--mission-id":
+                saw_mission_id_in_open = True
+        else:
+            violations.append(f"{flag} on {recv_name!r}")
+    check("no-mission-flags-outside-open", not violations)
+    check("open-declares-mission-id", saw_mission_id_in_open)
+
+
+TESTS = [
+    test_open_approve_effect_status_roundtrip,
+    test_resume_detects_drift_exit_3,
+    test_accept_self_cert_refused_exit_2,
+    test_full_lifecycle_via_cli,
+    test_no_mission_flags_outside_open,
+]
+
+
+def main() -> int:
+    for fn in TESTS:
+        fn()
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from custody_store import sha256_bytes  # noqa: E402
+from custody_mission import (  # noqa: E402
+    AcceptanceRefused,
+    CustodyError,
+    IllegalTransition,
+    Mission,
+    MultipleActiveMissions,
+    NoActiveMission,
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def open_mission(workspace: Path, mission_id: str, instruction: str,
+                  required_tier: str = "declared-role-separation",
+                  actor: str = "agent:worker") -> Mission:
+    return Mission.open(
+        workspace, mission_id=mission_id, instruction=instruction,
+        operator_ref="operator:zach", steward_ref="agent:worker",
+        required_tier=required_tier, actor=actor)
+
+
+def test_open_creates_draft_r1(workspace: Path) -> None:
+    m = open_mission(workspace, "m-open", "Do the thing.")
+    st = m.status()
+    check("open-revision-1", st["revision"] == 1)
+    check("open-status-draft", st["status"] == "draft")
+    check("open-instruction-verbatim",
+          st["manifest"]["authority"]["instruction"] == "Do the thing.")
+
+
+def test_pathless_load_single_active(workspace: Path) -> None:
+    m = open_mission(workspace, "m-load", "Ship it.")
+    m.approve()
+    found = Mission.load(workspace, actor="agent:second")
+    check("load-finds-single", found.store.mission_dir == m.store.mission_dir)
+    check("load-status-active", found.status()["status"] == "active")
+
+
+def test_load_refuses_zero_and_multiple(workspace: Path) -> None:
+    try:
+        Mission.load(workspace, actor="agent:x")
+        check("load-zero-raises", False)
+    except NoActiveMission:
+        check("load-zero-raises", True)
+
+    open_mission(workspace, "m-one", "A.")
+    open_mission(workspace, "m-two", "B.")
+    try:
+        Mission.load(workspace, actor="agent:x")
+        check("load-multiple-raises", False)
+    except MultipleActiveMissions:
+        check("load-multiple-raises", True)
+
+
+def test_effect_writes_receipt_and_artifact(workspace: Path) -> None:
+    m = open_mission(workspace, "m-effect", "Write notes.")
+    m.approve()
+    receipt = m.record_effect("notes/a.md", "hello", "req-1")
+    target = workspace / "notes" / "a.md"
+    check("effect-artifact-exists", target.exists())
+    check("effect-artifact-content", target.read_text(encoding="utf-8") == "hello")
+    check("effect-receipt-hash", receipt["after_sha256"] == sha256_bytes(b"hello"))
+    st = m.status()
+    check("effect-receipt-id-recorded", "req-1" in st["receipt_ids"])
+
+
+def test_effect_refuses_escape(workspace: Path) -> None:
+    m = open_mission(workspace, "m-escape", "Guard paths.")
+    m.approve()
+    try:
+        m.record_effect("../outside.md", "x", "req-esc-1")
+        check("effect-refuses-dotdot", False)
+    except CustodyError:
+        check("effect-refuses-dotdot", True)
+    try:
+        m.record_effect("C:/x", "x", "req-esc-2")
+        check("effect-refuses-absolute", False)
+    except CustodyError:
+        check("effect-refuses-absolute", True)
+    check("effect-escape-no-artifact",
+          not (workspace.parent / "outside.md").exists())
+
+
+def test_resume_detects_drift_and_reconcile_clears(workspace: Path) -> None:
+    m = open_mission(workspace, "m-drift", "Track drift.")
+    m.approve()
+    m.record_effect("notes/a.md", "hello", "req-1")
+    target = workspace / "notes" / "a.md"
+    target.write_text("tampered", encoding="utf-8")
+
+    mismatched = m.resume()
+    check("resume-returns-path", mismatched == ["notes/a.md"])
+    st = m.status()
+    check("resume-status-reopened", st["status"] == "reopened")
+    check("resume-marker-present",
+          "RECONCILIATION:notes/a.md" in st["state"]["unresolved_verdicts"])
+
+    m.reconcile("notes/a.md", "hello", "req-2")
+    st2 = m.status()
+    check("reconcile-marker-cleared",
+          "RECONCILIATION:notes/a.md" not in st2["state"]["unresolved_verdicts"])
+    check("reconcile-status-active", st2["status"] == "active")
+    check("reconcile-content-restored", target.read_text(encoding="utf-8") == "hello")
+
+
+def test_instruction_immutable(workspace: Path) -> None:
+    m = open_mission(workspace, "m-tamper", "Keep me stable.")
+    m.approve()
+    r2_path = m.store.checkpoints_dir / "r00000002.json"
+    tampered = json.loads(r2_path.read_text(encoding="utf-8"))
+    tampered["manifest"]["authority"]["instruction"] = "Different instruction now."
+    r2_path.write_text(json.dumps(tampered, indent=1, sort_keys=True) + "\n",
+                        encoding="utf-8")
+    try:
+        m.note("carry on")
+        check("instruction-tamper-detected", False)
+    except CustodyError:
+        check("instruction-tamper-detected", True)
+
+
+def test_accept_requires_verifying_and_separation(workspace: Path) -> None:
+    m = open_mission(workspace, "m-accept", "Finish task.")
+    m.approve()
+    try:
+        m.record_verdict("PASS", acceptor_id="agent:acceptor",
+                          assurance_tier="declared-role-separation",
+                          reason="looks done")
+        check("accept-requires-verifying", False)
+    except IllegalTransition:
+        check("accept-requires-verifying", True)
+
+    m.begin_verification()
+    try:
+        m.record_verdict("PASS", acceptor_id="agent:worker",
+                          assurance_tier="declared-role-separation",
+                          reason="self says done")
+        check("accept-refuses-self-cert", False)
+    except AcceptanceRefused:
+        check("accept-refuses-self-cert", True)
+
+    m.record_verdict("PASS", acceptor_id="agent:acceptor",
+                      assurance_tier="declared-role-separation",
+                      reason="separately reviewed")
+    st = m.status()
+    check("accept-pass-completes", st["status"] == "completed")
+
+
+def test_fail_is_clearable(workspace: Path) -> None:
+    m = open_mission(workspace, "m-fail", "Ship safely.")
+    m.approve()
+    m.begin_verification()
+    m.record_verdict("FAIL", acceptor_id="agent:acceptor",
+                      assurance_tier="declared-role-separation",
+                      reason="missing edge case")
+    st = m.status()
+    check("fail-status-reopened", st["status"] == "reopened")
+    check("fail-marker-present",
+          any(marker.startswith("FAIL:") for marker in st["state"]["unresolved_verdicts"]))
+
+    m.record_effect("notes/fix.md", "patched", "req-fix-1")
+    m.clear_fail("missing edge case", "req-fix-1")
+    st2 = m.status()
+    check("fail-marker-cleared",
+          not any(marker.startswith("FAIL:") for marker in st2["state"]["unresolved_verdicts"]))
+    check("fail-status-active-after-clear", st2["status"] == "active")
+
+    m.begin_verification()
+    m.record_verdict("PASS", acceptor_id="agent:acceptor",
+                      assurance_tier="declared-role-separation",
+                      reason="fix verified")
+    st3 = m.status()
+    check("fail-then-pass-completes", st3["status"] == "completed")
+
+
+def test_operator_tier(workspace: Path) -> None:
+    m = open_mission(workspace, "m-tier", "High stakes change.",
+                      required_tier="operator-accepted")
+    m.approve()
+    m.begin_verification()
+    try:
+        m.record_verdict("PASS", acceptor_id="agent:acceptor",
+                          assurance_tier="declared-role-separation",
+                          reason="peer reviewed")
+        check("tier-insufficient-refused", False)
+    except AcceptanceRefused:
+        check("tier-insufficient-refused", True)
+
+    m.record_verdict("PASS", acceptor_id="operator:zach",
+                      assurance_tier="operator-accepted",
+                      reason="operator signed off")
+    st = m.status()
+    check("tier-operator-accept-completes", st["status"] == "completed")
+
+
+TESTS = [
+    test_open_creates_draft_r1,
+    test_pathless_load_single_active,
+    test_load_refuses_zero_and_multiple,
+    test_effect_writes_receipt_and_artifact,
+    test_effect_refuses_escape,
+    test_resume_detects_drift_and_reconcile_clears,
+    test_instruction_immutable,
+    test_accept_requires_verifying_and_separation,
+    test_fail_is_clearable,
+    test_operator_tier,
+]
+
+
+def main() -> int:
+    for fn in TESTS:
+        with tempfile.TemporaryDirectory() as td:
+            fn(Path(td))
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_process_proof.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_process_proof.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Three-subprocess kill/resume/repair continuity proof: black-box through
+custody_cli.py only, exactly as three independent, non-cooperating processes
+(no shared Python state) would drive one mission end to end.
+
+Process A opens, approves, records an effect, and sets a frontier, then a
+deliberately-hung fourth invocation is killed before it can touch the store
+-- proving a killed process leaves no partial checkpoint behind. A drift is
+then planted directly on disk (an out-of-band edit between processes).
+Process B resumes with no mission id, sees the drift, and reconciles it.
+Process C verifies, is refused a self-certified PASS, receives a legitimate
+FAIL, remediates, clears it, re-verifies, and reaches a PASS acceptance from
+a truly independent acceptor. A final independent pass re-derives the full
+checkpoint hash chain straight off disk -- never trusting the module under
+test's own chain-verification code -- and confirms no `*.tmp` file survives
+anywhere under `missions/`.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+CLI = ROOT / "custody_cli.py"
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(CLI), *args], capture_output=True, text=True)
+
+
+def status_json(ws: Path, actor: str) -> dict:
+    r = run("status", "--workspace", str(ws), "--actor", actor)
+    check("status-call-exit-0", r.returncode == 0)
+    return json.loads(r.stdout)
+
+
+def sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def independent_chain_errors(mission_dir: Path) -> list[str]:
+    """Recompute the checkpoint hash chain straight off disk, without
+    importing or calling into custody_store.MissionStore.load_latest --
+    the point of an *independent* re-verification is to never trust the
+    module under test's own chain-verification code."""
+    errors: list[str] = []
+    paths = sorted((mission_dir / "checkpoints").glob("r????????.json"))
+    if not paths:
+        return [f"no checkpoint files under {mission_dir / 'checkpoints'}"]
+    prev_sha: str | None = None
+    for i, path in enumerate(paths, start=1):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if record.get("revision") != i:
+            errors.append(
+                f"{path.name}: revision {record.get('revision')!r} != expected {i}")
+        if record.get("prev_checkpoint_sha256") != prev_sha:
+            errors.append(f"{path.name}: prev_checkpoint_sha256 chain break")
+        prev_sha = sha256_file(path)
+    return errors
+
+
+def test_three_subprocess_kill_resume_repair_proof() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        mission_id = "m-proof-kill-resume-repair"
+        instruction = "Prove three-process kill, resume, and repair continuity end-to-end."
+        missions_root = ws / "missions"
+        mission_dir = missions_root / mission_id
+
+        # ---------------------------------------------------------------
+        # Process A: open, approve, effect, frontier -- each its own
+        # process, exactly as an operator or another process would drive
+        # the CLI. Then a deliberately-hung fourth invocation is killed.
+        # ---------------------------------------------------------------
+        r = run("open", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--mission-id", mission_id, "--instruction", instruction,
+                 "--operator", "operator:zach", "--steward", "agent:worker")
+        check("a-open-exit-0", r.returncode == 0)
+
+        r = run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        check("a-approve-exit-0", r.returncode == 0)
+
+        r = run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--path", "notes/proof.md", "--content", "state-1",
+                 "--request-id", "req-a1")
+        check("a-effect-exit-0", r.returncode == 0)
+        check("a-effect-artifact-written",
+              (ws / "notes" / "proof.md").read_text(encoding="utf-8") == "state-1")
+
+        r = run("frontier", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--text", "next: hand off to the resuming process")
+        check("a-frontier-exit-0", r.returncode == 0)
+
+        st = status_json(ws, "agent:worker")
+        check("a-revision-after-frontier-is-4", st["revision"] == 4)
+
+        # Deliberately-hung fourth invocation: a `python -c` wrapper that
+        # imports custody_cli (proving the module loads cleanly) and then
+        # sleeps well past our kill -- so it is provably killed before it
+        # ever calls main() and attempts any store write. Simpler and more
+        # deterministic than racing a kill against a still-writing `effect`.
+        hung = subprocess.Popen(
+            [sys.executable, "-c", "import time, custody_cli; time.sleep(60)"],
+            cwd=str(ROOT), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        deadline = time.time() + 5
+        alive_before_kill = False
+        while time.time() < deadline:
+            if hung.poll() is None:
+                alive_before_kill = True
+                break
+            time.sleep(0.05)
+        check("a-hung-wrapper-alive-before-kill", alive_before_kill)
+        time.sleep(0.3)  # let it finish importing and reach time.sleep(60)
+        hung.kill()
+        try:
+            hung.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            hung.kill()
+            hung.communicate()
+        check("a-hung-wrapper-killed-nonzero-exit", hung.returncode != 0)
+
+        st = status_json(ws, "agent:worker")
+        check("a-hung-wrapper-died-pre-checkpoint-revision-still-4",
+              st["revision"] == 4)
+        tmp_after_kill = sorted(missions_root.rglob("*.tmp"))
+        check("a-no-tmp-files-after-kill", tmp_after_kill == [])
+
+        # ---------------------------------------------------------------
+        # Drift plant: an out-of-band edit between processes, bypassing
+        # custody entirely -- exactly what `resume` exists to catch.
+        # ---------------------------------------------------------------
+        (ws / "notes" / "proof.md").write_bytes(b"drifted-out-of-band-bytes")
+
+        # ---------------------------------------------------------------
+        # Process B: resume with no mission id, see the drift, reconcile.
+        # ---------------------------------------------------------------
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:worker")
+        check("b-resume-exit-3", r.returncode == 3)
+        check("b-resume-names-drifted-path",
+              "notes/proof.md" in r.stdout or "notes/proof.md" in r.stderr)
+
+        st = status_json(ws, "agent:worker")
+        check("b-status-reopened", st["status"] == "reopened")
+        check("b-status-reconciliation-marker",
+              "RECONCILIATION:notes/proof.md" in st["state"]["unresolved_verdicts"])
+
+        r = run("reconcile", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--path", "notes/proof.md", "--content", "state-1",
+                 "--request-id", "req-b1")
+        check("b-reconcile-exit-0", r.returncode == 0)
+
+        st = status_json(ws, "agent:worker")
+        check("b-status-active-after-reconcile", st["status"] == "active")
+        check("b-no-reconciliation-marker-remains",
+              "RECONCILIATION:notes/proof.md" not in st["state"]["unresolved_verdicts"])
+        check("b-revision-after-reconcile-is-6", st["revision"] == 6)
+
+        # ---------------------------------------------------------------
+        # Process C: verify, refuse a self-certified PASS, take a
+        # legitimate FAIL, remediate, clear it, re-verify, and accept
+        # from a truly independent acceptor.
+        # ---------------------------------------------------------------
+        r = run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+        check("c-verify-exit-0", r.returncode == 0)
+
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--verdict", "PASS", "--acceptor", "agent:worker",
+                 "--tier", "declared-role-separation",
+                 "--reason", "worker accepting its own work")
+        check("c-self-cert-exit-2", r.returncode == 2)
+        check("c-self-cert-stderr-names-exception", "AcceptanceRefused" in r.stderr)
+
+        st = status_json(ws, "agent:worker")
+        check("c-self-cert-refused-still-verifying", st["status"] == "verifying")
+        check("c-self-cert-refused-revision-still-7", st["revision"] == 7)
+
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:acceptor-2",
+                 "--verdict", "FAIL", "--acceptor", "agent:acceptor-2",
+                 "--tier", "declared-role-separation", "--reason", "missing section")
+        check("c-fail-exit-0", r.returncode == 0)
+
+        st = status_json(ws, "agent:worker")
+        check("c-fail-reopened", st["status"] == "reopened")
+        check("c-fail-marker-present",
+              "FAIL:missing section" in st["state"]["unresolved_verdicts"])
+
+        r = run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--path", "notes/proof.md", "--content", "state-2-remediated",
+                 "--request-id", "req-c1")
+        check("c-remediation-effect-exit-0", r.returncode == 0)
+
+        r = run("clear-fail", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--match", "missing section", "--request-id", "req-c1")
+        check("c-clear-fail-exit-0", r.returncode == 0)
+
+        st = status_json(ws, "agent:worker")
+        check("c-active-after-clear-fail", st["status"] == "active")
+
+        r = run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+        check("c-reverify-exit-0", r.returncode == 0)
+
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:acceptor-2",
+                 "--verdict", "PASS", "--acceptor", "agent:acceptor-2",
+                 "--tier", "declared-role-separation",
+                 "--reason", "remediated and independently reverified")
+        check("c-final-pass-exit-0", r.returncode == 0)
+
+        # A completed mission is unreachable via pathless discovery by
+        # contract (no --mission-id escape hatch exists) -- confirm that
+        # holds here too, then read the final state straight off disk.
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker")
+        check("c-completed-mission-unreachable-exit-2", r.returncode == 2)
+        check("c-completed-mission-no-active-mission",
+              "NoActiveMission" in r.stderr)
+
+        # ---------------------------------------------------------------
+        # Independent re-verification from disk: recompute the full
+        # checkpoint hash chain ourselves (never trusting the module
+        # under test's own chain-verification code), and confirm no
+        # `.tmp` file survives anywhere under missions/.
+        # ---------------------------------------------------------------
+        chain_errors = independent_chain_errors(mission_dir)
+        check("chain-independently-verified", chain_errors == [])
+        for err in chain_errors:
+            print(f"  chain error: {err}")
+
+        checkpoint_paths = sorted((mission_dir / "checkpoints").glob("r????????.json"))
+        final = json.loads(checkpoint_paths[-1].read_text(encoding="utf-8"))
+        check("final-status-completed", final["status"] == "completed")
+        check("final-revision-at-least-10", final["revision"] >= 10)
+
+        r1 = json.loads(checkpoint_paths[0].read_text(encoding="utf-8"))
+        check("r1-file-is-revision-1", r1["revision"] == 1)
+        check("instruction-byte-identical-to-r1",
+              final["manifest"]["authority"]["instruction"]
+              == r1["manifest"]["authority"]["instruction"]
+              == instruction)
+
+        tmp_files = sorted(missions_root.rglob("*.tmp"))
+        check("no-tmp-files-anywhere-under-missions", tmp_files == [])
+
+
+TESTS = [
+    test_three_subprocess_kill_resume_repair_proof,
+]
+
+
+def main() -> int:
+    for fn in TESTS:
+        fn()
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from custody_store import (  # noqa: E402
+    ChainBroken, MissionStore, StoreError, atomic_write_json, sha256_file,
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def manifest() -> dict:
+    return json.loads(
+        (ROOT / "examples" / "valid-manifest-minimal.json").read_text(
+            encoding="utf-8"))
+
+
+def checkpoint(rev: int, prev: str | None, status: str = "draft") -> dict:
+    return {
+        "record": "checkpoint@1",
+        "mission_id": "tracer-media-missing",
+        "revision": rev,
+        "status": status,
+        "prev_checkpoint_sha256": prev,
+        "manifest": manifest(),
+        "state": {"frontier": "f", "notes": [], "unresolved_verdicts": []},
+        "receipt_ids": [],
+        "written_utc": "2026-08-11T00:00:01Z",
+        "written_by": "agent:worker",
+    }
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        mdir = Path(td) / "missions" / "tracer-media-missing"
+        store = MissionStore(mdir)
+
+        # invalid record refused before touching disk
+        try:
+            store.write_checkpoint({"record": "checkpoint@1"})
+            check("store-refuses-invalid", False)
+        except StoreError:
+            check("store-refuses-invalid", True)
+
+        sha1 = store.write_checkpoint(checkpoint(1, None))
+        check("r1-written", (mdir / "checkpoints" / "r00000001.json").exists())
+
+        # r2 with wrong prev refused
+        try:
+            store.write_checkpoint(checkpoint(2, "b" * 64, "active"))
+            check("store-refuses-bad-chain", False)
+        except StoreError:
+            check("store-refuses-bad-chain", True)
+
+        store.write_checkpoint(checkpoint(2, sha1, "active"))
+        latest, path = store.load_latest()
+        check("latest-is-r2", latest["revision"] == 2)
+
+        # tamper with r1 on disk -> chain verification must fail
+        p1 = mdir / "checkpoints" / "r00000001.json"
+        p1.write_text(p1.read_text(encoding="utf-8").replace(
+            "await operator approval", "tampered"), encoding="utf-8")
+        try:
+            store.load_latest()
+            check("chain-tamper-detected", False)
+        except ChainBroken:
+            check("chain-tamper-detected", True)
+
+        # receipts round-trip
+        receipt = json.loads((ROOT / "examples" / "valid-receipt.json").read_text(
+            encoding="utf-8"))
+        rp = store.write_receipt(receipt)
+        check("receipt-written", rp.exists())
+        check("receipt-loaded", store.load_receipts() == [receipt])
+
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
@@ -88,6 +88,13 @@ def main() -> int:
         check("receipt-written", rp.exists())
         check("receipt-loaded", store.load_receipts() == [receipt])
 
+        # writing a second receipt with the same request_id must be refused
+        try:
+            store.write_receipt(receipt)
+            check("store-refuses-duplicate-receipt", False)
+        except StoreError:
+            check("store-refuses-duplicate-receipt", True)
+
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -77,6 +77,39 @@ def test_unknown_record_kind_rejected() -> None:
     check("unknown-record-kind", validate_record({"record": "mystery@1"}) != [])
 
 
+def valid_checkpoint_r1() -> dict:
+    return load("valid-checkpoint-r1.json")
+
+
+def test_checkpoint_valid_examples() -> None:
+    check("checkpoint-r1", validate_record(valid_checkpoint_r1()) == [])
+    check("checkpoint-r2", validate_record(load("valid-checkpoint-r2-chained.json")) == [])
+
+
+def test_checkpoint_r1_must_have_null_prev() -> None:
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    rec["prev_checkpoint_sha256"] = "a" * 64
+    check("checkpoint-r1-null-prev", validate_record(rec) != [])
+
+
+def test_checkpoint_r2_requires_prev_sha() -> None:
+    rec = load("valid-checkpoint-r2-chained.json")
+    rec["prev_checkpoint_sha256"] = None
+    check("checkpoint-r2-needs-prev", validate_record(rec) != [])
+
+
+def test_checkpoint_embedded_manifest_is_validated() -> None:
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    del rec["manifest"]["authority"]
+    check("checkpoint-embedded-manifest", validate_record(rec) != [])
+
+
+def test_checkpoint_status_closed_list() -> None:
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    rec["status"] = "paused"
+    check("checkpoint-closed-status", validate_record(rec) != [])
+
+
 def test_examples_corpus() -> None:
     ex = ROOT / "examples"
     for path in sorted(ex.glob("valid-*.json")):
@@ -95,6 +128,11 @@ def main() -> int:
     test_manifest_bad_tier()
     test_manifest_amendments_must_be_list_of_dated_text()
     test_unknown_record_kind_rejected()
+    test_checkpoint_valid_examples()
+    test_checkpoint_r1_must_have_null_prev()
+    test_checkpoint_r2_requires_prev_sha()
+    test_checkpoint_embedded_manifest_is_validated()
+    test_checkpoint_status_closed_list()
     test_examples_corpus()
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -110,6 +110,33 @@ def test_checkpoint_status_closed_list() -> None:
     check("checkpoint-closed-status", validate_record(rec) != [])
 
 
+def test_receipt_valid() -> None:
+    check("receipt-valid", validate_record(load("valid-receipt.json")) == [])
+
+
+def test_receipt_after_hash_required() -> None:
+    rec = load("valid-receipt.json")
+    rec["after_sha256"] = "not-a-hash"
+    check("receipt-after-hash", validate_record(rec) != [])
+
+
+def test_verdict_valid_pass() -> None:
+    check("verdict-pass", validate_record(load("valid-verdict-pass-separated.json")) == [])
+    check("verdict-fail", validate_record(load("valid-verdict-fail.json")) == [])
+
+
+def test_verdict_self_certification_refused() -> None:
+    rec = load("valid-verdict-pass-separated.json")
+    rec["acceptor_id"] = rec["worker_id"]
+    check("verdict-no-self-cert", validate_record(rec) != [])
+
+
+def test_verdict_operator_tier_binds_acceptor() -> None:
+    rec = load("valid-verdict-pass-separated.json")
+    rec["assurance_tier"] = "operator-accepted"
+    check("verdict-operator-tier-acceptor", validate_record(rec) != [])
+
+
 def test_examples_corpus() -> None:
     ex = ROOT / "examples"
     for path in sorted(ex.glob("valid-*.json")):
@@ -133,6 +160,11 @@ def main() -> int:
     test_checkpoint_r2_requires_prev_sha()
     test_checkpoint_embedded_manifest_is_validated()
     test_checkpoint_status_closed_list()
+    test_receipt_valid()
+    test_receipt_after_hash_required()
+    test_verdict_valid_pass()
+    test_verdict_self_certification_refused()
+    test_verdict_operator_tier_binds_acceptor()
     test_examples_corpus()
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from verify_mission_custody import (  # noqa: E402
+    RECORD_KINDS,
+    STATES,
+    TIERS,
+    VERDICTS,
+    validate_record,
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def load(name: str) -> dict:
+    return json.loads((ROOT / "examples" / name).read_text(encoding="utf-8"))
+
+
+def valid_manifest() -> dict:
+    return load("valid-manifest-minimal.json")
+
+
+def test_constants() -> None:
+    check("states-closed-list", STATES == {
+        "draft", "active", "reopened", "verifying", "completed", "cancelled"})
+    check("tiers", TIERS == {"operator-accepted", "declared-role-separation"})
+    check("verdicts", VERDICTS == {"PASS", "FAIL", "INCONCLUSIVE"})
+    check("record-kinds", RECORD_KINDS == {
+        "mission-manifest@1", "checkpoint@1", "receipt@1", "acceptance-verdict@1"})
+
+
+def test_manifest_valid_example() -> None:
+    check("manifest-valid-example", validate_record(valid_manifest()) == [])
+
+
+def test_manifest_missing_instruction() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    del rec["authority"]["instruction"]
+    check("manifest-missing-instruction", validate_record(rec) != [])
+
+
+def test_manifest_unknown_top_level_field() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["surprise"] = 1
+    check("manifest-unknown-field", validate_record(rec) != [])
+
+
+def test_manifest_bad_tier() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["acceptance"]["required_tier"] = "externally-proven"
+    check("manifest-no-externally-proven-tier", validate_record(rec) != [])
+
+
+def test_manifest_amendments_must_be_list_of_dated_text() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["amendments"] = ["bare string"]
+    check("manifest-amendment-shape", validate_record(rec) != [])
+
+
+def test_unknown_record_kind_rejected() -> None:
+    check("unknown-record-kind", validate_record({"record": "mystery@1"}) != [])
+
+
+def test_examples_corpus() -> None:
+    ex = ROOT / "examples"
+    for path in sorted(ex.glob("valid-*.json")):
+        rec = json.loads(path.read_text(encoding="utf-8"))
+        check(f"corpus-{path.name}", validate_record(rec) == [])
+    for path in sorted(ex.glob("invalid-*.json")):
+        rec = json.loads(path.read_text(encoding="utf-8"))
+        check(f"corpus-{path.name}", validate_record(rec) != [])
+
+
+def main() -> int:
+    test_constants()
+    test_manifest_valid_example()
+    test_manifest_missing_instruction()
+    test_manifest_unknown_top_level_field()
+    test_manifest_bad_tier()
+    test_manifest_amendments_must_be_list_of_dated_text()
+    test_unknown_record_kind_rejected()
+    test_examples_corpus()
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -137,6 +137,16 @@ def test_verdict_operator_tier_binds_acceptor() -> None:
     check("verdict-operator-tier-acceptor", validate_record(rec) != [])
 
 
+def test_receipt_and_verdict_mission_id_kebab_required() -> None:
+    rec = load("valid-receipt.json")
+    rec["mission_id"] = "Bad_ID"
+    check("receipt-mission-id-kebab", validate_record(rec) != [])
+
+    rec = load("valid-verdict-pass-separated.json")
+    rec["mission_id"] = "Bad_ID"
+    check("verdict-mission-id-kebab", validate_record(rec) != [])
+
+
 def test_examples_corpus() -> None:
     ex = ROOT / "examples"
     for path in sorted(ex.glob("valid-*.json")):
@@ -165,6 +175,7 @@ def main() -> int:
     test_verdict_valid_pass()
     test_verdict_self_certification_refused()
     test_verdict_operator_tier_binds_acceptor()
+    test_receipt_and_verdict_mission_id_kebab_required()
     test_examples_corpus()
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -196,7 +196,10 @@ def validate_receipt(rec: dict) -> list[str]:
     _check_exact_fields(errors, rec, RECEIPT_FIELDS, "receipt")
     if errors:
         return errors
-    for name in ("mission_id", "request_id", "actor", "artifact_path"):
+    _require(errors, isinstance(rec["mission_id"], str)
+             and bool(_ID_RE.match(rec["mission_id"])),
+             "mission_id", "kebab-case identifier required")
+    for name in ("request_id", "actor", "artifact_path"):
         _require(errors, isinstance(rec[name], str) and rec[name],
                  name, "non-empty string required")
     _require(errors, is_iso_utc(rec["utc"]), "utc", "ISO-8601 Z required")
@@ -218,8 +221,10 @@ def validate_acceptance_verdict(rec: dict) -> list[str]:
              f"one of {sorted(VERDICTS)} required")
     _require(errors, rec["assurance_tier"] in TIERS, "assurance_tier",
              f"one of {sorted(TIERS)} required")
-    for name in ("acceptor_id", "worker_id", "operator_ref", "reason",
-                 "mission_id"):
+    _require(errors, isinstance(rec["mission_id"], str)
+             and bool(_ID_RE.match(rec["mission_id"])),
+             "mission_id", "kebab-case identifier required")
+    for name in ("acceptor_id", "worker_id", "operator_ref", "reason"):
         _require(errors, isinstance(rec[name], str) and rec[name],
                  name, "non-empty string required")
     _require(errors, _str_list(rec["receipt_refs"]), "receipt_refs",

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -39,6 +39,14 @@ CHECKPOINT_FIELDS = {
     "record", "mission_id", "revision", "status", "prev_checkpoint_sha256",
     "manifest", "state", "receipt_ids", "written_utc", "written_by",
 }
+RECEIPT_FIELDS = {
+    "record", "mission_id", "request_id", "actor", "utc",
+    "artifact_path", "before_sha256", "after_sha256",
+}
+VERDICT_FIELDS = {
+    "record", "mission_id", "revision", "verdict", "acceptor_id", "worker_id",
+    "operator_ref", "assurance_tier", "receipt_refs", "reason", "utc",
+}
 
 
 def is_iso_utc(value: Any) -> bool:
@@ -183,12 +191,48 @@ def validate_checkpoint(rec: dict) -> list[str]:
     return errors
 
 
-def validate_receipt(rec: dict) -> list[str]:  # replaced in Task 3
-    return ["record: receipt@1 validation not implemented"]
+def validate_receipt(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, RECEIPT_FIELDS, "receipt")
+    if errors:
+        return errors
+    for name in ("mission_id", "request_id", "actor", "artifact_path"):
+        _require(errors, isinstance(rec[name], str) and rec[name],
+                 name, "non-empty string required")
+    _require(errors, is_iso_utc(rec["utc"]), "utc", "ISO-8601 Z required")
+    _require(errors, rec["before_sha256"] is None or is_sha256(rec["before_sha256"]),
+             "before_sha256", "null (new artifact) or 64-hex sha256 required")
+    _require(errors, is_sha256(rec["after_sha256"]),
+             "after_sha256", "64-hex sha256 required")
+    return errors
 
 
-def validate_acceptance_verdict(rec: dict) -> list[str]:  # replaced in Task 3
-    return ["record: acceptance-verdict@1 validation not implemented"]
+def validate_acceptance_verdict(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, VERDICT_FIELDS, "verdict")
+    if errors:
+        return errors
+    _require(errors, isinstance(rec["revision"], int) and rec["revision"] >= 1,
+             "revision", "integer >= 1 required")
+    _require(errors, rec["verdict"] in VERDICTS, "verdict",
+             f"one of {sorted(VERDICTS)} required")
+    _require(errors, rec["assurance_tier"] in TIERS, "assurance_tier",
+             f"one of {sorted(TIERS)} required")
+    for name in ("acceptor_id", "worker_id", "operator_ref", "reason",
+                 "mission_id"):
+        _require(errors, isinstance(rec[name], str) and rec[name],
+                 name, "non-empty string required")
+    _require(errors, _str_list(rec["receipt_refs"]), "receipt_refs",
+             "list of receipt id strings required")
+    _require(errors, is_iso_utc(rec["utc"]), "utc", "ISO-8601 Z required")
+    if not errors:
+        _require(errors, rec["acceptor_id"] != rec["worker_id"],
+                 "acceptor_id", "self-certification refused (== worker_id)")
+        if rec["assurance_tier"] == "operator-accepted":
+            _require(errors, rec["acceptor_id"] == rec["operator_ref"],
+                     "acceptor_id",
+                     "operator-accepted tier requires acceptor_id == operator_ref")
+    return errors
 
 
 def main(argv: list[str]) -> int:

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -35,6 +35,10 @@ AUTHORITY_FIELDS = {
     "operator_ref", "instruction", "amendments", "permissions",
     "protected_state", "acceptable_costs",
 }
+CHECKPOINT_FIELDS = {
+    "record", "mission_id", "revision", "status", "prev_checkpoint_sha256",
+    "manifest", "state", "receipt_ids", "written_utc", "written_by",
+}
 
 
 def is_iso_utc(value: Any) -> bool:
@@ -138,8 +142,45 @@ def validate_record(record: Any) -> list[str]:
     return validate_acceptance_verdict(record)  # Task 3
 
 
-def validate_checkpoint(rec: dict) -> list[str]:  # replaced in Task 2
-    return ["record: checkpoint@1 validation not implemented"]
+def validate_checkpoint(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, CHECKPOINT_FIELDS, "checkpoint")
+    if errors:
+        return errors
+    _require(errors, isinstance(rec["revision"], int) and rec["revision"] >= 1,
+             "revision", "integer >= 1 required")
+    _require(errors, rec["status"] in STATES, "status",
+             f"one of {sorted(STATES)} required")
+    prev = rec["prev_checkpoint_sha256"]
+    if rec.get("revision") == 1:
+        _require(errors, prev is None, "prev_checkpoint_sha256",
+                 "null required at revision 1")
+    else:
+        _require(errors, is_sha256(prev), "prev_checkpoint_sha256",
+                 "64-hex sha256 of prior checkpoint file required")
+    if isinstance(rec["manifest"], dict) \
+            and rec["manifest"].get("record") == "mission-manifest@1":
+        for err in validate_manifest(rec["manifest"]):
+            errors.append(f"manifest.{err}")
+        if rec["manifest"].get("mission_id") != rec["mission_id"]:
+            errors.append("manifest.mission_id: must equal checkpoint mission_id")
+    else:
+        errors.append("manifest: embedded mission-manifest@1 required")
+    state = rec["state"]
+    ok = isinstance(state, dict) \
+        and set(state) == {"frontier", "notes", "unresolved_verdicts"} \
+        and isinstance(state.get("frontier"), str) and state["frontier"] \
+        and _str_list(state.get("notes")) \
+        and _str_list(state.get("unresolved_verdicts"))
+    _require(errors, ok, "state",
+             "frontier (non-empty str), notes[], unresolved_verdicts[] required")
+    _require(errors, _str_list(rec["receipt_ids"]), "receipt_ids",
+             "list of receipt id strings required")
+    _require(errors, is_iso_utc(rec["written_utc"]), "written_utc",
+             "ISO-8601 Z timestamp required")
+    _require(errors, isinstance(rec["written_by"], str) and rec["written_by"],
+             "written_by", "non-empty actor id required")
+    return errors
 
 
 def validate_receipt(rec: dict) -> list[str]:  # replaced in Task 3

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Validate mission-custody@1 records without third-party dependencies.
+
+Record kinds: mission-manifest@1, checkpoint@1, receipt@1, acceptance-verdict@1.
+validate_record() dispatches on the required "record" field and returns a list
+of "FIELD: reason" strings; empty list means valid.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+STATES = {"draft", "active", "reopened", "verifying", "completed", "cancelled"}
+TIERS = {"operator-accepted", "declared-role-separation"}
+VERDICTS = {"PASS", "FAIL", "INCONCLUSIVE"}
+RECORD_KINDS = {
+    "mission-manifest@1",
+    "checkpoint@1",
+    "receipt@1",
+    "acceptance-verdict@1",
+}
+
+_ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+_SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+MANIFEST_FIELDS = {
+    "record", "mission_id", "created_utc", "authority", "scope",
+    "acceptance", "stop_rules", "steward_ref",
+}
+AUTHORITY_FIELDS = {
+    "operator_ref", "instruction", "amendments", "permissions",
+    "protected_state", "acceptable_costs",
+}
+
+
+def is_iso_utc(value: Any) -> bool:
+    return isinstance(value, str) and bool(_ISO_RE.match(value))
+
+
+def is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and bool(_SHA_RE.match(value))
+
+
+def _str_list(value: Any) -> bool:
+    return isinstance(value, list) and all(
+        isinstance(item, str) and item for item in value)
+
+
+def _require(errors: list[str], cond: bool, field: str, reason: str) -> None:
+    if not cond:
+        errors.append(f"{field}: {reason}")
+
+
+def _check_exact_fields(errors: list[str], rec: dict, allowed: set[str],
+                        where: str) -> None:
+    for key in rec:
+        if key not in allowed:
+            errors.append(f"{where}.{key}: unknown field")
+    for key in allowed:
+        if key not in rec:
+            errors.append(f"{where}.{key}: missing")
+
+
+def validate_manifest(rec: dict) -> list[str]:
+    errors: list[str] = []
+    _check_exact_fields(errors, rec, MANIFEST_FIELDS, "manifest")
+    if errors:
+        return errors
+    _require(errors, isinstance(rec["mission_id"], str)
+             and bool(_ID_RE.match(rec["mission_id"])),
+             "mission_id", "kebab-case identifier required")
+    _require(errors, is_iso_utc(rec["created_utc"]),
+             "created_utc", "ISO-8601 Z timestamp required")
+    _require(errors, isinstance(rec["steward_ref"], str) and rec["steward_ref"],
+             "steward_ref", "non-empty string required")
+
+    auth = rec["authority"]
+    if not isinstance(auth, dict):
+        errors.append("authority: object required")
+        return errors
+    _check_exact_fields(errors, auth, AUTHORITY_FIELDS, "authority")
+    if not errors:
+        _require(errors, isinstance(auth["operator_ref"], str)
+                 and auth["operator_ref"],
+                 "authority.operator_ref", "non-empty string required")
+        _require(errors, isinstance(auth["instruction"], str)
+                 and auth["instruction"],
+                 "authority.instruction", "non-empty verbatim string required")
+        amendments = auth["amendments"]
+        ok = isinstance(amendments, list) and all(
+            isinstance(a, dict) and set(a) == {"utc", "text"}
+            and is_iso_utc(a["utc"]) and isinstance(a["text"], str) and a["text"]
+            for a in amendments)
+        _require(errors, ok, "authority.amendments",
+                 "append-only list of {utc, text} objects required")
+        for name in ("permissions", "protected_state", "acceptable_costs"):
+            _require(errors, _str_list(auth[name]),
+                     f"authority.{name}", "list of strings required")
+
+    scope = rec["scope"]
+    ok = isinstance(scope, dict) and set(scope) == {"in", "out"} \
+        and _str_list(scope.get("in")) and _str_list(scope.get("out"))
+    _require(errors, ok, "scope", '{"in": [...], "out": [...]} required')
+
+    acc = rec["acceptance"]
+    ok = isinstance(acc, dict) and set(acc) == {"required_tier", "acceptor_ref"} \
+        and acc.get("required_tier") in TIERS \
+        and (acc.get("acceptor_ref") is None
+             or (isinstance(acc.get("acceptor_ref"), str) and acc["acceptor_ref"]))
+    _require(errors, ok, "acceptance",
+             "required_tier in TIERS and acceptor_ref string-or-null required")
+
+    stop = rec["stop_rules"]
+    ok = isinstance(stop, dict) \
+        and set(stop) == {"hold_if", "stop_if", "escalate_if"} \
+        and all(_str_list(stop[k]) for k in ("hold_if", "stop_if", "escalate_if"))
+    _require(errors, ok, "stop_rules",
+             "hold_if/stop_if/escalate_if string lists required")
+    return errors
+
+
+def validate_record(record: Any) -> list[str]:
+    if not isinstance(record, dict):
+        return ["record: JSON object required"]
+    kind = record.get("record")
+    if kind not in RECORD_KINDS:
+        return [f"record: unknown kind {kind!r}"]
+    if kind == "mission-manifest@1":
+        return validate_manifest(record)
+    if kind == "checkpoint@1":
+        return validate_checkpoint(record)      # Task 2
+    if kind == "receipt@1":
+        return validate_receipt(record)         # Task 3
+    return validate_acceptance_verdict(record)  # Task 3
+
+
+def validate_checkpoint(rec: dict) -> list[str]:  # replaced in Task 2
+    return ["record: checkpoint@1 validation not implemented"]
+
+
+def validate_receipt(rec: dict) -> list[str]:  # replaced in Task 3
+    return ["record: receipt@1 validation not implemented"]
+
+
+def validate_acceptance_verdict(rec: dict) -> list[str]:  # replaced in Task 3
+    return ["record: acceptance-verdict@1 validation not implemented"]
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: verify_mission_custody.py <file.json>...", file=sys.stderr)
+        return 2
+    failed = False
+    for arg in argv:
+        rec = json.loads(Path(arg).read_text(encoding="utf-8"))
+        errors = validate_record(rec)
+        if errors:
+            failed = True
+            for err in errors:
+                print(f"{arg}: {err}")
+        else:
+            print(f"{arg}: valid")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: manifest
+description: Use when work is mission-shaped — multi-session, consequential, cross-agent, or interruption-expensive — or on the explicit phrase "manifest this" (also /manifest): open, resume, verify, or close a custodied mission with recorded authority, durable checkpoints, drift re-anchoring, and independent acceptance. Answers "will this survive interruption?", "who authorized this scope?", "what makes done defensible?". Do NOT fire for routine one-step work checkable in-session.
+---
+
+# manifest — mission custody (custodian)
+
+You are a mission steward under bounded delegated agency. The contract of
+record is the mission's durable state under `missions/<id>/` (mission-custody@1
+records), never the chat.
+
+Custody core: `plugins/epistemic-skills/contracts/mission-custody/custody_cli.py`
+(stdlib; run with `python`). Every mutating call names `--actor` with YOUR
+stable session identity. Exit 2 = refusal (read the stderr class name); exit 3
+on resume = drift found — reconcile before anything else.
+
+## Modes
+
+1. **Open** — capture the operator instruction VERBATIM: `open --mission-id
+   <kebab> --instruction <verbatim> --operator <ref> --steward <your actor>
+   [--tier declared-role-separation]`. Then `approve` only after the operator
+   confirms authority (permissions, protected state, stop rules).
+2. **Resume** — `resume` (pathless; never pass a mission path). Treat chat and
+   memory as untrusted until it exits 0. On exit 3: reconcile each named
+   artifact (re-verify against live state first), then continue.
+3. **Advance** — one bounded step inside authority; route every artifact write
+   through `effect`; record `frontier` after material progress.
+4. **Verify / Close** — `verify`, then acceptance by a DIFFERENT actor:
+   a distinct session runs `accept`. Never accept work you performed; the core
+   refuses it (AcceptanceRefused) — do not work around the refusal.
+
+## Boundaries
+
+- Decline routine, one-step, in-session-checkable work (say so; no mission).
+- Never select or invoke other skills by name from this seat; when a
+  load-bearing condition blocks progress (an unverified claim, an unmapped
+  territory, an irreversible fork), STATE THE CONDITION and the return point
+  (mission id + frontier) and let the surrounding stack answer it.
+- Custody here is convention-held (no enforcement hook yet — Stage C is
+  gated on the tracer retro): honestly label it if asked.
+- Degraded modes: core unavailable -> author a markdown mission manifest,
+  label it session-bounded; store unwritable -> surface immediately; operator
+  revocation -> stop consequential work, surface AUTHORITY_REVOKED.
+- Mission state commits to the working repo by default (gitignore escape
+  hatch for noisy missions).

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -18,8 +18,9 @@ on resume = drift found — reconcile before anything else.
 
 1. **Open** — capture the operator instruction VERBATIM: `open --mission-id
    <kebab> --instruction <verbatim> --operator <ref> --steward <your actor>
-   [--tier declared-role-separation]`. Then `approve` only after the operator
-   confirms authority (permissions, protected state, stop rules).
+   [--tier declared-role-separation] [--hold-if RULE ...] [--stop-if RULE ...]
+   [--escalate-if RULE ...] [--cost COST ...]`. Then `approve` only after the
+   operator confirms authority (permissions, protected state, stop rules).
 2. **Resume** — `resume` (pathless; never pass a mission path). Treat chat and
    memory as untrusted until it exits 0. On exit 3: reconcile each named
    artifact (re-verify against live state first), then continue.


### PR DESCRIPTION
## mission-custody@1 contracts + custody core + `manifest` skill

**Design:** `docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md` (operator-approved) · **Plan:** `docs/superpowers/plans/2026-08-11-mission-custody-contracts.md` · Stage C (enforcement hooks) explicitly **out of scope**, gated on the tracer retro (template in-branch).

### Provenance

Executes the FOLD cell of the pre-committed demand×vehicle decision rule from the practical-agency gauntlet run `practical-agency-telos-2026-08-10` (verdict: NO-GO on unconditional continuation; H-GATE-FIRST + H-FOLD; fold-feasibility spike PASS; custodian experience + contracts-first + ES-as-contract-home chosen by operator). Lineage: helix (banked 2026-07-20) → practical-agency (parked prior art; its schemas seeded this family) → this contract family.

### What's in

- **`contracts/mission-custody/`** — `mission-manifest@1`, `checkpoint@1`, `receipt@1`, `acceptance-verdict@1`: schema docs + ONE stdlib verifier (`verify_mission_custody.py`, closed vocabularies, exact-field checks) + examples corpus (every `invalid-*.json` provably fails) + `README`/`SECURITY`.
- **Custody core (689 lines, cap 500–800)** — `custody_store.py` (atomic mkstemp+fsync+replace writes, `prev_checkpoint_sha256` chain, receipt overwrite guard), `custody_mission.py` (closed six-state lifecycle, append-only verbatim instruction, pathless single-active-mission discovery, drift → recorded `reopened` + reconcile, kernel-refused self-acceptance, tiered acceptance, **FAIL-clearable** — the parked prior-art's reject dead-end designed out with a regression test), `custody_cli.py` (thin dispatch; exit 0/2/3; no mission-id/path flags outside `open` — enforced by an AST test).
- **`skills/manifest/`** — the custodian skill: three trigger doors (`/manifest`, description-fired, metacognate-condition vocabulary), hard decline clause, no-routing (zero skill names — verified). Description = **477 UTF-8 bytes**; operator byte-budget sign-off 2026-08-11: "Approve — spend the bytes" (recorded in the build ledger).
- **CI** — `.github/workflows/mission-custody-contract.yml` (pins byte-identical to `commission-watch-contract.yml`), runs all five suites + verifier compile.

### Evidence

- **Suites:** 5/5 test files exit 0, 0 failures (mission_custody 36 checks · store 8 · mission 31 · cli 34 · process_proof 46), re-run independently by implementer, task reviewers, final reviewer, and controller.
- **Continuity proof:** `test_custody_process_proof.py` — three separate OS subprocesses, hard-killed between stages, planted disk drift, pathless recovery, FAIL→remediate→re-verify→PASS→`completed`, full hash chain re-derived from disk.
- **Live UAT (Stage B oracle):** real session drove the SKILL.md's documented commands end-to-end — drift caught (`resume` exit 3), self-acceptance refused (exit 2, `AcceptanceRefused`), independent acceptor session recomputed artifact hashes from disk before ruling PASS; mission completed at r8. Packet: the operator private UAT archive (mission-custody-uat-2026-08-11), sha256 `e0f4596c17442b13e8c22e035610a4a167c33e8fe37c1ba8cf98c98460580f10`.
- **Review:** per-task SDD reviews (2 fix rounds across 10 tasks) + final whole-branch review (most capable model) → 2 blockers fixed in one wave (`f0a5ab4`), scoped re-review 3/3 ADDRESSED, no new breakage. 9 deferred minors triaged ACCEPT; follow-ups tracked in the build ledger: draft-state effect policy · `open` flags for stop-rules/costs (landing next on this branch) · corrupt-chain dirs named in `NoActiveMission` · two trailer irregularities on early docs commits.

### Claim ceiling (honest labels)

Stage B custody is **convention-held** — no enforcement hook exists yet; nothing prevents an in-process bypass of the broker. That is the deliberate experiment: the media-tracer mission's retro (template: `docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md`) answers the adoption falsifier and decides Stage C. Acceptance tiers are honest: `operator-accepted` > `declared-role-separation`; **no `externally-proven` tier exists**. Receipts are hashed, not signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ

