### PR TITLE
ci: skip workflow jobs on draft PRs, scope push triggers to main

### DIFF
--- a/.github/workflows/commission-watch-contract.yml
+++ b/.github/workflows/commission-watch-contract.yml
@@ -3,6 +3,9 @@ name: commission-watch-contract
 "on":
   workflow_dispatch:
   push:
+    # WIP branches are agent scratch; the gate runs on merge to main and on
+    # non-draft PRs, not on every push to a development branch.
+    branches: [main]
     paths:
       - "plugins/epistemic-skills/contracts/watch-commission/**"
       - "plugins/epistemic-skills/contracts/epistemic-events/sentinels/watch-silence-read-as-healthy.json"
@@ -38,6 +41,8 @@ permissions:
 
 jobs:
   contract:
+    # Draft PRs are agent WIP; the gate runs when the PR is marked ready.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,9 @@ name: DCO
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    # ready_for_review included so a PR opened as draft gets its DCO check
+    # the moment it becomes a real candidate.
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -11,6 +13,8 @@ permissions:
 jobs:
   dco:
     name: DCO
+    # Draft PRs are agent WIP; the check runs when the PR is marked ready.
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:

--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -40,6 +40,8 @@ permissions:
 
 jobs:
   stdlib-checks:
+    # Draft PRs are agent WIP; the gate runs when the PR is marked ready.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/mission-custody-contract.yml
+++ b/.github/workflows/mission-custody-contract.yml
@@ -3,6 +3,9 @@ name: mission-custody-contract
 "on":
   workflow_dispatch:
   push:
+    # WIP branches are agent scratch; the gate runs on merge to main and on
+    # non-draft PRs, not on every push to a development branch.
+    branches: [main]
     paths:
       - "plugins/epistemic-skills/contracts/mission-custody/**"
       - "docs/superpowers/specs/2026-08-11-mission-custody-contracts-design.md"
@@ -20,6 +23,8 @@ permissions:
 
 jobs:
   contract:
+    # Draft PRs are agent WIP; the gate runs when the PR is marked ready.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/openai-bundles.yml
+++ b/.github/workflows/openai-bundles.yml
@@ -35,6 +35,8 @@ concurrency:
 
 jobs:
   build:
+    # Draft PRs are agent WIP; bundles build when the PR is marked ready.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:

--- a/.github/workflows/release-security.yml
+++ b/.github/workflows/release-security.yml
@@ -15,6 +15,10 @@ permissions:
 
 jobs:
   full-history-secret-scan:
+    # Draft PRs are agent WIP; the scan runs when the PR is marked ready.
+    # This narrows nothing about WHAT is scanned -- every non-draft PR and
+    # every push to main still gets the full-history scan.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Why

Agent WIP branches (chatgpt/*, spec/*) run full CI on every push and every draft-PR sync. Per the 2026-08-11 org CI survey (scratch/ci-survey-2026-08-11.md), this repo emitted **~29 failures/2w**, concentrated on `chatgpt/practical-agency-manifest` and `spec/mission-custody-contracts-design`: commission-watch-contract 14, DCO 4, epistemic-flexibility 4, mission-custody-contract 4, plus push-side noise from unfiltered push triggers.

## What changed (per workflow)

| Workflow | Change |
|---|---|
| commission-watch-contract.yml | `push` had **no branch filter** (fired on every branch) — scoped to `main`; job `contract` gated on `github.event.pull_request.draft == false` |
| mission-custody-contract.yml | same: `push` scoped to `main`; job `contract` draft-gated |
| epistemic-flexibility.yml | push already main-only; job `stdlib-checks` draft-gated |
| openai-bundles.yml | push already main-only; job `build` draft-gated |
| release-security.yml | push already main-only; job `full-history-secret-scan` draft-gated (every non-draft PR and push-to-main still gets the full-history scan — nothing about *what* is scanned is narrowed) |
| dco.yml | added `ready_for_review` to `pull_request_target` types; job `dco` draft-gated — a PR opened as draft gets its DCO check the moment it is marked ready |

## What is preserved

- All gates still run on **push to main**, **workflow_dispatch**, and **non-draft PRs**. Marking a draft ready fires `ready_for_review` → `pull_request` event → jobs run, so no candidate reaches merge ungated.
- Branch protection: **none configured on `main`** (verified via `gh api repos/ZMS-Labs/epistemic-skills/branches/main/protection` → 404), so no required checks are affected.

## Failure mode killed

Draft-PR syncs and WIP-branch pushes no longer dispatch these workflows, eliminating the ~29 failures/2w of agent-WIP churn while keeping full gating on real candidates.