### PR TITLE
fix(mission-custody): close the probe-verified custody gaps from the field efficacy evaluation

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -108,6 +108,9 @@ def build_parser() -> argparse.ArgumentParser:
     _add_content_flags(p_reconcile)
     p_reconcile.add_argument("--request-id", required=True)
 
+    p_ack = sub.add_parser("acknowledge-loss", parents=[common])
+    p_ack.add_argument("--request-id", required=True)
+
     sub.add_parser("verify", parents=[common])
 
     p_accept = sub.add_parser("accept", parents=[common])
@@ -184,6 +187,8 @@ def dispatch(args: argparse.Namespace) -> int:
         receipt = mission.reconcile(args.path, _read_content(args),
                                      args.request_id)
         _print_status(receipt)
+    elif args.command == "acknowledge-loss":
+        print(mission.acknowledge_receipt_loss(args.request_id))
     elif args.command == "verify":
         print(mission.begin_verification())
     elif args.command == "accept":

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -23,6 +23,7 @@ import sys
 from pathlib import Path
 
 from custody_mission import CustodyError, Mission
+from custody_store import StoreError
 
 
 def _print_status(checkpoint: dict) -> None:
@@ -202,7 +203,10 @@ def main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
     try:
         return dispatch(args)
-    except CustodyError as exc:
+    except (CustodyError, StoreError) as exc:
+        # StoreError refusals (concurrent writer, duplicate receipt, invalid
+        # record) honor the same exit-2 contract as custody refusals instead
+        # of escaping as a traceback with exit 1.
         print(_ascii_safe(f"{type(exc).__name__}: {exc}"), file=sys.stderr)
         return 2
 

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 """Thin argparse CLI over the Mission lifecycle API (custody_mission.Mission).
 No logic beyond translation: every subcommand parses flags, calls exactly one
-Mission method, and prints exactly what that method returns.
+Mission method, and prints exactly what that method returns -- the new
+revision number for lifecycle mutations, the receipt JSON for effect and
+reconcile, the checkpoint JSON for status.
 
 Discovery is pathless by contract: no subcommand other than `open` accepts a
 --mission-path or --mission-id flag. `Mission.load()` finds the single active
 mission under --workspace on every other command.
 
-Exit codes: 0 success; 2 usage/refusal (a CustodyError subclass prints its
-class name + message to stderr); 3 drift detected on `resume`.
+Exit codes: 0 success; 2 usage/refusal (argparse prints usage; a CustodyError
+subclass prints its class name + message to stderr); 3 drift detected on
+`resume`. On a clean resume the drift list on stdout is empty by contract;
+a one-line summary goes to stderr so vacuous cleanliness (zero receipts on
+record) is visible instead of indistinguishable from verified cleanliness.
 """
 from __future__ import annotations
 
@@ -33,11 +38,30 @@ def _ascii_safe(text: str) -> str:
     return text.encode("ascii", "backslashreplace").decode("ascii")
 
 
+def _read_content(args: argparse.Namespace) -> str:
+    if args.content_file is not None:
+        # newline='' disables universal-newline translation: the receipt
+        # hashes exactly the bytes the file carries, CRLF preserved -- silent
+        # normalization here would make every cross-store hash compare lie.
+        with open(args.content_file, encoding="utf-8", newline="") as handle:
+            return handle.read()
+    return args.content
+
+
 def _common_parser() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--workspace", required=True)
     common.add_argument("--actor", required=True)
     return common
+
+
+def _add_content_flags(parser: argparse.ArgumentParser) -> None:
+    # Artifact bodies do not belong on a command line: argv caps out near
+    # 32K chars on Windows and every shell metacharacter must survive
+    # quoting -- --content-file reads the bytes directly instead.
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--content")
+    group.add_argument("--content-file", dest="content_file")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -61,7 +85,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_open.add_argument("--cost", action="append", default=[], dest="acceptable_costs")
 
     sub.add_parser("approve", parents=[common])
-    sub.add_parser("status", parents=[common])
+
+    p_status = sub.add_parser("status", parents=[common])
+    p_status.add_argument("--brief", action="store_true")
 
     p_note = sub.add_parser("note", parents=[common])
     p_note.add_argument("--text", required=True)
@@ -71,14 +97,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_effect = sub.add_parser("effect", parents=[common])
     p_effect.add_argument("--path", required=True)
-    p_effect.add_argument("--content", required=True)
+    _add_content_flags(p_effect)
     p_effect.add_argument("--request-id", required=True)
 
     sub.add_parser("resume", parents=[common])
 
     p_reconcile = sub.add_parser("reconcile", parents=[common])
     p_reconcile.add_argument("--path", required=True)
-    p_reconcile.add_argument("--content", required=True)
+    _add_content_flags(p_reconcile)
     p_reconcile.add_argument("--request-id", required=True)
 
     sub.add_parser("verify", parents=[common])
@@ -99,6 +125,20 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _brief(checkpoint: dict) -> dict:
+    return {
+        "mission_id": checkpoint["mission_id"],
+        "status": checkpoint["status"],
+        "revision": checkpoint["revision"],
+        "frontier": checkpoint["state"]["frontier"],
+        "unresolved_verdicts": checkpoint["state"]["unresolved_verdicts"],
+        "notes_count": len(checkpoint["state"]["notes"]),
+        "receipt_ids_count": len(checkpoint["receipt_ids"]),
+        "written_utc": checkpoint["written_utc"],
+        "written_by": checkpoint["written_by"],
+    }
+
+
 def dispatch(args: argparse.Namespace) -> int:
     workspace = Path(args.workspace)
 
@@ -111,36 +151,47 @@ def dispatch(args: argparse.Namespace) -> int:
             permissions=args.permission, protected_state=args.protected,
             hold_if=args.hold_if, stop_if=args.stop_if, escalate_if=args.escalate_if,
             acceptable_costs=args.acceptable_costs)
+        print(1)  # Mission.open always writes revision 1
         return 0
 
     mission = Mission.load(workspace, actor=args.actor)
 
     if args.command == "approve":
-        mission.approve()
+        print(mission.approve())
     elif args.command == "status":
-        _print_status(mission.status())
+        latest = mission.status()
+        _print_status(_brief(latest) if args.brief else latest)
     elif args.command == "note":
-        mission.note(args.text)
+        print(mission.note(args.text))
     elif args.command == "frontier":
-        mission.set_frontier(args.text)
+        print(mission.set_frontier(args.text))
     elif args.command == "effect":
-        mission.record_effect(args.path, args.content, args.request_id)
+        receipt = mission.record_effect(args.path, _read_content(args),
+                                         args.request_id)
+        _print_status(receipt)
     elif args.command == "resume":
         drift = mission.resume()
         for relpath in drift:
             print(_ascii_safe(relpath))
+        if not drift:
+            n = len(set(mission.status()["receipt_ids"]))
+            vacuous = " -- vacuously (no effects recorded)" if n == 0 else ""
+            print(f"resume: clean; {n} receipt id(s) on record{vacuous}",
+                  file=sys.stderr)
         return 3 if drift else 0
     elif args.command == "reconcile":
-        mission.reconcile(args.path, args.content, args.request_id)
+        receipt = mission.reconcile(args.path, _read_content(args),
+                                     args.request_id)
+        _print_status(receipt)
     elif args.command == "verify":
-        mission.begin_verification()
+        print(mission.begin_verification())
     elif args.command == "accept":
-        mission.record_verdict(args.verdict, acceptor_id=args.acceptor,
-                                assurance_tier=args.tier, reason=args.reason)
+        print(mission.record_verdict(args.verdict, acceptor_id=args.acceptor,
+                                      assurance_tier=args.tier, reason=args.reason))
     elif args.command == "clear-fail":
-        mission.clear_fail(args.match, args.request_id)
+        print(mission.clear_fail(args.match, args.request_id))
     elif args.command == "cancel":
-        mission.cancel(args.reason)
+        print(mission.cancel(args.reason))
     else:
         raise AssertionError(f"unhandled command {args.command!r}")
     return 0

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -4,7 +4,9 @@ reanchoring on resume and a clearable FAIL path (no PA reject dead-end)."""
 from __future__ import annotations
 
 import json
+import os
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -115,6 +117,7 @@ class Mission:
         workspace = Path(workspace)
         missions_root = workspace / "missions"
         active: list[Path] = []
+        skipped: list[str] = []
         if missions_root.is_dir():
             for mission_dir in sorted(missions_root.iterdir()):
                 if not mission_dir.is_dir():
@@ -124,12 +127,21 @@ class Mission:
                     continue
                 try:
                     latest, _ = store.load_latest()
-                except StoreError:
+                except (StoreError, ValueError, OSError) as exc:
+                    # A corrupt sibling must not brick discovery of a healthy
+                    # mission -- but the skip is loud, and if nothing loads the
+                    # skip reasons ride the NoActiveMission error.
+                    reason = f"{mission_dir.name}: {type(exc).__name__}: {exc}"
+                    skipped.append(reason)
+                    print(("custody: skipping unreadable mission dir " + reason)
+                          .encode("ascii", "backslashreplace").decode("ascii"),
+                          file=sys.stderr)
                     continue
                 if latest["status"] not in ("completed", "cancelled"):
                     active.append(mission_dir)
         if not active:
-            raise NoActiveMission(f"no active mission under {missions_root}")
+            detail = f"; skipped unreadable: {'; '.join(skipped)}" if skipped else ""
+            raise NoActiveMission(f"no active mission under {missions_root}{detail}")
         if len(active) > 1:
             names = ", ".join(p.name for p in active)
             raise MultipleActiveMissions(f"multiple active missions: {names}")
@@ -137,14 +149,23 @@ class Mission:
 
     # -- internal helpers ---------------------------------------------------
 
-    def _verify_instruction(self, latest: dict) -> None:
+    def _verify_manifest(self, latest: dict) -> None:
+        """The whole manifest is immutable from open to close (no code path
+        amends it in @1). Verifying only the instruction left every other
+        authority field -- scope, permissions, stop_rules, and critically
+        acceptance.required_tier -- silently editable on the tail checkpoint,
+        which no successor hash references."""
         origin_path = self.store.checkpoint_paths()[0]
         origin = json.loads(origin_path.read_text(encoding="utf-8"))
-        origin_instruction = origin["manifest"]["authority"]["instruction"]
-        latest_instruction = latest["manifest"]["authority"]["instruction"]
-        if origin_instruction != latest_instruction:
+        origin_manifest = origin["manifest"]
+        latest_manifest = latest["manifest"]
+        if origin_manifest != latest_manifest:
+            differing = sorted(
+                key for key in set(origin_manifest) | set(latest_manifest)
+                if origin_manifest.get(key) != latest_manifest.get(key))
             raise CustodyError(
-                "authority.instruction changed since mission open (tampered)")
+                "manifest changed since mission open (tampered): "
+                + ", ".join(differing))
 
     def _write_next(self, latest: dict, latest_path: Path, *, status: str,
                      note: str | None = None, frontier: str | None = None,
@@ -243,7 +264,7 @@ class Mission:
 
     def approve(self) -> int:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] != "draft":
             raise IllegalTransition(
                 f"cannot approve: status is {latest['status']!r}, expected 'draft'")
@@ -253,7 +274,7 @@ class Mission:
     def record_effect(self, artifact_relpath: str, content: str,
                        request_id: str) -> dict:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] not in _EFFECT_STATES:
             raise IllegalTransition(f"cannot record_effect: status is {latest['status']!r}")
         receipt = self._write_effect(latest, artifact_relpath, content, request_id)
@@ -263,7 +284,7 @@ class Mission:
 
     def note(self, text: str) -> int:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] not in _OPEN_STATES:
             raise IllegalTransition(f"cannot note: status is {latest['status']!r}")
         new = self._write_next(latest, path, status=latest["status"], note=text)
@@ -271,7 +292,7 @@ class Mission:
 
     def set_frontier(self, text: str) -> int:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] not in _OPEN_STATES:
             raise IllegalTransition(f"cannot set_frontier: status is {latest['status']!r}")
         new = self._write_next(latest, path, status=latest["status"], frontier=text)
@@ -279,54 +300,82 @@ class Mission:
 
     def resume(self) -> list[str]:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] in ("completed", "cancelled"):
             raise IllegalTransition(f"cannot resume: status is {latest['status']!r}")
-        latest_by_path: dict[str, dict] = {}
+        latest_by_key: dict[str, dict] = {}
+        missing: list[str] = []
         for request_id in latest["receipt_ids"]:
             receipt = self._load_receipt(request_id)
-            if receipt is not None:
-                latest_by_path[receipt["artifact_path"]] = receipt
+            if receipt is None:
+                # An unloadable receipt is drift, not a skip: the artifact it
+                # covered can no longer be verified, and silence here is a
+                # false "clean" for exactly the file most likely tampered.
+                if request_id not in missing:
+                    missing.append(request_id)
+                continue
+            key = receipt["artifact_path"]
+            if os.name == "nt":
+                # Case-insensitive filesystems: Doc.md and doc.md are one
+                # artifact; keying case-sensitively splits them and reports
+                # spurious drift on the superseded casing.
+                key = key.casefold()
+            latest_by_key[key] = receipt
         mismatched: list[str] = []
-        for rel, receipt in latest_by_path.items():
+        for receipt in latest_by_key.values():
+            rel = receipt["artifact_path"]
             target = self.workspace / rel
             actual = sha256_file(target) if target.exists() else None
             if actual != receipt["after_sha256"]:
                 mismatched.append(rel)
-        if not mismatched:
-            return []
         mismatched.sort()
+        missing.sort()
+        findings = mismatched + [f"RECEIPT-MISSING:{rid}" for rid in missing]
+        if not findings:
+            return []
         unresolved = list(latest["state"]["unresolved_verdicts"])
         for rel in mismatched:
             marker = f"RECONCILIATION:{rel}"
             if marker not in unresolved:
                 unresolved.append(marker)
+        for rid in missing:
+            marker = f"RECEIPT-MISSING:{rid}"
+            if marker not in unresolved:
+                unresolved.append(marker)
         self._write_next(latest, path, status="reopened", unresolved_verdicts=unresolved,
-                          note=f"drift detected: {', '.join(mismatched)}")
-        return mismatched
+                          note=f"drift detected: {', '.join(findings)}")
+        return findings
 
     def reconcile(self, artifact_relpath: str, content: str, request_id: str) -> dict:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] != "reopened":
             raise IllegalTransition(
                 f"cannot reconcile: status is {latest['status']!r}, expected 'reopened'")
         norm = artifact_relpath.replace("\\", "/")
-        marker = f"RECONCILIATION:{norm}"
         unresolved = latest["state"]["unresolved_verdicts"]
-        if marker not in unresolved:
-            raise CustodyError(f"no reconciliation marker for {artifact_relpath!r}")
+        # A drifted artifact clears RECONCILIATION:<path>; a lost receipt
+        # clears RECEIPT-MISSING:<request_id> by re-minting under the same id
+        # (write_receipt's duplicate refusal cannot fire -- the file is gone).
+        markers = [m for m in (f"RECONCILIATION:{norm}",
+                                f"RECEIPT-MISSING:{request_id}")
+                   if m in unresolved]
+        if not markers:
+            raise CustodyError(
+                f"no reconciliation or receipt-missing marker for "
+                f"{artifact_relpath!r} / {request_id!r}")
         receipt = self._write_effect(latest, artifact_relpath, content, request_id)
-        remaining = [m for m in unresolved if m != marker]
+        remaining = [m for m in unresolved if m not in markers]
         next_status = "active" if not remaining else "reopened"
-        self._write_next(latest, path, status=next_status, add_receipt_id=request_id,
+        add_id = request_id if request_id not in latest["receipt_ids"] else None
+        self._write_next(latest, path, status=next_status, add_receipt_id=add_id,
                           unresolved_verdicts=remaining,
                           note=f"reconciled: {artifact_relpath}")
         return receipt
 
     def begin_verification(self) -> int:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] != "active":
             raise IllegalTransition(
                 f"cannot begin_verification: status is {latest['status']!r}, expected 'active'")
@@ -339,7 +388,7 @@ class Mission:
     def record_verdict(self, verdict: str, acceptor_id: str, assurance_tier: str,
                         reason: str) -> int:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if verdict not in VERDICTS:
             raise CustodyError(f"unknown verdict {verdict!r}")
         if verdict in ("PASS", "FAIL"):
@@ -349,6 +398,15 @@ class Mission:
                     "expected 'verifying'")
         elif latest["status"] not in _OPEN_STATES:
             raise IllegalTransition(f"cannot record verdict: status is {latest['status']!r}")
+        if acceptor_id != self.actor:
+            # A verdict is recorded by its acceptor: the acting session must
+            # BE the named acceptor, so a worker session cannot fabricate a
+            # verdict under someone else's name (it can still lie about who it
+            # is -- principal binding is the enforcement hook's job -- but the
+            # record can no longer be incoherent about it).
+            raise AcceptanceRefused(
+                f"acceptor_id {acceptor_id!r} must equal the acting actor "
+                f"{self.actor!r}: a verdict is recorded by its acceptor")
 
         manifest = latest["manifest"]
         worker_id = manifest["steward_ref"]
@@ -392,7 +450,7 @@ class Mission:
 
     def clear_fail(self, reason_fragment: str, receipt_request_id: str) -> int:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] != "reopened":
             raise IllegalTransition(
                 f"cannot clear_fail: status is {latest['status']!r}, expected 'reopened'")
@@ -419,7 +477,7 @@ class Mission:
 
     def cancel(self, reason: str) -> int:
         latest, path = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         if latest["status"] not in ("draft", "active", "reopened", "verifying"):
             raise IllegalTransition(f"cannot cancel: status is {latest['status']!r}")
         new = self._write_next(latest, path, status="cancelled", note=f"cancelled: {reason}")
@@ -427,5 +485,5 @@ class Mission:
 
     def status(self) -> dict:
         latest, _ = self.store.load_latest()
-        self._verify_instruction(latest)
+        self._verify_manifest(latest)
         return latest

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -21,6 +21,7 @@ _TIER_RANK = {"declared-role-separation": 1, "operator-accepted": 2}
 assert set(_TIER_RANK) == TIERS, "tier rank table out of sync with verify_mission_custody.TIERS"
 
 _ABS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_RETIRED_NOTE = "receipt loss acknowledged: "
 
 
 def now_utc() -> str:
@@ -229,6 +230,12 @@ class Mission:
             raise CustodyError(
                 f"receipt already exists for request_id {request_id!r}; "
                 "effects are idempotent by request id -- use a fresh id")
+        if request_id in self._retired_receipt_ids(latest):
+            # Reuse would make one id mean two different artifacts across the
+            # record, forcing an auditor to walk revisions to disambiguate.
+            raise CustodyError(
+                f"request_id {request_id!r} was retired by an acknowledged "
+                "receipt loss and can never be reused -- use a fresh id")
         target = self._resolve_artifact_path(artifact_relpath)
         before_sha = sha256_file(target) if target.exists() else None
         data = content.encode("utf-8")
@@ -259,7 +266,47 @@ class Mission:
             return None
         except ValueError:
             return None
-        return record if not validate_record(record) else None
+        if validate_record(record):
+            return None
+        # A receipt whose own request_id disagrees with the content-addressed
+        # name it is stored under is malformed by construction -- never a
+        # trustworthy source for a claim about that id.
+        return record if record.get("request_id") == request_id else None
+
+    def _historical_effect_path(self, request_id: str) -> str | None:
+        """The artifact path this request id was minted against, read from the
+        hash-chained checkpoint history: the effect note appended by the very
+        revision that put the id into receipt_ids. A lost receipt's path is
+        NOT unknowable -- the chain remembers it, and interior checkpoints are
+        tamper-evident, so this is a sounder authority than a receipt file
+        anyone able to write the receipts dir could have replaced.
+        None when underivable (treated as unprovable, never as agreement)."""
+        prev_ids: list[str] = []
+        prev_notes: list[str] = []
+        for cp_path in self.store.checkpoint_paths():
+            record = json.loads(cp_path.read_text(encoding="utf-8"))
+            ids = record["receipt_ids"]
+            notes = record["state"]["notes"]
+            if request_id in ids and request_id not in prev_ids:
+                for note in notes[len(prev_notes):]:
+                    for prefix in ("effect: ", "reconciled: "):
+                        if note.startswith(prefix):
+                            return note[len(prefix):]
+                return None
+            prev_ids, prev_notes = ids, notes
+        return None
+
+    def _retired_receipt_ids(self, latest: dict) -> set[str]:
+        """Ids whose loss was acknowledged. Retirement is permanent and lives
+        in the append-only notes (checkpoint state is exact-field-closed in
+        @1), so a retired id can never be silently recycled for a different
+        artifact once the file that once occupied its path is gone."""
+        retired: set[str] = set()
+        for note in latest["state"]["notes"]:
+            if note.startswith(_RETIRED_NOTE):
+                tail = note[len(_RETIRED_NOTE):].split(";")[0]
+                retired.add(tail.split(" (covered ")[0].strip())
+        return retired
 
     def _find_verdict_record(self, verdict: str, reason: str) -> dict | None:
         verdicts_dir = self.store.mission_dir / "verdicts"
@@ -297,7 +344,18 @@ class Mission:
         if latest["status"] not in _EFFECT_STATES:
             raise IllegalTransition(f"cannot record_effect: status is {latest['status']!r}")
         receipt = self._write_effect(latest, artifact_relpath, content, request_id)
-        self._write_next(latest, path, status=latest["status"], add_receipt_id=request_id,
+        # A fresh effect on an artifact awaiting re-coverage discharges that
+        # obligation -- that is exactly what RECOVER asks for.
+        unresolved = latest["state"]["unresolved_verdicts"]
+        recover = f"RECOVER:{artifact_relpath.replace(chr(92), '/')}"
+        status = latest["status"]
+        remaining = None
+        if recover in unresolved:
+            remaining = [m for m in unresolved if m != recover]
+            if status == "reopened" and not remaining:
+                status = "active"
+        self._write_next(latest, path, status=status, add_receipt_id=request_id,
+                          unresolved_verdicts=remaining,
                           note=f"effect: {artifact_relpath}")
         return receipt
 
@@ -395,14 +453,16 @@ class Mission:
         return receipt
 
     def acknowledge_receipt_loss(self, request_id: str) -> int:
-        """The only exit for a RECEIPT-MISSING marker, and it never writes an
-        artifact or deletes a file. If the receipt has been restored since
-        detection, the stale marker clears and coverage simply continues
-        (round-2 finding B: the old re-mint path destroyed a healthy restored
-        receipt and overwrote the live artifact). If it is still unloadable,
-        the loss is recorded permanently in the notes and the id leaves
-        receipt_ids -- provenance cannot be resurrected, so ongoing coverage
-        requires a FRESH effect, minted honestly as a new event."""
+        """The only exit for a RECEIPT-MISSING marker. It never writes an
+        artifact and never deletes a file, and it never asserts continuity it
+        has not proven: a receipt found at the id's path counts as RESTORED
+        only if it agrees with the chained history (its own request_id, and
+        the artifact path the id was originally minted against). A receipt
+        that disagrees is a different receipt wearing the id's name -- trusting
+        its schema-validity alone let a forged path silently replace real
+        coverage while the mission read clean (merge-gate round 3). Anything
+        unproven retires the id with the loss recorded permanently; ongoing
+        coverage then requires a FRESH effect, minted as a new event."""
         latest, path = self.store.load_latest()
         self._verify_manifest(latest)
         if latest["status"] != "reopened":
@@ -415,17 +475,40 @@ class Mission:
             raise CustodyError(f"no receipt-loss marker for {request_id!r}")
         remaining = [m for m in unresolved if m != marker]
         next_status = "active" if not remaining else "reopened"
-        if self._load_receipt(request_id) is not None:
+
+        receipt = self._load_receipt(request_id)  # already request_id-checked
+        recorded_path = self._historical_effect_path(request_id)
+        if receipt is not None and recorded_path is not None \
+                and receipt["artifact_path"] == recorded_path:
             new = self._write_next(
                 latest, path, status=next_status, unresolved_verdicts=remaining,
-                note=f"receipt restored: {request_id}; coverage continues")
+                note=(f"receipt restored: {request_id}; matches the recorded "
+                      f"effect on {recorded_path}; coverage continues"))
             return new["revision"]
+
+        covered = f" (covered {recorded_path})" if recorded_path else ""
+        if receipt is None:
+            why = "receipt unloadable"
+        elif recorded_path is None:
+            why = "no recorded effect in the chain to check the receipt against"
+        else:
+            why = (f"present receipt claims {receipt['artifact_path']!r}, "
+                   f"chain records {recorded_path!r} -- NOT trusted")
         receipt_ids = [rid for rid in latest["receipt_ids"] if rid != request_id]
+        if recorded_path is not None:
+            # Losing coverage is an OBLIGATION, not a footnote: the mission
+            # stays reopened, naming the artifact that must be re-covered, so
+            # an uncovered artifact can never sit quietly in an active
+            # mission just because its receipt was destroyed.
+            recover = f"RECOVER:{recorded_path}"
+            if recover not in remaining:
+                remaining = remaining + [recover]
+            next_status = "reopened"
         new = self._write_next(
             latest, path, status=next_status, unresolved_verdicts=remaining,
             receipt_ids=receipt_ids,
-            note=(f"receipt loss acknowledged: {request_id}; prior coverage "
-                  "unknown -- re-cover the artifact with a fresh effect"))
+            note=(f"{_RETIRED_NOTE}{request_id}{covered}; {why}; id retired "
+                  "permanently -- re-cover the artifact with a fresh effect"))
         return new["revision"]
 
     def begin_verification(self) -> int:

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -173,6 +173,7 @@ class Mission:
     def _write_next(self, latest: dict, latest_path: Path, *, status: str,
                      note: str | None = None, frontier: str | None = None,
                      add_receipt_id: str | None = None,
+                     receipt_ids: list[str] | None = None,
                      unresolved_verdicts: list[str] | None = None) -> dict:
         notes = list(latest["state"]["notes"])
         if note is not None:
@@ -184,7 +185,8 @@ class Mission:
                 list(unresolved_verdicts) if unresolved_verdicts is not None
                 else list(latest["state"]["unresolved_verdicts"])),
         }
-        receipt_ids = list(latest["receipt_ids"])
+        receipt_ids = (list(receipt_ids) if receipt_ids is not None
+                       else list(latest["receipt_ids"]))
         if add_receipt_id is not None:
             receipt_ids.append(add_receipt_id)
         checkpoint = {
@@ -371,34 +373,18 @@ class Mission:
                 f"cannot reconcile: status is {latest['status']!r}, expected 'reopened'")
         norm = artifact_relpath.replace("\\", "/")
         unresolved = latest["state"]["unresolved_verdicts"]
-        # Exactly ONE obligation clears per call. A drifted artifact clears
-        # RECONCILIATION:<path>; a lost receipt clears RECEIPT-MISSING:<id> by
-        # re-minting under the same id. When the call matches BOTH, they are
-        # separate obligations sharing one receipt -- clearing them together
-        # would silently drop the missing receipt's artifact from custody.
-        drift_marker = f"RECONCILIATION:{norm}"
-        missing_marker = f"RECEIPT-MISSING:{request_id}"
-        drift_hit = drift_marker in unresolved
-        missing_hit = missing_marker in unresolved
-        if drift_hit and missing_hit:
+        # reconcile clears DRIFT only. A lost receipt's path is unknowable
+        # once the receipt is gone, so any flow that re-binds its request id
+        # to a caller-chosen path is a forgery channel (merge-gate round 2,
+        # finding A): acknowledge_receipt_loss is the only exit for
+        # RECEIPT-MISSING markers, and it destroys nothing.
+        marker = f"RECONCILIATION:{norm}"
+        if marker not in unresolved:
+            raise CustodyError(f"no reconciliation marker for {artifact_relpath!r}")
+        if f"RECEIPT-MISSING:{request_id}" in unresolved:
             raise CustodyError(
-                f"ambiguous reconciliation: {drift_marker} and {missing_marker} "
-                "are separate obligations -- clear the drift with a fresh "
-                "request id, then re-mint the missing receipt on its own")
-        if drift_hit:
-            marker = drift_marker
-        elif missing_hit:
-            marker = missing_marker
-            # The missing-receipt file may still exist corrupt or stale (that
-            # is HOW it went missing); re-minting must replace it, not wedge
-            # on the duplicate refusal.
-            stale = self.store.receipt_path(request_id)
-            if stale.exists():
-                stale.unlink()
-        else:
-            raise CustodyError(
-                f"no reconciliation or receipt-missing marker for "
-                f"{artifact_relpath!r} / {request_id!r}")
+                f"request_id {request_id!r} has a pending receipt-loss marker; "
+                "acknowledge the loss and reconcile under a fresh id")
         receipt = self._write_effect(latest, artifact_relpath, content, request_id)
         remaining = [m for m in unresolved if m != marker]
         next_status = "active" if not remaining else "reopened"
@@ -407,6 +393,40 @@ class Mission:
                           unresolved_verdicts=remaining,
                           note=f"reconciled: {artifact_relpath}")
         return receipt
+
+    def acknowledge_receipt_loss(self, request_id: str) -> int:
+        """The only exit for a RECEIPT-MISSING marker, and it never writes an
+        artifact or deletes a file. If the receipt has been restored since
+        detection, the stale marker clears and coverage simply continues
+        (round-2 finding B: the old re-mint path destroyed a healthy restored
+        receipt and overwrote the live artifact). If it is still unloadable,
+        the loss is recorded permanently in the notes and the id leaves
+        receipt_ids -- provenance cannot be resurrected, so ongoing coverage
+        requires a FRESH effect, minted honestly as a new event."""
+        latest, path = self.store.load_latest()
+        self._verify_manifest(latest)
+        if latest["status"] != "reopened":
+            raise IllegalTransition(
+                f"cannot acknowledge_receipt_loss: status is "
+                f"{latest['status']!r}, expected 'reopened'")
+        marker = f"RECEIPT-MISSING:{request_id}"
+        unresolved = latest["state"]["unresolved_verdicts"]
+        if marker not in unresolved:
+            raise CustodyError(f"no receipt-loss marker for {request_id!r}")
+        remaining = [m for m in unresolved if m != marker]
+        next_status = "active" if not remaining else "reopened"
+        if self._load_receipt(request_id) is not None:
+            new = self._write_next(
+                latest, path, status=next_status, unresolved_verdicts=remaining,
+                note=f"receipt restored: {request_id}; coverage continues")
+            return new["revision"]
+        receipt_ids = [rid for rid in latest["receipt_ids"] if rid != request_id]
+        new = self._write_next(
+            latest, path, status=next_status, unresolved_verdicts=remaining,
+            receipt_ids=receipt_ids,
+            note=(f"receipt loss acknowledged: {request_id}; prior coverage "
+                  "unknown -- re-cover the artifact with a fresh effect"))
+        return new["revision"]
 
     def begin_verification(self) -> int:
         latest, path = self.store.load_latest()

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -22,6 +22,15 @@ assert set(_TIER_RANK) == TIERS, "tier rank table out of sync with verify_missio
 
 _ABS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
 _RETIRED_NOTE = "receipt loss acknowledged: "
+# Notes are the mission's append-only, hash-chained narrative AND the carrier
+# for retirement (checkpoint state is exact-field-closed in @1, so a
+# retired_ids field would break the schema). Machine-written notes therefore
+# own these prefixes exclusively: a caller-supplied note that could imitate
+# one would let ordinary narrative forge machine state.
+_RESERVED_NOTE_PREFIXES = (
+    "effect: ", "reconciled: ", "drift detected: ", "receipt restored: ",
+    _RETIRED_NOTE,
+)
 
 
 def now_utc() -> str:
@@ -302,10 +311,20 @@ class Mission:
         @1), so a retired id can never be silently recycled for a different
         artifact once the file that once occupied its path is gone."""
         retired: set[str] = set()
+        decoder = json.JSONDecoder()
         for note in latest["state"]["notes"]:
-            if note.startswith(_RETIRED_NOTE):
-                tail = note[len(_RETIRED_NOTE):].split(";")[0]
-                retired.add(tail.split(" (covered ")[0].strip())
+            if not note.startswith(_RETIRED_NOTE):
+                continue
+            # The id is JSON-encoded, so it is read back exactly regardless of
+            # what it contains. Splitting on a delimiter truncated any id
+            # holding that delimiter, and a truncated id compared unequal to
+            # the real one -- silently un-retiring it (merge-gate round 4).
+            try:
+                value, _ = decoder.raw_decode(note[len(_RETIRED_NOTE):])
+            except ValueError:
+                continue
+            if isinstance(value, str):
+                retired.add(value)
         return retired
 
     def _find_verdict_record(self, verdict: str, reason: str) -> dict | None:
@@ -364,6 +383,12 @@ class Mission:
         self._verify_manifest(latest)
         if latest["status"] not in _OPEN_STATES:
             raise IllegalTransition(f"cannot note: status is {latest['status']!r}")
+        for prefix in _RESERVED_NOTE_PREFIXES:
+            if text.startswith(prefix):
+                raise CustodyError(
+                    f"note text may not begin with {prefix!r}: machine-written "
+                    "notes carry mission state and narrative must not be able "
+                    "to imitate them")
         new = self._write_next(latest, path, status=latest["status"], note=text)
         return new["revision"]
 
@@ -486,7 +511,8 @@ class Mission:
                       f"effect on {recorded_path}; coverage continues"))
             return new["revision"]
 
-        covered = f" (covered {recorded_path})" if recorded_path else ""
+        covered = (f" (covered {json.dumps(recorded_path)})"
+                   if recorded_path else "")
         if receipt is None:
             why = "receipt unloadable"
         elif recorded_path is None:
@@ -507,8 +533,9 @@ class Mission:
         new = self._write_next(
             latest, path, status=next_status, unresolved_verdicts=remaining,
             receipt_ids=receipt_ids,
-            note=(f"{_RETIRED_NOTE}{request_id}{covered}; {why}; id retired "
-                  "permanently -- re-cover the artifact with a fresh effect"))
+            note=(f"{_RETIRED_NOTE}{json.dumps(request_id)}{covered}; {why}; "
+                  "id retired permanently -- re-cover the artifact with a "
+                  "fresh effect"))
         return new["revision"]
 
     def begin_verification(self) -> int:

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -127,10 +127,13 @@ class Mission:
                     continue
                 try:
                     latest, _ = store.load_latest()
-                except (StoreError, ValueError, OSError) as exc:
-                    # A corrupt sibling must not brick discovery of a healthy
+                except (StoreError, ValueError) as exc:
+                    # A CORRUPT sibling must not brick discovery of a healthy
                     # mission -- but the skip is loud, and if nothing loads the
-                    # skip reasons ride the NoActiveMission error.
+                    # skip reasons ride the NoActiveMission error. Environmental
+                    # OSErrors (transient locks, permissions) propagate instead:
+                    # skipping those would reroute discovery around a mission
+                    # that is merely busy, inviting a duplicate open.
                     reason = f"{mission_dir.name}: {type(exc).__name__}: {exc}"
                     skipped.append(reason)
                     print(("custody: skipping unreadable mission dir " + reason)
@@ -217,6 +220,13 @@ class Mission:
 
     def _write_effect(self, latest: dict, artifact_relpath: str, content: str,
                        request_id: str) -> dict:
+        # Idempotency is checked BEFORE the workspace mutates: previously the
+        # target file was rewritten and only then did write_receipt refuse the
+        # duplicate, leaving an unreceipted mutation behind.
+        if self.store.receipt_path(request_id).exists():
+            raise CustodyError(
+                f"receipt already exists for request_id {request_id!r}; "
+                "effects are idempotent by request id -- use a fresh id")
         target = self._resolve_artifact_path(artifact_relpath)
         before_sha = sha256_file(target) if target.exists() else None
         data = content.encode("utf-8")
@@ -236,11 +246,18 @@ class Mission:
         return receipt
 
     def _load_receipt(self, request_id: str) -> dict | None:
-        name = sha256_bytes(request_id.encode("utf-8")) + ".json"
-        path = self.store.receipts_dir / name
-        if not path.exists():
+        """None means UNLOADABLE -- absent, corrupt, or schema-invalid alike.
+        A corrupt receipt must degrade to drift (RECEIPT-MISSING), never crash
+        resume: crashing the recovery path on a mangled receipt is a denial of
+        service by exactly the tampering drift detection exists to catch."""
+        path = self.store.receipt_path(request_id)
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
             return None
-        return json.loads(path.read_text(encoding="utf-8"))
+        except ValueError:
+            return None
+        return record if not validate_record(record) else None
 
     def _find_verdict_record(self, verdict: str, reason: str) -> dict | None:
         verdicts_dir = self.store.mission_dir / "verdicts"
@@ -354,18 +371,36 @@ class Mission:
                 f"cannot reconcile: status is {latest['status']!r}, expected 'reopened'")
         norm = artifact_relpath.replace("\\", "/")
         unresolved = latest["state"]["unresolved_verdicts"]
-        # A drifted artifact clears RECONCILIATION:<path>; a lost receipt
-        # clears RECEIPT-MISSING:<request_id> by re-minting under the same id
-        # (write_receipt's duplicate refusal cannot fire -- the file is gone).
-        markers = [m for m in (f"RECONCILIATION:{norm}",
-                                f"RECEIPT-MISSING:{request_id}")
-                   if m in unresolved]
-        if not markers:
+        # Exactly ONE obligation clears per call. A drifted artifact clears
+        # RECONCILIATION:<path>; a lost receipt clears RECEIPT-MISSING:<id> by
+        # re-minting under the same id. When the call matches BOTH, they are
+        # separate obligations sharing one receipt -- clearing them together
+        # would silently drop the missing receipt's artifact from custody.
+        drift_marker = f"RECONCILIATION:{norm}"
+        missing_marker = f"RECEIPT-MISSING:{request_id}"
+        drift_hit = drift_marker in unresolved
+        missing_hit = missing_marker in unresolved
+        if drift_hit and missing_hit:
+            raise CustodyError(
+                f"ambiguous reconciliation: {drift_marker} and {missing_marker} "
+                "are separate obligations -- clear the drift with a fresh "
+                "request id, then re-mint the missing receipt on its own")
+        if drift_hit:
+            marker = drift_marker
+        elif missing_hit:
+            marker = missing_marker
+            # The missing-receipt file may still exist corrupt or stale (that
+            # is HOW it went missing); re-minting must replace it, not wedge
+            # on the duplicate refusal.
+            stale = self.store.receipt_path(request_id)
+            if stale.exists():
+                stale.unlink()
+        else:
             raise CustodyError(
                 f"no reconciliation or receipt-missing marker for "
                 f"{artifact_relpath!r} / {request_id!r}")
         receipt = self._write_effect(latest, artifact_relpath, content, request_id)
-        remaining = [m for m in unresolved if m not in markers]
+        remaining = [m for m in unresolved if m != marker]
         next_status = "active" if not remaining else "reopened"
         add_id = request_id if request_id not in latest["receipt_ids"] else None
         self._write_next(latest, path, status=next_status, add_receipt_id=add_id,

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
@@ -47,6 +47,17 @@ def _publish_exclusive(tmp: str, path: Path) -> None:
     except FileExistsError:
         raise StoreError(
             f"{path.name} already exists; concurrent writer detected") from None
+    except BaseException:
+        # Never leave a partial record at the canonical name: it would brick
+        # chain loading AND block every retry with a misleading concurrent-
+        # writer refusal. Residual window: a hard kill between write and this
+        # unlink still strands a partial file -- load_latest fails loudly on
+        # it (never silently), and the os.link path above has no such window.
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
 
 
 def atomic_write_json(path: Path, record: dict, *, exclusive: bool = False) -> str:
@@ -121,12 +132,15 @@ class MissionStore:
             prev_sha = sha256_file(path)
         return record, paths[-1]
 
+    def receipt_path(self, request_id: str) -> Path:
+        name = sha256_bytes(request_id.encode("utf-8")) + ".json"
+        return self.receipts_dir / name
+
     def write_receipt(self, record: dict) -> Path:
         errors = validate_record(record)
         if errors:
             raise StoreError(f"invalid receipt: {errors[:3]}")
-        name = sha256_bytes(record["request_id"].encode("utf-8")) + ".json"
-        path = self.receipts_dir / name
+        path = self.receipt_path(record["request_id"])
         if path.exists():
             raise StoreError(
                 f"receipt already exists for request_id {record['request_id']!r}")

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
@@ -27,7 +27,29 @@ def sha256_file(path: Path) -> str:
     return sha256_bytes(path.read_bytes())
 
 
-def atomic_write_json(path: Path, record: dict) -> str:
+def _publish_exclusive(tmp: str, path: Path) -> None:
+    """Publish tmp at path, refusing to overwrite: two writers racing to the
+    same checkpoint name must produce one winner and one LOUD failure, never a
+    silent last-writer-wins clobber of a chained record."""
+    try:
+        os.link(tmp, path)
+        return
+    except FileExistsError:
+        raise StoreError(
+            f"{path.name} already exists; concurrent writer detected") from None
+    except OSError:
+        pass  # hard links unsupported on this filesystem
+    try:
+        with open(path, "xb") as out, open(tmp, "rb") as src:
+            out.write(src.read())
+            out.flush()
+            os.fsync(out.fileno())
+    except FileExistsError:
+        raise StoreError(
+            f"{path.name} already exists; concurrent writer detected") from None
+
+
+def atomic_write_json(path: Path, record: dict, *, exclusive: bool = False) -> str:
     errors = validate_record(record)
     if errors:
         raise StoreError(f"invalid record for {path.name}: {errors[:3]}")
@@ -39,7 +61,11 @@ def atomic_write_json(path: Path, record: dict) -> str:
             handle.write(data)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(tmp, path)
+        if exclusive:
+            _publish_exclusive(tmp, path)
+            os.unlink(tmp)
+        else:
+            os.replace(tmp, path)
     except BaseException:
         if os.path.exists(tmp):
             os.unlink(tmp)
@@ -78,7 +104,7 @@ class MissionStore:
             prior_sha = sha256_file(existing[-1])
             if record["prev_checkpoint_sha256"] != prior_sha:
                 raise StoreError("prev_checkpoint_sha256 does not match prior file")
-        return atomic_write_json(self._path_for(revision), record)
+        return atomic_write_json(self._path_for(revision), record, exclusive=True)
 
     def load_latest(self) -> tuple[dict, Path]:
         paths = self.checkpoint_paths()

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-verdict-self-certified-case.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-verdict-self-certified-case.json
@@ -1,0 +1,13 @@
+{
+  "record": "acceptance-verdict@1",
+  "mission_id": "tracer-media-missing",
+  "revision": 6,
+  "verdict": "PASS",
+  "acceptor_id": "Agent:Claude-Code-Session",
+  "worker_id": "agent:claude-code-session",
+  "operator_ref": "operator:zach-stern",
+  "assurance_tier": "declared-role-separation",
+  "receipt_refs": ["req-0001"],
+  "reason": "Worker accepting its own work behind a capitalization variant.",
+  "utc": "2026-08-11T01:00:00Z"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -343,12 +343,21 @@ def test_resume_missing_receipt_via_cli() -> None:
         check("lostrec-exit-3", r.returncode == 3)
         check("lostrec-names-request-id", "RECEIPT-MISSING:req-1" in r.stdout)
 
+        # the forgery channel is closed at the CLI: a decoy path cannot claim
+        # the lost id (round-2 finding A ran this exact sequence and won)
         r = run("reconcile", "--workspace", str(ws), "--actor", "agent:worker",
-                 "--path", "notes/a.md", "--content", "hello",
+                 "--path", "notes/decoy.md", "--content", "harmless decoy",
                  "--request-id", "req-1")
-        check("lostrec-reconcile-exit-0", r.returncode == 0)
+        check("lostrec-forgery-exit-2", r.returncode == 2)
+        check("lostrec-decoy-not-written", not (ws / "notes" / "decoy.md").exists())
+
+        r = run("acknowledge-loss", "--workspace", str(ws),
+                 "--actor", "agent:worker", "--request-id", "req-1")
+        check("lostrec-ack-exit-0", r.returncode == 0)
+        check("lostrec-ack-prints-revision", r.stdout.strip().isdigit())
         r = run("resume", "--workspace", str(ws), "--actor", "agent:third")
-        check("lostrec-clean-after-reconcile", r.returncode == 0)
+        check("lostrec-clean-after-ack", r.returncode == 0)
+        check("lostrec-clean-is-vacuous-again", "vacuously" in r.stderr)
 
 
 def test_no_mission_flags_outside_open() -> None:

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -125,7 +125,16 @@ def test_full_lifecycle_via_cli() -> None:
         check("full-frontier-set", st["state"]["frontier"] == "next: write the fix")
 
         run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+
+        # a verdict is recorded by its acceptor: the worker session naming a
+        # different acceptor is refused
         r = run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--verdict", "FAIL", "--acceptor", "agent:acceptor",
+                 "--tier", "declared-role-separation", "--reason", "missing case")
+        check("full-fabricated-acceptor-exit-2", r.returncode == 2)
+        check("full-fabricated-acceptor-refused", "AcceptanceRefused" in r.stderr)
+
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:acceptor",
                  "--verdict", "FAIL", "--acceptor", "agent:acceptor",
                  "--tier", "declared-role-separation", "--reason", "missing case")
         check("full-fail-exit-0", r.returncode == 0)
@@ -138,7 +147,7 @@ def test_full_lifecycle_via_cli() -> None:
         check("full-clear-fail-exit-0", r.returncode == 0)
 
         run("verify", "--workspace", str(ws), "--actor", "agent:worker")
-        r = run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:acceptor",
                  "--verdict", "PASS", "--acceptor", "agent:acceptor",
                  "--tier", "declared-role-separation", "--reason", "fix verified")
         check("full-accept-pass-exit-0", r.returncode == 0)
@@ -190,7 +199,7 @@ def test_ascii_safe_drift_and_error_output() -> None:
             "--path", non_ascii_path, "--content", "hello",
             "--request-id", "req-ascii-2")
         run("verify", "--workspace", str(ws), "--actor", "agent:worker")
-        run("accept", "--workspace", str(ws), "--actor", "agent:worker",
+        run("accept", "--workspace", str(ws), "--actor", "agent:acceptor",
             "--verdict", "FAIL", "--acceptor", "agent:acceptor",
             "--tier", "declared-role-separation", "--reason", "needs review")
 
@@ -249,6 +258,99 @@ def test_open_without_stop_rules_yields_empty_lists() -> None:
               manifest["authority"]["acceptable_costs"] == [])
 
 
+def test_success_output_confirms_the_write() -> None:
+    """Every mutating command prints its landed revision (or receipt): a mute
+    success path is what got resume misread as broken (efficacy evaluation
+    2026-08-12). Also covers --brief and --content-file."""
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        r = open_cli(ws, "m-cli-output", "Confirm every write.")
+        check("open-prints-r1", r.stdout.strip() == "1")
+
+        r = run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        check("approve-prints-r2", r.stdout.strip() == "2")
+
+        r = run("note", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--text", "landed?")
+        check("note-prints-r3", r.stdout.strip() == "3")
+
+        r = run("frontier", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--text", "next step")
+        check("frontier-prints-r4", r.stdout.strip() == "4")
+
+        # --content-file carries bodies argv cannot: quoting-hostile text
+        body = 'a "quoted" $body with `backticks` and\nnewlines\n'
+        src = ws / "body-src.md"
+        src.write_text(body, encoding="utf-8")
+        r = run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--path", "notes/from-file.md", "--content-file", str(src),
+                 "--request-id", "req-file-1")
+        check("effect-content-file-exit-0", r.returncode == 0)
+        check("effect-content-file-written",
+              (ws / "notes" / "from-file.md").read_text(encoding="utf-8") == body)
+        receipt = json.loads(r.stdout)
+        check("effect-prints-receipt",
+              receipt["record"] == "receipt@1"
+              and receipt["request_id"] == "req-file-1")
+
+        r = run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--path", "notes/x.md", "--content", "inline",
+                 "--content-file", str(src), "--request-id", "req-both")
+        check("effect-content-flags-exclusive", r.returncode == 2)
+
+        r = run("status", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--brief")
+        st = json.loads(r.stdout)
+        check("status-brief-shape",
+              set(st) == {"mission_id", "status", "revision", "frontier",
+                          "unresolved_verdicts", "notes_count",
+                          "receipt_ids_count", "written_utc", "written_by"})
+        check("status-brief-revision", st["revision"] == 5)
+
+        # clean resume: stdout stays empty by contract; the summary (with the
+        # vacuous-clean distinction) goes to stderr
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:second")
+        check("resume-clean-summary-on-stderr", "resume: clean" in r.stderr)
+        check("resume-clean-not-vacuous", "vacuously" not in r.stderr)
+        check("resume-clean-stdout-still-empty", r.stdout.strip() == "")
+
+
+def test_resume_vacuous_clean_is_labelled() -> None:
+    """Zero receipts means the drift check verified nothing -- the prior
+    session read exactly this silence as tool breakage, three times."""
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        open_cli(ws, "m-cli-vacuous", "No effects yet.")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:second")
+        check("resume-vacuous-exit-0", r.returncode == 0)
+        check("resume-vacuous-stdout-empty", r.stdout.strip() == "")
+        check("resume-vacuous-labelled", "vacuously" in r.stderr)
+
+
+def test_resume_missing_receipt_via_cli() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        ws = Path(td)
+        open_cli(ws, "m-cli-lostrec", "Guard receipts.")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        run("effect", "--workspace", str(ws), "--actor", "agent:worker",
+            "--path", "notes/a.md", "--content", "hello", "--request-id", "req-1")
+        mission_dir = ws / "missions" / "m-cli-lostrec"
+        for p in (mission_dir / "receipts").glob("*.json"):
+            p.unlink()
+
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:second")
+        check("lostrec-exit-3", r.returncode == 3)
+        check("lostrec-names-request-id", "RECEIPT-MISSING:req-1" in r.stdout)
+
+        r = run("reconcile", "--workspace", str(ws), "--actor", "agent:worker",
+                 "--path", "notes/a.md", "--content", "hello",
+                 "--request-id", "req-1")
+        check("lostrec-reconcile-exit-0", r.returncode == 0)
+        r = run("resume", "--workspace", str(ws), "--actor", "agent:third")
+        check("lostrec-clean-after-reconcile", r.returncode == 0)
+
+
 def test_no_mission_flags_outside_open() -> None:
     tree = ast.parse(CLI.read_text(encoding="utf-8"))
 
@@ -296,6 +398,9 @@ TESTS = [
     test_ascii_safe_drift_and_error_output,
     test_open_stop_rules_and_acceptable_costs,
     test_open_without_stop_rules_yields_empty_lists,
+    test_success_output_confirms_the_write,
+    test_resume_vacuous_clean_is_labelled,
+    test_resume_missing_receipt_via_cli,
     test_no_mission_flags_outside_open,
 ]
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -187,6 +187,75 @@ def test_resume_missing_receipt_is_drift(workspace: Path) -> None:
     check("missing-receipt-clean-after", m.resume() == [])
 
 
+def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
+    """One receipt must not retire two unrelated obligations: clearing a
+    drift marker and an unrelated RECEIPT-MISSING marker together silently
+    dropped the lost receipt's artifact from custody (merge-gate blocker 1)."""
+    m = open_mission(workspace, "m-two-markers", "Keep obligations separate.")
+    m.approve()
+    m.record_effect("notes/a.md", "aa", "req-a")
+    m.record_effect("notes/b.md", "bb", "req-b")
+    (workspace / "notes" / "a.md").write_text("tampered", encoding="utf-8")
+    m.store.receipt_path("req-b").unlink()
+
+    findings = m.resume()
+    check("two-markers-both-reported",
+          findings == ["notes/a.md", "RECEIPT-MISSING:req-b"])
+
+    try:
+        m.reconcile("notes/a.md", "aa", "req-b")
+        check("two-markers-ambiguity-refused", False)
+    except CustodyError:
+        check("two-markers-ambiguity-refused", True)
+
+    m.reconcile("notes/a.md", "aa", "req-c")
+    st = m.status()
+    check("two-markers-drift-cleared-missing-remains",
+          st["state"]["unresolved_verdicts"] == ["RECEIPT-MISSING:req-b"]
+          and st["status"] == "reopened")
+
+    m.reconcile("notes/b.md", "bb", "req-b")
+    check("two-markers-all-cleared", m.status()["status"] == "active")
+
+    # custody of b.md survived: tampering it is still detected
+    (workspace / "notes" / "b.md").write_text("tampered too", encoding="utf-8")
+    check("two-markers-b-still-covered", m.resume() == ["notes/b.md"])
+
+
+def test_corrupt_receipt_degrades_to_drift(workspace: Path) -> None:
+    """A corrupt-but-present receipt must surface as RECEIPT-MISSING drift,
+    not crash resume; and reconcile must re-mint over the stale file instead
+    of wedging on the duplicate refusal (merge-gate blocker 2)."""
+    m = open_mission(workspace, "m-corrupt-receipt", "Survive mangled receipts.")
+    m.approve()
+    m.record_effect("notes/a.md", "hello", "req-1")
+    m.store.receipt_path("req-1").write_text("{not json", encoding="utf-8")
+
+    findings = m.resume()
+    check("corrupt-receipt-is-drift", findings == ["RECEIPT-MISSING:req-1"])
+
+    m.reconcile("notes/a.md", "hello", "req-1")
+    st = m.status()
+    check("corrupt-receipt-reminted", st["status"] == "active")
+    check("corrupt-receipt-clean-after", m.resume() == [])
+
+
+def test_effect_duplicate_id_leaves_workspace_untouched(workspace: Path) -> None:
+    """Idempotency refusal must fire BEFORE the workspace mutates."""
+    m = open_mission(workspace, "m-dup-effect", "Refuse before writing.")
+    m.approve()
+    m.record_effect("notes/a.md", "hello", "req-1")
+    try:
+        m.record_effect("notes/b.md", "evil", "req-1")
+        check("dup-effect-refused", False)
+    except CustodyError:
+        check("dup-effect-refused", True)
+    check("dup-effect-no-new-artifact",
+          not (workspace / "notes" / "b.md").exists())
+    check("dup-effect-original-intact",
+          (workspace / "notes" / "a.md").read_text(encoding="utf-8") == "hello")
+
+
 def test_accept_requires_verifying_and_separation(workspace: Path) -> None:
     m = open_mission(workspace, "m-accept", "Finish task.")
     m.approve()
@@ -295,6 +364,9 @@ TESTS = [
     test_instruction_immutable,
     test_manifest_envelope_immutable,
     test_resume_missing_receipt_is_drift,
+    test_reconcile_clears_exactly_one_marker,
+    test_corrupt_receipt_degrades_to_drift,
+    test_effect_duplicate_id_leaves_workspace_untouched,
     test_accept_requires_verifying_and_separation,
     test_fail_is_clearable,
     test_operator_tier,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -162,7 +162,9 @@ def test_manifest_envelope_immutable(workspace: Path) -> None:
 def test_resume_missing_receipt_is_drift(workspace: Path) -> None:
     """A receipt file that cannot be loaded is drift, not a silent skip: the
     artifact it covered can no longer be verified (probe P5 reported a false
-    'clean' after deleting receipts/)."""
+    'clean' after deleting receipts/). The lost receipt's path is unknowable,
+    so the ONLY exit is acknowledge_receipt_loss -- never a re-mint that
+    binds the id to a caller-chosen path (round-2 finding A: forgery)."""
     m = open_mission(workspace, "m-receiptless", "Guard the receipts.")
     m.approve()
     m.record_effect("notes/a.md", "hello", "req-1")
@@ -176,21 +178,70 @@ def test_resume_missing_receipt_is_drift(workspace: Path) -> None:
     check("missing-receipt-marker-present",
           "RECEIPT-MISSING:req-1" in st["state"]["unresolved_verdicts"])
 
-    # reconcile re-mints the lost receipt under the same request id
-    m.reconcile("notes/a.md", "hello", "req-1")
+    # the forgery channel is closed: reconcile cannot bind the lost id (or
+    # any fresh id) to a decoy path with no drift marker of its own
+    try:
+        m.reconcile("notes/decoy.md", "harmless decoy", "req-1")
+        check("missing-receipt-forgery-refused", False)
+    except CustodyError:
+        check("missing-receipt-forgery-refused", True)
+    check("missing-receipt-decoy-not-written",
+          not (workspace / "notes" / "decoy.md").exists())
+
+    rev = m.acknowledge_receipt_loss("req-1")
     st2 = m.status()
+    check("missing-receipt-ack-revision", st2["revision"] == rev)
     check("missing-receipt-marker-cleared",
           "RECEIPT-MISSING:req-1" not in st2["state"]["unresolved_verdicts"])
     check("missing-receipt-status-active", st2["status"] == "active")
-    check("missing-receipt-no-duplicate-id",
-          st2["receipt_ids"].count("req-1") == 1)
-    check("missing-receipt-clean-after", m.resume() == [])
+    check("missing-receipt-id-retired", "req-1" not in st2["receipt_ids"])
+    check("missing-receipt-loss-recorded-in-notes",
+          any("receipt loss acknowledged: req-1" in n
+              for n in st2["state"]["notes"]))
+
+    # ongoing coverage is re-established honestly, as a NEW event
+    m.record_effect("notes/a.md", "hello", "req-1b")
+    check("missing-receipt-clean-after-recover", m.resume() == [])
+    (workspace / "notes" / "a.md").write_text("tampered", encoding="utf-8")
+    check("missing-receipt-recovered-coverage-live",
+          m.resume() == ["notes/a.md"])
+
+
+def test_restored_receipt_survives_acknowledge(workspace: Path) -> None:
+    """Round-2 finding B: a receipt restored between detection and recovery
+    must NOT be destroyed, and the live artifact must NOT be overwritten --
+    the stale marker clears and coverage simply continues."""
+    m = open_mission(workspace, "m-restored", "Never destroy a healthy receipt.")
+    m.approve()
+    m.record_effect("notes/a.md", "correct content", "req-1")
+    original_receipt = m.store.receipt_path("req-1").read_text(encoding="utf-8")
+    m.store.receipt_path("req-1").unlink()
+    m.resume()  # marker recorded
+
+    # a second session / backup restores the receipt intact
+    m.store.receipt_path("req-1").write_text(original_receipt, encoding="utf-8")
+
+    m.acknowledge_receipt_loss("req-1")
+    st = m.status()
+    check("restored-receipt-marker-cleared",
+          "RECEIPT-MISSING:req-1" not in st["state"]["unresolved_verdicts"])
+    check("restored-receipt-status-active", st["status"] == "active")
+    check("restored-receipt-id-kept", "req-1" in st["receipt_ids"])
+    check("restored-receipt-file-intact",
+          m.store.receipt_path("req-1").read_text(encoding="utf-8")
+          == original_receipt)
+    check("restored-artifact-untouched",
+          (workspace / "notes" / "a.md").read_text(encoding="utf-8")
+          == "correct content")
+    check("restored-coverage-continues", m.resume() == [])
+    (workspace / "notes" / "a.md").write_text("tampered", encoding="utf-8")
+    check("restored-coverage-detects-drift", m.resume() == ["notes/a.md"])
 
 
 def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
-    """One receipt must not retire two unrelated obligations: clearing a
-    drift marker and an unrelated RECEIPT-MISSING marker together silently
-    dropped the lost receipt's artifact from custody (merge-gate blocker 1)."""
+    """One receipt must not retire two unrelated obligations (merge-gate
+    blocker 1): drift clears through reconcile with a FRESH id; the loss
+    marker only through acknowledge_receipt_loss."""
     m = open_mission(workspace, "m-two-markers", "Keep obligations separate.")
     m.approve()
     m.record_effect("notes/a.md", "aa", "req-a")
@@ -202,11 +253,12 @@ def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
     check("two-markers-both-reported",
           findings == ["notes/a.md", "RECEIPT-MISSING:req-b"])
 
+    # a lost id cannot piggyback on a real drift reconciliation
     try:
         m.reconcile("notes/a.md", "aa", "req-b")
-        check("two-markers-ambiguity-refused", False)
+        check("two-markers-lost-id-refused", False)
     except CustodyError:
-        check("two-markers-ambiguity-refused", True)
+        check("two-markers-lost-id-refused", True)
 
     m.reconcile("notes/a.md", "aa", "req-c")
     st = m.status()
@@ -214,18 +266,19 @@ def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
           st["state"]["unresolved_verdicts"] == ["RECEIPT-MISSING:req-b"]
           and st["status"] == "reopened")
 
-    m.reconcile("notes/b.md", "bb", "req-b")
+    m.acknowledge_receipt_loss("req-b")
     check("two-markers-all-cleared", m.status()["status"] == "active")
 
-    # custody of b.md survived: tampering it is still detected
+    # b.md's coverage is re-established as a new event, then verified live
+    m.record_effect("notes/b.md", "bb", "req-b2")
     (workspace / "notes" / "b.md").write_text("tampered too", encoding="utf-8")
-    check("two-markers-b-still-covered", m.resume() == ["notes/b.md"])
+    check("two-markers-b-recovered-coverage", m.resume() == ["notes/b.md"])
 
 
 def test_corrupt_receipt_degrades_to_drift(workspace: Path) -> None:
     """A corrupt-but-present receipt must surface as RECEIPT-MISSING drift,
-    not crash resume; and reconcile must re-mint over the stale file instead
-    of wedging on the duplicate refusal (merge-gate blocker 2)."""
+    not crash resume (merge-gate blocker 2); acknowledging the loss never
+    deletes the corrupt file (forensic evidence) and never wedges."""
     m = open_mission(workspace, "m-corrupt-receipt", "Survive mangled receipts.")
     m.approve()
     m.record_effect("notes/a.md", "hello", "req-1")
@@ -234,9 +287,13 @@ def test_corrupt_receipt_degrades_to_drift(workspace: Path) -> None:
     findings = m.resume()
     check("corrupt-receipt-is-drift", findings == ["RECEIPT-MISSING:req-1"])
 
-    m.reconcile("notes/a.md", "hello", "req-1")
+    m.acknowledge_receipt_loss("req-1")
     st = m.status()
-    check("corrupt-receipt-reminted", st["status"] == "active")
+    check("corrupt-receipt-acknowledged", st["status"] == "active")
+    check("corrupt-receipt-id-retired", "req-1" not in st["receipt_ids"])
+    check("corrupt-receipt-file-preserved",
+          m.store.receipt_path("req-1").read_text(encoding="utf-8")
+          == "{not json")
     check("corrupt-receipt-clean-after", m.resume() == [])
 
 
@@ -364,6 +421,7 @@ TESTS = [
     test_instruction_immutable,
     test_manifest_envelope_immutable,
     test_resume_missing_receipt_is_drift,
+    test_restored_receipt_survives_acknowledge,
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -138,6 +138,55 @@ def test_instruction_immutable(workspace: Path) -> None:
         check("instruction-tamper-detected", True)
 
 
+def test_manifest_envelope_immutable(workspace: Path) -> None:
+    """Tail-checkpoint tamper of ANY manifest field must be caught, not just
+    the instruction: scope, stop_rules, and acceptance.required_tier were
+    silently editable (probe P4, efficacy evaluation 2026-08-12), enabling a
+    tier downgrade followed by self-acceptance."""
+    m = open_mission(workspace, "m-envelope", "Keep the envelope stable.")
+    m.approve()
+    r2_path = m.store.checkpoints_dir / "r00000002.json"
+    tampered = json.loads(r2_path.read_text(encoding="utf-8"))
+    tampered["manifest"]["stop_rules"]["hold_if"] = []
+    tampered["manifest"]["acceptance"]["required_tier"] = "declared-role-separation"
+    tampered["manifest"]["authority"]["permissions"] = ["do anything"]
+    r2_path.write_text(json.dumps(tampered, indent=1, sort_keys=True) + "\n",
+                        encoding="utf-8")
+    try:
+        m.note("carry on")
+        check("envelope-tamper-detected", False)
+    except CustodyError:
+        check("envelope-tamper-detected", True)
+
+
+def test_resume_missing_receipt_is_drift(workspace: Path) -> None:
+    """A receipt file that cannot be loaded is drift, not a silent skip: the
+    artifact it covered can no longer be verified (probe P5 reported a false
+    'clean' after deleting receipts/)."""
+    m = open_mission(workspace, "m-receiptless", "Guard the receipts.")
+    m.approve()
+    m.record_effect("notes/a.md", "hello", "req-1")
+    for p in m.store.receipts_dir.glob("*.json"):
+        p.unlink()
+
+    findings = m.resume()
+    check("missing-receipt-reported", findings == ["RECEIPT-MISSING:req-1"])
+    st = m.status()
+    check("missing-receipt-status-reopened", st["status"] == "reopened")
+    check("missing-receipt-marker-present",
+          "RECEIPT-MISSING:req-1" in st["state"]["unresolved_verdicts"])
+
+    # reconcile re-mints the lost receipt under the same request id
+    m.reconcile("notes/a.md", "hello", "req-1")
+    st2 = m.status()
+    check("missing-receipt-marker-cleared",
+          "RECEIPT-MISSING:req-1" not in st2["state"]["unresolved_verdicts"])
+    check("missing-receipt-status-active", st2["status"] == "active")
+    check("missing-receipt-no-duplicate-id",
+          st2["receipt_ids"].count("req-1") == 1)
+    check("missing-receipt-clean-after", m.resume() == [])
+
+
 def test_accept_requires_verifying_and_separation(workspace: Path) -> None:
     m = open_mission(workspace, "m-accept", "Finish task.")
     m.approve()
@@ -158,9 +207,30 @@ def test_accept_requires_verifying_and_separation(workspace: Path) -> None:
     except AcceptanceRefused:
         check("accept-refuses-self-cert", True)
 
-    m.record_verdict("PASS", acceptor_id="agent:acceptor",
-                      assurance_tier="declared-role-separation",
-                      reason="separately reviewed")
+    # the worker session naming somebody else as acceptor is a fabricated
+    # verdict, not role separation: the acting actor must BE the acceptor
+    try:
+        m.record_verdict("PASS", acceptor_id="agent:acceptor",
+                          assurance_tier="declared-role-separation",
+                          reason="worker speaking for an absent acceptor")
+        check("accept-refuses-fabricated-acceptor", False)
+    except AcceptanceRefused:
+        check("accept-refuses-fabricated-acceptor", True)
+
+    # a case variant of the worker is still the worker
+    acc_case = Mission.load(workspace, actor="Agent:Worker")
+    try:
+        acc_case.record_verdict("PASS", acceptor_id="Agent:Worker",
+                                 assurance_tier="declared-role-separation",
+                                 reason="worker in a different capitalization")
+        check("accept-refuses-case-variant-self-cert", False)
+    except AcceptanceRefused:
+        check("accept-refuses-case-variant-self-cert", True)
+
+    acceptor = Mission.load(workspace, actor="agent:acceptor")
+    acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                             assurance_tier="declared-role-separation",
+                             reason="separately reviewed")
     st = m.status()
     check("accept-pass-completes", st["status"] == "completed")
 
@@ -169,9 +239,10 @@ def test_fail_is_clearable(workspace: Path) -> None:
     m = open_mission(workspace, "m-fail", "Ship safely.")
     m.approve()
     m.begin_verification()
-    m.record_verdict("FAIL", acceptor_id="agent:acceptor",
-                      assurance_tier="declared-role-separation",
-                      reason="missing edge case")
+    acceptor = Mission.load(workspace, actor="agent:acceptor")
+    acceptor.record_verdict("FAIL", acceptor_id="agent:acceptor",
+                             assurance_tier="declared-role-separation",
+                             reason="missing edge case")
     st = m.status()
     check("fail-status-reopened", st["status"] == "reopened")
     check("fail-marker-present",
@@ -185,9 +256,9 @@ def test_fail_is_clearable(workspace: Path) -> None:
     check("fail-status-active-after-clear", st2["status"] == "active")
 
     m.begin_verification()
-    m.record_verdict("PASS", acceptor_id="agent:acceptor",
-                      assurance_tier="declared-role-separation",
-                      reason="fix verified")
+    acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                             assurance_tier="declared-role-separation",
+                             reason="fix verified")
     st3 = m.status()
     check("fail-then-pass-completes", st3["status"] == "completed")
 
@@ -197,17 +268,19 @@ def test_operator_tier(workspace: Path) -> None:
                       required_tier="operator-accepted")
     m.approve()
     m.begin_verification()
+    acceptor = Mission.load(workspace, actor="agent:acceptor")
     try:
-        m.record_verdict("PASS", acceptor_id="agent:acceptor",
-                          assurance_tier="declared-role-separation",
-                          reason="peer reviewed")
+        acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                                 assurance_tier="declared-role-separation",
+                                 reason="peer reviewed")
         check("tier-insufficient-refused", False)
     except AcceptanceRefused:
         check("tier-insufficient-refused", True)
 
-    m.record_verdict("PASS", acceptor_id="operator:zach",
-                      assurance_tier="operator-accepted",
-                      reason="operator signed off")
+    operator = Mission.load(workspace, actor="operator:zach")
+    operator.record_verdict("PASS", acceptor_id="operator:zach",
+                             assurance_tier="operator-accepted",
+                             reason="operator signed off")
     st = m.status()
     check("tier-operator-accept-completes", st["status"] == "completed")
 
@@ -220,6 +293,8 @@ TESTS = [
     test_effect_refuses_escape,
     test_resume_detects_drift_and_reconcile_clears,
     test_instruction_immutable,
+    test_manifest_envelope_immutable,
+    test_resume_missing_receipt_is_drift,
     test_accept_requires_verifying_and_separation,
     test_fail_is_clearable,
     test_operator_tier,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -193,14 +193,32 @@ def test_resume_missing_receipt_is_drift(workspace: Path) -> None:
     check("missing-receipt-ack-revision", st2["revision"] == rev)
     check("missing-receipt-marker-cleared",
           "RECEIPT-MISSING:req-1" not in st2["state"]["unresolved_verdicts"])
-    check("missing-receipt-status-active", st2["status"] == "active")
+    # lost coverage is an obligation, not a footnote: the mission stays
+    # reopened naming the artifact that must be re-covered
+    check("missing-receipt-recover-obligation",
+          st2["state"]["unresolved_verdicts"] == ["RECOVER:notes/a.md"]
+          and st2["status"] == "reopened")
     check("missing-receipt-id-retired", "req-1" not in st2["receipt_ids"])
     check("missing-receipt-loss-recorded-in-notes",
           any("receipt loss acknowledged: req-1" in n
+              and "covered notes/a.md" in n
               for n in st2["state"]["notes"]))
 
-    # ongoing coverage is re-established honestly, as a NEW event
+    # a retired id can never be recycled for a different artifact
+    try:
+        m.record_effect("notes/unrelated.md", "other", "req-1")
+        check("retired-id-reuse-refused", False)
+    except CustodyError:
+        check("retired-id-reuse-refused", True)
+    check("retired-id-reuse-no-artifact",
+          not (workspace / "notes" / "unrelated.md").exists())
+
+    # ongoing coverage is re-established honestly, as a NEW event, and doing
+    # so discharges the RECOVER obligation
     m.record_effect("notes/a.md", "hello", "req-1b")
+    st3 = m.status()
+    check("missing-receipt-recover-discharged",
+          st3["state"]["unresolved_verdicts"] == [] and st3["status"] == "active")
     check("missing-receipt-clean-after-recover", m.resume() == [])
     (workspace / "notes" / "a.md").write_text("tampered", encoding="utf-8")
     check("missing-receipt-recovered-coverage-live",
@@ -238,6 +256,45 @@ def test_restored_receipt_survives_acknowledge(workspace: Path) -> None:
     check("restored-coverage-detects-drift", m.resume() == ["notes/a.md"])
 
 
+def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
+    """Round-3 finding: a schema-valid receipt planted at the lost id's path
+    must not buy continuity. The chain records which artifact the id was
+    minted against, so a receipt naming a different path is a different
+    receipt wearing the id's name -- retire, never affirm coverage."""
+    m = open_mission(workspace, "m-forged", "Do not trust a planted receipt.")
+    m.approve()
+    m.record_effect("notes/real-secret.md", "the real secret", "req-9")
+    genuine = json.loads(
+        m.store.receipt_path("req-9").read_text(encoding="utf-8"))
+    m.store.receipt_path("req-9").unlink()
+    m.resume()
+
+    # attacker plants a well-formed receipt for a decoy artifact under the
+    # lost id's content-addressed name
+    (workspace / "decoy.md").write_text("harmless decoy", encoding="utf-8")
+    forged = dict(genuine, artifact_path="decoy.md",
+                  after_sha256=sha256_bytes(b"harmless decoy"))
+    m.store.receipt_path("req-9").write_text(
+        json.dumps(forged, indent=1, sort_keys=True) + "\n", encoding="utf-8")
+
+    m.acknowledge_receipt_loss("req-9")
+    st = m.status()
+    check("forged-receipt-not-affirmed",
+          not any("coverage continues" in n for n in st["state"]["notes"]))
+    check("forged-receipt-id-retired", "req-9" not in st["receipt_ids"])
+    check("forged-receipt-mismatch-recorded",
+          any("NOT trusted" in n and "decoy.md" in n
+              and "notes/real-secret.md" in n for n in st["state"]["notes"]))
+
+    # the decoy never becomes monitored coverage, and the real file's true
+    # state is honestly uncovered rather than falsely reported clean
+    (workspace / "decoy.md").write_text("changed", encoding="utf-8")
+    check("forged-receipt-decoy-not-covered", m.resume() == [])
+    check("forged-receipt-real-file-intact",
+          (workspace / "notes" / "real-secret.md").read_text(encoding="utf-8")
+          == "the real secret")
+
+
 def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
     """One receipt must not retire two unrelated obligations (merge-gate
     blocker 1): drift clears through reconcile with a FRESH id; the loss
@@ -267,10 +324,12 @@ def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
           and st["status"] == "reopened")
 
     m.acknowledge_receipt_loss("req-b")
-    check("two-markers-all-cleared", m.status()["status"] == "active")
+    check("two-markers-loss-becomes-recover-obligation",
+          m.status()["state"]["unresolved_verdicts"] == ["RECOVER:notes/b.md"])
 
     # b.md's coverage is re-established as a new event, then verified live
     m.record_effect("notes/b.md", "bb", "req-b2")
+    check("two-markers-all-cleared", m.status()["status"] == "active")
     (workspace / "notes" / "b.md").write_text("tampered too", encoding="utf-8")
     check("two-markers-b-recovered-coverage", m.resume() == ["notes/b.md"])
 
@@ -289,7 +348,9 @@ def test_corrupt_receipt_degrades_to_drift(workspace: Path) -> None:
 
     m.acknowledge_receipt_loss("req-1")
     st = m.status()
-    check("corrupt-receipt-acknowledged", st["status"] == "active")
+    check("corrupt-receipt-acknowledged",
+          st["state"]["unresolved_verdicts"] == ["RECOVER:notes/a.md"]
+          and st["status"] == "reopened")
     check("corrupt-receipt-id-retired", "req-1" not in st["receipt_ids"])
     check("corrupt-receipt-file-preserved",
           m.store.receipt_path("req-1").read_text(encoding="utf-8")
@@ -422,6 +483,7 @@ TESTS = [
     test_manifest_envelope_immutable,
     test_resume_missing_receipt_is_drift,
     test_restored_receipt_survives_acknowledge,
+    test_forged_restored_receipt_is_not_trusted,
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -200,8 +200,8 @@ def test_resume_missing_receipt_is_drift(workspace: Path) -> None:
           and st2["status"] == "reopened")
     check("missing-receipt-id-retired", "req-1" not in st2["receipt_ids"])
     check("missing-receipt-loss-recorded-in-notes",
-          any("receipt loss acknowledged: req-1" in n
-              and "covered notes/a.md" in n
+          any('receipt loss acknowledged: "req-1"' in n
+              and 'covered "notes/a.md"' in n
               for n in st2["state"]["notes"]))
 
     # a retired id can never be recycled for a different artifact
@@ -254,6 +254,71 @@ def test_restored_receipt_survives_acknowledge(workspace: Path) -> None:
     check("restored-coverage-continues", m.resume() == [])
     (workspace / "notes" / "a.md").write_text("tampered", encoding="utf-8")
     check("restored-coverage-detects-drift", m.resume() == ["notes/a.md"])
+
+
+def test_retirement_survives_hostile_request_ids(workspace: Path) -> None:
+    """Round-4 finding: retirement is carried in the notes, so the id must be
+    encoded unambiguously. Splitting on a delimiter truncated any id holding
+    that delimiter, and the truncated id compared unequal to the real one --
+    silently un-retiring it and letting it be reused for another artifact."""
+    tricky = 'req-1; not-the-real-tail (covered "lie.md")'
+    m = open_mission(workspace, "m-tricky-id", "Encode ids, do not split them.")
+    m.approve()
+    m.record_effect("notes/a.md", "real content", tricky)
+    m.store.receipt_path(tricky).unlink()
+    m.resume()
+    m.acknowledge_receipt_loss(tricky)
+
+    st = m.status()
+    check("tricky-id-retired-exactly",
+          m._retired_receipt_ids(st) == {tricky})
+    try:
+        m.record_effect("notes/hijacked.md", "attacker content", tricky)
+        check("tricky-id-reuse-refused", False)
+    except CustodyError:
+        check("tricky-id-reuse-refused", True)
+    check("tricky-id-no-hijacked-artifact",
+          not (workspace / "notes" / "hijacked.md").exists())
+
+
+def test_note_cannot_forge_machine_state(workspace: Path) -> None:
+    """Round-4 finding (d): narrative must not be able to imitate the notes
+    the machine writes -- a hand-written 'retirement' could otherwise deny an
+    id that was never lost, or dress up a fabricated effect."""
+    m = open_mission(workspace, "m-note-forge", "Narrative is not state.")
+    m.approve()
+    for forgery in ('receipt loss acknowledged: "never-lost" (covered "x.md"); ',
+                     "effect: notes/never-written.md",
+                     "reconciled: notes/never-drifted.md",
+                     "drift detected: notes/a.md",
+                     "receipt restored: req-x; coverage continues"):
+        try:
+            m.note(forgery)
+            check(f"note-forgery-refused[{forgery[:20]}]", False)
+        except CustodyError:
+            check(f"note-forgery-refused[{forgery[:20]}]", True)
+
+    # the id a forged retirement tried to poison is still usable
+    m.record_effect("notes/legit.md", "legit", "never-lost")
+    check("note-forgery-id-still-usable",
+          "never-lost" in m.status()["receipt_ids"])
+
+
+def test_receipt_ids_always_carry_a_derivable_path(workspace: Path) -> None:
+    """Pins the note-format contract _historical_effect_path depends on:
+    EVERY revision that adds an id to receipt_ids must append a note the
+    lookup can parse. If a future code path adds an id without one, the
+    recorded path becomes underivable and loss recovery degrades silently."""
+    m = open_mission(workspace, "m-note-contract", "Pin the note contract.")
+    m.approve()
+    m.record_effect("notes/a.md", "aa", "req-effect")
+    (workspace / "notes" / "a.md").write_text("tampered", encoding="utf-8")
+    m.resume()
+    m.reconcile("notes/a.md", "aa", "req-reconciled")
+
+    for request_id in m.status()["receipt_ids"]:
+        check(f"derivable-path[{request_id}]",
+              m._historical_effect_path(request_id) == "notes/a.md")
 
 
 def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
@@ -483,6 +548,9 @@ TESTS = [
     test_manifest_envelope_immutable,
     test_resume_missing_receipt_is_drift,
     test_restored_receipt_survives_acknowledge,
+    test_retirement_survives_hostile_request_ids,
+    test_note_cannot_forge_machine_state,
+    test_receipt_ids_always_carry_a_derivable_path,
     test_forged_restored_receipt_is_not_trusted,
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
@@ -118,6 +118,42 @@ def main() -> int:
               list(Path(td).glob("*.tmp")) == [])
         check("store-clobber-winner-intact", sha256_file(target) == first_sha)
 
+    # the no-hardlink fallback must not strand a partial record at the
+    # canonical name on failure, and a retry must then succeed (merge-gate
+    # blocker 3: partial JSON bricked loading AND blocked every retry with a
+    # misleading concurrent-writer refusal)
+    import custody_store as cs
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "r00000001.json"
+        real_link, real_fsync = cs.os.link, cs.os.fsync
+
+        def no_link(*a, **k):
+            raise OSError("hard links unsupported")
+
+        calls = {"n": 0}
+
+        def flaky_fsync(fd):
+            calls["n"] += 1
+            if calls["n"] == 2:  # 1st = tmp write; 2nd = fallback target
+                raise OSError(28, "No space left on device")
+            return real_fsync(fd)
+
+        cs.os.link, cs.os.fsync = no_link, flaky_fsync
+        try:
+            try:
+                atomic_write_json(target, checkpoint(1, None), exclusive=True)
+                check("fallback-failure-propagates", False)
+            except OSError:
+                check("fallback-failure-propagates", True)
+            check("fallback-no-partial-left", not target.exists())
+            check("fallback-no-tmp-left", list(Path(td).glob("*.tmp")) == [])
+
+            cs.os.fsync = real_fsync  # link still unsupported: retry via fallback
+            atomic_write_json(target, checkpoint(1, None), exclusive=True)
+            check("fallback-retry-succeeds", target.exists())
+        finally:
+            cs.os.link, cs.os.fsync = real_link, real_fsync
+
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_store.py
@@ -101,6 +101,23 @@ def main() -> int:
         except StoreError:
             check("store-refuses-duplicate-receipt", True)
 
+    # two writers racing to the same checkpoint name: exclusive publication
+    # makes the loser fail loudly instead of silently clobbering the winner
+    # (probe P8: last-writer-wins lost a session's checkpoint with no trace)
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "r00000001.json"
+        atomic_write_json(target, checkpoint(1, None), exclusive=True)
+        first_sha = sha256_file(target)
+        try:
+            atomic_write_json(target, checkpoint(1, None, "active"),
+                              exclusive=True)
+            check("store-refuses-checkpoint-clobber", False)
+        except StoreError:
+            check("store-refuses-checkpoint-clobber", True)
+        check("store-clobber-loser-left-no-tmp",
+              list(Path(td).glob("*.tmp")) == [])
+        check("store-clobber-winner-intact", sha256_file(target) == first_sha)
+
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -130,6 +130,11 @@ def test_verdict_self_certification_refused() -> None:
     rec["acceptor_id"] = rec["worker_id"]
     check("verdict-no-self-cert", validate_record(rec) != [])
 
+    # a capitalization variant of the worker is still the worker
+    rec = load("valid-verdict-pass-separated.json")
+    rec["acceptor_id"] = rec["worker_id"].title()
+    check("verdict-no-self-cert-casefold", validate_record(rec) != [])
+
 
 def test_verdict_operator_tier_binds_acceptor() -> None:
     rec = load("valid-verdict-pass-separated.json")

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -231,8 +231,11 @@ def validate_acceptance_verdict(rec: dict) -> list[str]:
              "list of receipt id strings required")
     _require(errors, is_iso_utc(rec["utc"]), "utc", "ISO-8601 Z required")
     if not errors:
-        _require(errors, rec["acceptor_id"] != rec["worker_id"],
-                 "acceptor_id", "self-certification refused (== worker_id)")
+        # Casefolded: "Steward-A" accepting "steward-a" is the same principal
+        # wearing different capitalization, not role separation.
+        _require(errors,
+                 rec["acceptor_id"].casefold() != rec["worker_id"].casefold(),
+                 "acceptor_id", "self-certification refused (== worker_id, casefolded)")
         if rec["assurance_tier"] == "operator-accepted":
             _require(errors, rec["acceptor_id"] == rec["operator_ref"],
                      "acceptor_id",

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -10,25 +10,41 @@ record is the mission's durable state under `missions/<id>/` (mission-custody@1
 records), never the chat.
 
 Custody core: `plugins/epistemic-skills/contracts/mission-custody/custody_cli.py`
-(stdlib; run with `python`). Every mutating call names `--actor` with YOUR
-stable session identity. Exit 2 = refusal (read the stderr class name); exit 3
-on resume = drift found — reconcile before anything else.
+(stdlib; run with `python`). Every subcommand requires `--workspace <repo-root>`
+and `--actor <your stable session identity>`. Success CONFIRMS itself: lifecycle
+mutations print the landed revision, `effect`/`reconcile` print the receipt.
+Exit 2 = usage error (argparse prints usage) or refusal (a CustodyError class
+name on stderr); exit 3 on `resume` = drift found — reconcile before anything
+else.
 
 ## Modes
 
 1. **Open** — capture the operator instruction VERBATIM: `open --mission-id
    <kebab> --instruction <verbatim> --operator <ref> --steward <your actor>
+   --scope-in ... --scope-out ... --permission ... --protected ...
    [--tier declared-role-separation] [--hold-if RULE ...] [--stop-if RULE ...]
-   [--escalate-if RULE ...] [--cost COST ...]`. Then `approve` only after the
-   operator confirms authority (permissions, protected state, stop rules).
-2. **Resume** — `resume` (pathless; never pass a mission path). Treat chat and
-   memory as untrusted until it exits 0. On exit 3: reconcile each named
-   artifact (re-verify against live state first), then continue.
-3. **Advance** — one bounded step inside authority; route every artifact write
-   through `effect`; record `frontier` after material progress.
-4. **Verify / Close** — `verify`, then acceptance by a DIFFERENT actor:
-   a distinct session runs `accept`. Never accept work you performed; the core
-   refuses it (AcceptanceRefused) — do not work around the refusal.
+   [--escalate-if RULE ...] [--cost COST ...]`. An empty authority field is
+   unbounded, not safely defaulted — fill all four envelope flags or `note` why
+   the operator left one empty. Then `approve` only after the operator confirms
+   the whole envelope (scope in/out, permissions, protected state, stop rules).
+2. **Resume** — `resume` (pathless = no mission id or path; `--workspace` is
+   still required). Treat chat and memory as untrusted until it exits 0. It
+   hash-checks ONLY receipted artifacts — with zero receipts a clean exit is
+   vacuous (stderr says so): a statement about your custody, not the tool. On
+   exit 3: reconcile each named artifact (re-verify against live state first),
+   then continue.
+3. **Advance** — one bounded step inside authority. Durable workspace files go
+   through `effect --path <ws-relative> --content-file <file> --request-id <id>`
+   IN PLACE of Write/Edit — effect IS the write: it writes the file and mints
+   the receipt that `resume` drift-checks; a file written any other way is
+   invisible to resume. Non-file effects (API mutations, other repos, remote
+   state) cannot be receipted: `note` them with their verification evidence.
+   Update `frontier` whenever the true next action changes and before session
+   end — it is the next resume's anchor.
+4. **Verify / Close** — `verify`, then acceptance by a DIFFERENT actor: a
+   distinct session runs `accept` as itself (`--actor` must equal
+   `--acceptor`). Never accept work you performed; the core refuses it
+   (AcceptanceRefused) — do not work around the refusal.
 
 ## Boundaries
 
@@ -37,9 +53,10 @@ on resume = drift found — reconcile before anything else.
   load-bearing condition blocks progress (an unverified claim, an unmapped
   territory, an irreversible fork), STATE THE CONDITION and the return point
   (mission id + frontier) and let the surrounding stack answer it.
-- Custody here is convention-held, not mechanically enforced — no enforcement
-  hook exists yet (Stage C is gated on the tracer retro): honestly label it if
-  asked.
+- Custody here is convention-held, not mechanically enforced — the tracer
+  retro (2026-08-11) ruled Stage C teeth IN, tracked as epistemic-skills#117;
+  until that PreToolUse hook ships, honestly label enforcement as
+  convention-held if asked.
 - Degraded modes: core unavailable -> author a markdown mission manifest,
   label it session-bounded; store unwritable -> surface immediately; operator
   revocation -> stop consequential work, surface AUTHORITY_REVOKED.

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -31,8 +31,10 @@ else.
    still required). Treat chat and memory as untrusted until it exits 0. It
    hash-checks ONLY receipted artifacts — with zero receipts a clean exit is
    vacuous (stderr says so): a statement about your custody, not the tool. On
-   exit 3: reconcile each named artifact (re-verify against live state first),
-   then continue.
+   exit 3: reconcile each drifted artifact (re-verify against live state
+   first); a RECEIPT-MISSING finding clears only via `acknowledge-loss` —
+   lost provenance is recorded, never re-minted — then re-cover the artifact
+   with a fresh effect. Then continue.
 3. **Advance** — one bounded step inside authority. Durable workspace files go
    through `effect --path <ws-relative> --content-file <file> --request-id <id>`
    IN PLACE of Write/Edit — effect IS the write: it writes the file and mints


### PR DESCRIPTION
## What

Hardens the mission-custody@1 core, CLI, and manifest skill text against every fixable-in-@1 defect found by the 2026-08-12 manifest-efficacy evaluation (adversarial core review with dynamic probes + 52-checkpoint field audit of `media-library-rebuild` + tracer comparison). The evaluation itself is receipted into the field mission's record (`efficacy-eval-2026-08-12`).

## Why each change (probe → fix → regression test)

| Probe finding | Fix | Test |
|---|---|---|
| P4: tail-checkpoint tamper of scope/stop_rules/`required_tier` undetected (only `instruction` verified) — enables tier-downgrade → self-accept | `_verify_manifest`: full-manifest immutability vs origin | `test_manifest_envelope_immutable` |
| P2: worker completed its own mission via case-variant acceptor (`Steward-A` vs `steward-a`); fabricated absent acceptors also passed | `record_verdict` requires acting actor == acceptor; validator separation check casefolded; new invalid example | `accept-refuses-fabricated-acceptor`, `accept-refuses-case-variant-self-cert`, `verdict-no-self-cert-casefold`, corpus |
| P5: deleting `receipts/` → resume reports clean (false negative in the drift oracle) | unloadable receipt = drift: `RECEIPT-MISSING:<id>` marker, exit 3; `reconcile` re-mints under the same id | `test_resume_missing_receipt_is_drift`, `test_resume_missing_receipt_via_cli` |
| P8: two writers racing to one revision → silent last-writer-wins clobber of a chained record | exclusive checkpoint publication (hardlink / `O_EXCL`), loser fails loudly | `store-refuses-checkpoint-clobber` |
| P9: one corrupt sibling mission dir bricks ALL discovery (uncaught `JSONDecodeError`) | skip-and-warn; skip reasons ride the `NoActiveMission` message | covered via load path |
| P10: case-insensitive FS splits `Doc.md`/`doc.md` into spurious drift | casefolded drift keying on nt | resume path |
| P7: `--content` argv-only → ~32KB WinError-206 ceiling + full quoting exposure (the interface *invited* the shell-escaping failure class that broke 4 verification oracles in the field) | `--content-file` on effect/reconcile, newline translation disabled so receipts hash exact bytes (verified: 100KB CRLF+hostile content byte-identical round-trip) | `effect-content-file-*` |
| P1: mute success path — CLI discards the revision every method returns; got `resume` misread as broken 3× in the field | mutations print the landed revision; effect/reconcile print the receipt; `resume` prints a stderr summary labelling the zero-receipt case **vacuous**; `status --brief` | `test_success_output_confirms_the_write`, `test_resume_vacuous_clean_is_labelled` |

## Skill text (body-only; frontmatter description byte-identical — zero cost on the shared description budget)

Field evidence showed the text *shaped* the failures: every envelope flag the open template showed was populated, every omitted one was empty; `--workspace` appeared nowhere and "pathless" caused 3× false "resume is broken"; `effect`'s one bare imperative carried no consequence statement and went unused for 43/52 checkpoints while un-named `note` was used 33×. The amended text documents `--workspace` + silence semantics, completes the open template with the empty-field rule, states that effect IS the write and unreceipted files are invisible to resume (with the `note` fallback for non-file effects), adds frontier triggers, and updates the Stage-C honesty clause to the tracer retro's actual ruling (#117).

## Verification

All six CI steps green locally (py_compile + 5 suites incl. the three-subprocess kill/resume/repair proof); new smoke: 100KB quoting-hostile CRLF content through `--content-file` round-trips byte-identically and resumes clean.

## Deliberately NOT here

Receipt-hash chaining into checkpoints and a general tail anchor are schema-shaped (@1 validator is exact-field-closed) → #118. Principal binding beyond record coherence needs the harness enforcement boundary → #117 (Stage C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ