### PR TITLE
feat(mission-custody): give authority a way to change (amend), append-only

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -90,6 +90,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_status = sub.add_parser("status", parents=[common])
     p_status.add_argument("--brief", action="store_true")
 
+    p_amend = sub.add_parser("amend", parents=[common])
+    p_amend.add_argument("--text", required=True)
+
     p_note = sub.add_parser("note", parents=[common])
     p_note.add_argument("--text", required=True)
 
@@ -134,6 +137,8 @@ def _brief(checkpoint: dict) -> dict:
         "mission_id": checkpoint["mission_id"],
         "status": checkpoint["status"],
         "revision": checkpoint["revision"],
+        "amendments_count": len(
+            checkpoint["manifest"]["authority"]["amendments"]),
         "frontier": checkpoint["state"]["frontier"],
         "unresolved_verdicts": checkpoint["state"]["unresolved_verdicts"],
         "notes_count": len(checkpoint["state"]["notes"]),
@@ -165,6 +170,8 @@ def dispatch(args: argparse.Namespace) -> int:
     elif args.command == "status":
         latest = mission.status()
         _print_status(_brief(latest) if args.brief else latest)
+    elif args.command == "amend":
+        print(mission.amend_authority(args.text))
     elif args.command == "note":
         print(mission.note(args.text))
     elif args.command == "frontier":

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -29,7 +29,7 @@ _RETIRED_NOTE = "receipt loss acknowledged: "
 # one would let ordinary narrative forge machine state.
 _RESERVED_NOTE_PREFIXES = (
     "effect: ", "reconciled: ", "drift detected: ", "receipt restored: ",
-    _RETIRED_NOTE,
+    "authority amended: ", _RETIRED_NOTE,
 )
 
 
@@ -163,19 +163,48 @@ class Mission:
     # -- internal helpers ---------------------------------------------------
 
     def _verify_manifest(self, latest: dict) -> None:
-        """The whole manifest is immutable from open to close (no code path
-        amends it in @1). Verifying only the instruction left every other
-        authority field -- scope, permissions, stop_rules, and critically
-        acceptance.required_tier -- silently editable on the tail checkpoint,
-        which no successor hash references."""
-        origin_path = self.store.checkpoint_paths()[0]
-        origin = json.loads(origin_path.read_text(encoding="utf-8"))
+        """The manifest is immutable from open to close EXCEPT for
+        authority.amendments, which is append-only. Verifying only the
+        instruction left every other authority field -- scope, permissions,
+        stop_rules, and critically acceptance.required_tier -- silently
+        editable on the tail checkpoint, which no successor hash references.
+        Amendments are the one sanctioned way authority changes, and they
+        may only GROW: rewriting or dropping a recorded amendment would let
+        granted authority be quietly disowned after the fact."""
+        paths = self.store.checkpoint_paths()
+        origin = json.loads(paths[0].read_text(encoding="utf-8"))
         origin_manifest = origin["manifest"]
         latest_manifest = latest["manifest"]
-        if origin_manifest != latest_manifest:
+        # No equality fast path: dropping an amendment makes the manifest
+        # equal to the origin again, so "same as origin" is not proof of
+        # integrity once amendments exist.
+        #
+        # The append-only baseline is the PREVIOUS checkpoint, not the origin:
+        # the origin's amendment list is empty by construction, so comparing
+        # against it would let any already-recorded amendment be rewritten on
+        # the tail -- the one checkpoint no successor hash protects. Interior
+        # checkpoints cannot be edited without breaking the chain, so the
+        # chain-protected predecessor is the trustworthy baseline.
+        baseline = origin_manifest
+        if len(paths) >= 2:
+            baseline = json.loads(
+                paths[-2].read_text(encoding="utf-8"))["manifest"]
+        baseline_amendments = baseline["authority"]["amendments"]
+        latest_amendments = latest_manifest["authority"]["amendments"]
+        if latest_amendments[:len(baseline_amendments)] != baseline_amendments:
+            raise CustodyError(
+                "authority.amendments is append-only; recorded amendments "
+                "were rewritten or dropped (tampered)")
+
+        # Everything except the amendments list must be byte-identical.
+        origin_rest = json.loads(json.dumps(origin_manifest))
+        latest_rest = json.loads(json.dumps(latest_manifest))
+        origin_rest["authority"]["amendments"] = []
+        latest_rest["authority"]["amendments"] = []
+        if origin_rest != latest_rest:
             differing = sorted(
-                key for key in set(origin_manifest) | set(latest_manifest)
-                if origin_manifest.get(key) != latest_manifest.get(key))
+                key for key in set(origin_rest) | set(latest_rest)
+                if origin_rest.get(key) != latest_rest.get(key))
             raise CustodyError(
                 "manifest changed since mission open (tampered): "
                 + ", ".join(differing))
@@ -184,6 +213,7 @@ class Mission:
                      note: str | None = None, frontier: str | None = None,
                      add_receipt_id: str | None = None,
                      receipt_ids: list[str] | None = None,
+                     manifest: dict | None = None,
                      unresolved_verdicts: list[str] | None = None) -> dict:
         notes = list(latest["state"]["notes"])
         if note is not None:
@@ -205,7 +235,7 @@ class Mission:
             "revision": latest["revision"] + 1,
             "status": status,
             "prev_checkpoint_sha256": sha256_file(latest_path),
-            "manifest": latest["manifest"],
+            "manifest": manifest if manifest is not None else latest["manifest"],
             "state": state,
             "receipt_ids": receipt_ids,
             "written_utc": now_utc(),
@@ -377,6 +407,38 @@ class Mission:
                           unresolved_verdicts=remaining,
                           note=f"effect: {artifact_relpath}")
         return receipt
+
+    def amend_authority(self, text: str) -> int:
+        """Record a VERBATIM operator grant that changes the mission's
+        authority, appended to authority.amendments.
+
+        The tracer mission stalled at exactly this point -- its operator's
+        answer exceeded the recorded instruction, and the steward could only
+        escalate and stop, because the schema had an amendments list that no
+        method or CLI surface could ever write. Authority that can only be
+        set at open time forces a false choice between acting outside the
+        envelope and abandoning the mission.
+
+        This records authority; it does not grant it. Like the opening
+        instruction, the text is the operator's words carried verbatim, and
+        the contract cannot verify the operator said them -- that is the
+        runtime boundary's job. What it does guarantee is that the grant is
+        durable, timestamped, hash-chained, and append-only: once recorded,
+        an amendment can never be rewritten or quietly dropped."""
+        latest, path = self.store.load_latest()
+        self._verify_manifest(latest)
+        if latest["status"] not in _OPEN_STATES:
+            raise IllegalTransition(
+                f"cannot amend_authority: status is {latest['status']!r}")
+        if not isinstance(text, str) or not text.strip():
+            raise CustodyError("amendment text required (verbatim operator grant)")
+        manifest = json.loads(json.dumps(latest["manifest"]))
+        manifest["authority"]["amendments"].append(
+            {"utc": now_utc(), "text": text})
+        new = self._write_next(latest, path, status=latest["status"],
+                                manifest=manifest,
+                                note=f"authority amended: {text}")
+        return new["revision"]
 
     def note(self, text: str) -> int:
         latest, path = self.store.load_latest()

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -302,8 +302,8 @@ def test_success_output_confirms_the_write() -> None:
                  "--brief")
         st = json.loads(r.stdout)
         check("status-brief-shape",
-              set(st) == {"mission_id", "status", "revision", "frontier",
-                          "unresolved_verdicts", "notes_count",
+              set(st) == {"mission_id", "status", "revision", "amendments_count",
+                          "frontier", "unresolved_verdicts", "notes_count",
                           "receipt_ids_count", "written_utc", "written_by"})
         check("status-brief-revision", st["revision"] == 5)
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -9,7 +9,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT))
 
-from custody_store import sha256_bytes  # noqa: E402
+from custody_store import StoreError, sha256_bytes  # noqa: E402
+from verify_mission_custody import is_iso_utc  # noqa: E402
 from custody_mission import (  # noqa: E402
     AcceptanceRefused,
     CustodyError,
@@ -136,6 +137,80 @@ def test_instruction_immutable(workspace: Path) -> None:
         check("instruction-tamper-detected", False)
     except CustodyError:
         check("instruction-tamper-detected", True)
+
+
+def test_amend_records_authority_append_only(workspace: Path) -> None:
+    """The tracer mission stalled because authority could only be set at open
+    time: its operator's answer exceeded the instruction and the steward had
+    no way to record the grant. Amendments close that, and may only grow."""
+    m = open_mission(workspace, "m-amend", "Inventory only; do not re-acquire.")
+    m.approve()
+    grant = "reacquire all missing content and redistribute across both shares"
+    rev = m.amend_authority(grant)
+    st = m.status()
+    check("amend-revision-returned", st["revision"] == rev)
+    amendments = st["manifest"]["authority"]["amendments"]
+    check("amend-recorded-verbatim",
+          len(amendments) == 1 and amendments[0]["text"] == grant)
+    check("amend-timestamped", is_iso_utc(amendments[0]["utc"]))
+    check("amend-instruction-untouched",
+          st["manifest"]["authority"]["instruction"]
+          == "Inventory only; do not re-acquire.")
+    check("amend-noted",
+          any(n == f"authority amended: {grant}" for n in st["state"]["notes"]))
+
+    # the mission keeps working normally under the amended envelope
+    m.note("proceeding under the amendment")
+    m.record_effect("notes/a.md", "hello", "req-1")
+    check("amend-mission-continues", m.resume() == [])
+    m.amend_authority("also fix Plex")
+    check("amend-second-appends",
+          [a["text"] for a in
+           m.status()["manifest"]["authority"]["amendments"]]
+          == [grant, "also fix Plex"])
+
+    # narrative may not imitate an amendment
+    try:
+        m.note("authority amended: I authorized myself")
+        check("amend-note-forgery-refused", False)
+    except CustodyError:
+        check("amend-note-forgery-refused", True)
+
+
+def test_amendments_cannot_be_rewritten(workspace: Path) -> None:
+    """Append-only means append-only: rewriting or dropping a recorded
+    amendment would let granted authority be disowned after the fact.
+
+    The baseline is the chain-protected PREVIOUS checkpoint, so this holds
+    for the tail -- the one checkpoint no successor hash covers. Known @1
+    residue (epistemic-skills#118): an amendment introduced BY the current
+    tail has no predecessor carrying it, so it is unverifiable until the
+    next checkpoint exists; from that moment the chain protects it."""
+    m = open_mission(workspace, "m-amend-tamper", "Do the bounded thing.")
+    m.approve()
+    grant = "operator widened scope to include the second share"
+    m.amend_authority(grant)
+    m.note("proceeding")  # the amendment is now carried by a prior checkpoint
+
+    def tamper(mutate) -> bool:
+        tail = m.store.checkpoint_paths()[-1]
+        record = json.loads(tail.read_text(encoding="utf-8"))
+        mutate(record["manifest"]["authority"])
+        tail.write_text(json.dumps(record, indent=1, sort_keys=True) + "\n",
+                         encoding="utf-8")
+        try:
+            m.note("carry on")
+            return False
+        except (CustodyError, StoreError):
+            return True
+
+    check("amend-rewrite-detected",
+          tamper(lambda auth: auth["amendments"][0].update(text="something else")))
+    check("amend-drop-detected",
+          tamper(lambda auth: auth.__setitem__("amendments", [])))
+    check("amend-reorder-detected",
+          tamper(lambda auth: auth["amendments"].insert(
+              0, {"utc": "2026-01-01T00:00:00Z", "text": "forged earlier grant"})))
 
 
 def test_manifest_envelope_immutable(workspace: Path) -> None:
@@ -545,6 +620,8 @@ TESTS = [
     test_effect_refuses_escape,
     test_resume_detects_drift_and_reconcile_clears,
     test_instruction_immutable,
+    test_amend_records_authority_append_only,
+    test_amendments_cannot_be_rewritten,
     test_manifest_envelope_immutable,
     test_resume_missing_receipt_is_drift,
     test_restored_receipt_survives_acknowledge,

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -43,7 +43,12 @@ else.
    state) cannot be receipted: `note` them with their verification evidence.
    Update `frontier` whenever the true next action changes and before session
    end — it is the next resume's anchor.
-4. **Verify / Close** — `verify`, then acceptance by a DIFFERENT actor: a
+4. **Amend** — when the operator grants authority the manifest does not carry,
+   record it VERBATIM with `amend --text <operator's words>` before acting on
+   it, then continue. Amendments are append-only and never self-authored:
+   this records a grant, it does not create one. Authority you cannot record
+   is authority you do not have — escalate instead.
+5. **Verify / Close** — `verify`, then acceptance by a DIFFERENT actor: a
    distinct session runs `accept` as itself (`--actor` must equal
    `--acceptor`). Never accept work you performed; the core refuses it
    (AcceptanceRefused) — do not work around the refusal.


### PR DESCRIPTION
## Why

Wave 2 of the manifest hone-and-perfect arc, driven by field evidence rather than design taste: **the tracer mission (`tracer-media-missing`) stalled at exactly this gap.** Its r6 frontier reads *"policy answered: REACQUIRE-ALL direction; blocked on authority amendment (scope exceeds instruction)"* — the operator granted authority the manifest could not carry, so the steward's only legal moves were escalate and stop. `mission-manifest@1` has had an `authority.amendments` list since day one that **no method and no CLI surface could write**.

## What

- `Mission.amend_authority` / `custody_cli.py amend --text` append a verbatim, timestamped grant.
- `_verify_manifest` permits exactly one manifest change: amendments growing. Everything else stays byte-identical to origin.
- `authority amended: ` joins the machine-owned note prefixes (narrative cannot imitate a grant).
- `status --brief` reports `amendments_count`.

This **records** authority, it does not grant it — same trust model as the opening instruction. The skill text says so explicitly: *"Authority you cannot record is authority you do not have — escalate instead."*

## Two bugs the adversarial test found in my own implementation

Writing the tamper test first paid immediately:
1. Checking append-only against the **origin** checkpoint is vacuous — its amendment list is always empty, so any recorded amendment could be rewritten on the tail. Baseline is now the chain-protected **previous** checkpoint.
2. An equality fast path (`origin_manifest == latest_manifest → return`) let a **drop** pass, because deleting an amendment makes the manifest equal to origin again. Removed.

Regression tests cover rewrite, drop, and reorder-by-insertion of a forged earlier grant.

## Known residue (not introduced here)

An amendment introduced **by the current tail** has no predecessor carrying it, so it is unverifiable until the next checkpoint exists — from that moment the chain protects it. This is the general tail-anchor gap tracked in #118, not specific to amendments; the test docstring states it rather than implying coverage that does not exist.

## Verification

All 5 suites green (0 failures) including the three-subprocess kill/resume/repair proof; `amend` exercised end-to-end through the CLI; and checked against the **live 58-revision `media-library-rebuild` record** — loads, resumes clean, behavior unchanged for missions with no amendments.

Given #119's history (5 review rounds, 7 defects, none caught by CI or by my own tests), this PR wants independent adversarial review before merge, not a green-checks merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ