### PR TITLE
fix(mission-custody): match obligations by artifact identity, not by string (audit blocker)

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -66,6 +66,8 @@ def _normalize_relpath(path: str) -> str:
     norm = path.replace("\\", "/")
     while "//" in norm:
         norm = norm.replace("//", "/")
+    while "/./" in norm:
+        norm = norm.replace("/./", "/")
     while norm.startswith("./"):
         norm = norm[2:]
     return norm.rstrip("/") or norm
@@ -622,6 +624,13 @@ class Mission:
 
         receipt = self._load_receipt(request_id)  # already request_id-checked
         recorded_path = self._historical_effect_path(request_id)
+        # Deliberately raw equality, NOT _same_artifact: everywhere else the
+        # question is "does this write satisfy that obligation", where two
+        # spellings of one file must match. Here the question is "is this the
+        # receipt the chain recorded", and a receipt that reappears respelled
+        # is not provably the original -- the safe answer is to retire the id
+        # and let a fresh effect re-establish coverage honestly. Strictness
+        # here is intentional, not an oversight.
         if receipt is not None and recorded_path is not None \
                 and receipt["artifact_path"] == recorded_path:
             new = self._write_next(

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -41,6 +41,29 @@ def _tier_meets(actual: str, required: str) -> bool:
     return _TIER_RANK[actual] >= _TIER_RANK[required]
 
 
+def _same_artifact(left: str, right: str) -> bool:
+    """Do two workspace-relative paths name the same artifact on THIS
+    platform? resume() already casefolds its drift keys on Windows; the
+    obligation markers must use the identical rule or an obligation raised
+    under one casing can never be discharged under another -- and since
+    both name one physical file, that is a mission that can never close."""
+    left = left.replace("\\", "/")
+    right = right.replace("\\", "/")
+    if os.name == "nt":
+        return left.casefold() == right.casefold()
+    return left == right
+
+
+def _find_marker(unresolved: list[str], prefix: str, artifact_relpath: str) -> str | None:
+    """The marker in `unresolved` naming this artifact, or None. Matching is
+    by artifact identity, never by string equality of the whole marker."""
+    for marker in unresolved:
+        if marker.startswith(prefix) and _same_artifact(
+                marker[len(prefix):], artifact_relpath):
+            return marker
+    return None
+
+
 class CustodyError(Exception):
     pass
 
@@ -366,10 +389,10 @@ class Mission:
         # A fresh effect on an artifact awaiting re-coverage discharges that
         # obligation -- that is exactly what RECOVER asks for.
         unresolved = latest["state"]["unresolved_verdicts"]
-        recover = f"RECOVER:{artifact_relpath.replace(chr(92), '/')}"
         status = latest["status"]
         remaining = None
-        if recover in unresolved:
+        recover = _find_marker(unresolved, "RECOVER:", artifact_relpath)
+        if recover is not None:
             remaining = [m for m in unresolved if m != recover]
             if status == "reopened" and not remaining:
                 status = "active"
@@ -461,8 +484,8 @@ class Mission:
         # to a caller-chosen path is a forgery channel (merge-gate round 2,
         # finding A): acknowledge_receipt_loss is the only exit for
         # RECEIPT-MISSING markers, and it destroys nothing.
-        marker = f"RECONCILIATION:{norm}"
-        if marker not in unresolved:
+        marker = _find_marker(unresolved, "RECONCILIATION:", norm)
+        if marker is None:
             raise CustodyError(f"no reconciliation marker for {artifact_relpath!r}")
         if f"RECEIPT-MISSING:{request_id}" in unresolved:
             raise CustodyError(
@@ -526,9 +549,8 @@ class Mission:
             # stays reopened, naming the artifact that must be re-covered, so
             # an uncovered artifact can never sit quietly in an active
             # mission just because its receipt was destroyed.
-            recover = f"RECOVER:{recorded_path}"
-            if recover not in remaining:
-                remaining = remaining + [recover]
+            if _find_marker(remaining, "RECOVER:", recorded_path) is None:
+                remaining = remaining + [f"RECOVER:{recorded_path}"]
             next_status = "reopened"
         new = self._write_next(
             latest, path, status=next_status, unresolved_verdicts=remaining,

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -41,16 +41,46 @@ def _tier_meets(actual: str, required: str) -> bool:
     return _TIER_RANK[actual] >= _TIER_RANK[required]
 
 
+def _ascii_case_fold(text: str) -> str:
+    """Fold A-Z only, leaving every other codepoint byte-exact.
+
+    NOT str.casefold(): full Unicode folding performs 1-to-many expansions
+    that NTFS's per-codepoint upcase table does not -- 'strasse.txt' and
+    'strasse.txt' with an eszett casefold equal while coexisting on disk as
+    two independent files (verified on NTFS), and U+212A KELVIN SIGN folds
+    onto 'k'. Under a marker comparison those false positives let a write to
+    one artifact discharge another artifact's obligation, dropping a real
+    file from custody while the mission reads clean.
+
+    The two error directions are not symmetric, so the tie-break is not a
+    close call. Under-matching leaves an obligation outstanding, and the
+    marker names the exact path that discharges it -- visible, recoverable.
+    Over-matching silently retires custody of a file nobody is watching."""
+    return "".join(c.lower() if "A" <= c <= "Z" else c for c in text)
+
+
+def _normalize_relpath(path: str) -> str:
+    """Spelling differences that cannot denote two different files:
+    separator flavor, repeated separators, a leading './', a trailing '/'.
+    ('..' never appears -- _resolve_artifact_path rejects it at the door.)"""
+    norm = path.replace("\\", "/")
+    while "//" in norm:
+        norm = norm.replace("//", "/")
+    while norm.startswith("./"):
+        norm = norm[2:]
+    return norm.rstrip("/") or norm
+
+
 def _same_artifact(left: str, right: str) -> bool:
     """Do two workspace-relative paths name the same artifact on THIS
-    platform? resume() already casefolds its drift keys on Windows; the
-    obligation markers must use the identical rule or an obligation raised
-    under one casing can never be discharged under another -- and since
-    both name one physical file, that is a mission that can never close."""
-    left = left.replace("\\", "/")
-    right = right.replace("\\", "/")
+    platform? Obligation markers must answer this the same way resume()
+    answers it for drift keys, or an obligation raised under one spelling
+    can never be discharged under another -- and since both name one
+    physical file, that is a mission that can never legitimately close."""
+    left = _normalize_relpath(left)
+    right = _normalize_relpath(right)
     if os.name == "nt":
-        return left.casefold() == right.casefold()
+        return _ascii_case_fold(left) == _ascii_case_fold(right)
     return left == right
 
 
@@ -439,12 +469,16 @@ class Mission:
                 if request_id not in missing:
                     missing.append(request_id)
                 continue
+            # Case-insensitive filesystems: Doc.md and doc.md are one
+            # artifact; keying case-sensitively splits them and reports
+            # spurious drift on the superseded casing. Folded ASCII-only --
+            # str.casefold() would map two genuinely distinct files onto one
+            # key here, and the loser would vanish from the drift check
+            # entirely (see _ascii_case_fold).
             key = receipt["artifact_path"]
+            key = _normalize_relpath(key)
             if os.name == "nt":
-                # Case-insensitive filesystems: Doc.md and doc.md are one
-                # artifact; keying case-sensitively splits them and reports
-                # spurious drift on the superseded casing.
-                key = key.casefold()
+                key = _ascii_case_fold(key)
             latest_by_key[key] = receipt
         mismatched: list[str] = []
         for receipt in latest_by_key.values():

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -360,6 +361,57 @@ def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
           == "the real secret")
 
 
+def test_obligations_match_by_artifact_not_by_string(workspace: Path) -> None:
+    """An obligation raised under one spelling of a path must be dischargeable
+    by genuinely covering THAT artifact, however the caller spells it. On a
+    case-insensitive filesystem 'Sub/File.TXT' and 'sub/file.txt' are one
+    physical file; matching markers by raw string equality left a mission
+    permanently unable to close after a legitimate recovery (independent
+    audit of e08a470). resume() already casefolded its drift keys -- the
+    obligation markers had not."""
+    m = open_mission(workspace, "m-case", "Match artifacts, not strings.")
+    m.approve()
+    m.record_effect("Sub/Dir/File.TXT", "original", "req-1")
+    m.store.receipt_path("req-1").unlink()
+    m.resume()
+    m.acknowledge_receipt_loss("req-1")
+    st = m.status()
+    check("case-recover-raised",
+          st["state"]["unresolved_verdicts"] == ["RECOVER:Sub/Dir/File.TXT"])
+
+    variant = "sub/dir/file.txt" if os.name == "nt" else "Sub/Dir/File.TXT"
+    m.record_effect(variant, "recovered", "req-2")
+    st2 = m.status()
+    check("case-recover-discharged",
+          st2["state"]["unresolved_verdicts"] == []
+          and st2["status"] == "active")
+
+    # and the mission can actually reach completion afterwards
+    m.begin_verification()
+    acceptor = Mission.load(workspace, actor="agent:acceptor")
+    acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                             assurance_tier="declared-role-separation",
+                             reason="recovered artifact re-observed")
+    check("case-recover-mission-can-close",
+          m.store.load_latest()[0]["status"] == "completed")
+
+
+def test_drift_marker_matches_by_artifact(workspace: Path) -> None:
+    """Same rule for drift markers: reconcile must find the obligation for
+    the artifact it is covering, not for a byte-identical spelling of it."""
+    m = open_mission(workspace, "m-case-drift", "Drift matches artifacts too.")
+    m.approve()
+    m.record_effect("Notes/A.md", "aa", "req-1")
+    (workspace / "Notes" / "A.md").write_text("tampered", encoding="utf-8")
+    check("case-drift-detected", m.resume() == ["Notes/A.md"])
+
+    variant = "notes/a.md" if os.name == "nt" else "Notes/A.md"
+    m.reconcile(variant, "aa", "req-2")
+    st = m.status()
+    check("case-drift-reconciled",
+          st["state"]["unresolved_verdicts"] == [] and st["status"] == "active")
+
+
 def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
     """One receipt must not retire two unrelated obligations (merge-gate
     blocker 1): drift clears through reconcile with a FRESH id; the loss
@@ -552,6 +604,8 @@ TESTS = [
     test_note_cannot_forge_machine_state,
     test_receipt_ids_always_carry_a_derivable_path,
     test_forged_restored_receipt_is_not_trusted,
+    test_obligations_match_by_artifact_not_by_string,
+    test_drift_marker_matches_by_artifact,
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -453,9 +453,14 @@ def test_distinct_files_never_share_an_obligation(workspace: Path) -> None:
           not _same_artifact("Kelvin.txt", "Kelvin.txt"))
     check("ascii-case-still-same-artifact-on-nt",
           _same_artifact("Sub/File.TXT", "sub/file.txt") == (os.name == "nt"))
-    for spelling in ("./notes/a.md", "notes//a.md", "notes\\a.md"):
+    for spelling in ("./notes/a.md", "notes//a.md", "notes\\a.md",
+                      "notes/./a.md", "./notes/./a.md", "notes/a.md/"):
         check(f"normalized-same-artifact[{spelling}]",
               _same_artifact(spelling, "notes/a.md"))
+    # normalization must not reach past spellings of ONE location
+    for distinct in ("notes/b.md", "other/a.md", "notes/a.md.bak", "a.md"):
+        check(f"normalization-not-overreaching[{distinct}]",
+              not _same_artifact(distinct, "notes/a.md"))
 
     # end to end: covering a different file must not discharge the obligation
     m = open_mission(workspace, "m-distinct", "Distinct files stay distinct.")

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(ROOT))
 
 from custody_store import sha256_bytes  # noqa: E402
 from custody_mission import (  # noqa: E402
+    _same_artifact,
     AcceptanceRefused,
     CustodyError,
     IllegalTransition,
@@ -361,6 +362,56 @@ def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
           == "the real secret")
 
 
+def test_distinct_files_never_share_an_obligation(workspace: Path) -> None:
+    """The inverse risk of case-insensitive matching, and the worse one.
+
+    str.casefold() expands the eszett to 'ss' and folds U+212A onto 'k';
+    NTFS does neither, so those names coexist as separate files on disk
+    (verified). Folding them together let a write to one artifact discharge
+    another's RECOVER obligation -- the real file left uncovered, no receipt
+    naming it, resume clean, and nothing in the record saying so. Silent
+    custody loss is strictly worse than an outstanding obligation, so the
+    fold is ASCII-only and these must NEVER match."""
+    check("eszett-not-same-artifact",
+          not _same_artifact("straße.txt", "strasse.txt"))
+    check("kelvin-not-same-artifact",
+          not _same_artifact("Kelvin.txt", "Kelvin.txt"))
+    check("ascii-case-still-same-artifact-on-nt",
+          _same_artifact("Sub/File.TXT", "sub/file.txt") == (os.name == "nt"))
+    for spelling in ("./notes/a.md", "notes//a.md", "notes\\a.md"):
+        check(f"normalized-same-artifact[{spelling}]",
+              _same_artifact(spelling, "notes/a.md"))
+
+    # end to end: covering a different file must not discharge the obligation
+    m = open_mission(workspace, "m-distinct", "Distinct files stay distinct.")
+    m.approve()
+    m.record_effect("straße.txt", "the real content", "id-true")
+    m.store.receipt_path("id-true").unlink()
+    m.resume()
+    m.acknowledge_receipt_loss("id-true")
+    check("distinct-recover-raised",
+          m.status()["state"]["unresolved_verdicts"]
+          == ["RECOVER:straße.txt"])
+
+    m.record_effect("strasse.txt", "unrelated decoy", "id-decoy")
+    st = m.status()
+    check("distinct-decoy-did-not-discharge",
+          st["state"]["unresolved_verdicts"] == ["RECOVER:straße.txt"]
+          and st["status"] == "reopened")
+    check("distinct-real-file-untouched",
+          (workspace / "straße.txt").read_text(encoding="utf-8")
+          == "the real content")
+
+    # and both files are independently covered once each is genuinely written
+    m.record_effect("straße.txt", "recovered for real", "id-true-2")
+    st2 = m.status()
+    check("distinct-real-recovery-discharges",
+          st2["state"]["unresolved_verdicts"] == [] and st2["status"] == "active")
+    (workspace / "strasse.txt").write_text("tampered", encoding="utf-8")
+    check("distinct-both-files-tracked-separately",
+          m.resume() == ["strasse.txt"])
+
+
 def test_obligations_match_by_artifact_not_by_string(workspace: Path) -> None:
     """An obligation raised under one spelling of a path must be dischargeable
     by genuinely covering THAT artifact, however the caller spells it. On a
@@ -604,6 +655,7 @@ TESTS = [
     test_note_cannot_forge_machine_state,
     test_receipt_ids_always_carry_a_derivable_path,
     test_forged_restored_receipt_is_not_trusted,
+    test_distinct_files_never_share_an_obligation,
     test_obligations_match_by_artifact_not_by_string,
     test_drift_marker_matches_by_artifact,
     test_reconcile_clears_exactly_one_marker,


### PR DESCRIPTION
## The defect (found by independent audit of merged `e08a470`)

A reachable state where a mission can **never legitimately close**.

On a case-insensitive filesystem `Sub/Dir/File.TXT` and `sub/dir/file.txt` are one physical file. Obligation markers were matched by raw string equality, so a `RECOVER:` obligation raised under one spelling could not be discharged by genuinely re-covering the same artifact under another. `begin_verification` then refuses forever — the artifact is really covered, by a real receipt, and the mission still cannot reach PASS. `cancel()` stayed reachable so it was not a total deadlock, but there was no legitimate path to done.

`resume()` had **already** casefolded its drift keys on Windows (`custody_mission.py`, drift-map keying). The obligation markers never got that treatment — an asymmetry inside a single module, and exactly the kind of thing that survives a green suite: zero existing tests combined casing with markers.

## The fix

- `_same_artifact` centralizes platform path-identity (separator normalization + Windows case folding) in **one** place rather than three ad-hoc comparisons.
- `_find_marker` locates the obligation naming an artifact; every marker site — RECOVER discharge, RECOVER dedup on retirement, RECONCILIATION lookup in `reconcile` — now goes through it.

Fixing all three sites rather than only the reported one: the auditor demonstrated RECOVER, but `reconcile`'s `RECONCILIATION:` lookup had the identical bug (a refusal rather than a wedge, since the caller can retry with the original casing — still wrong).

## Verification

All 5 suites green (0 failures). New regression tests carry the audit's repro **through to completion** — acknowledge a loss, re-cover under different casing, `verify`, independent `accept`, mission `completed` — plus the same rule for drift markers. The auditor's own CLI repro now returns the mission to `active` with no outstanding obligations and `begin_verification` succeeds.

## Provenance

Eighth defect found on this contract by adversarial review, and the third that CI was green through. It was found *after* #119 merged on a GO from a five-round reviewer, by a second auditor I kept running past the merge precisely because one clean verdict is not the same as no defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ