### PR TITLE
fix(mission-custody): one artifact, one current receipt (closes #120)

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -522,14 +522,22 @@ class Mission:
         self._verify_manifest(latest)
         if latest["status"] in ("completed", "cancelled"):
             raise IllegalTransition(f"cannot resume: status is {latest['status']!r}")
-        latest_by_key: dict[str, dict] = {}
+        # One artifact, one current receipt: receipt_ids is append-ordered, so
+        # the LAST id covering a path supersedes the earlier ones. Attribution
+        # must not depend on the receipt being loadable, or a lost newest
+        # receipt would let a superseded older one silently become the
+        # authority again -- comparing live content against stale ground truth
+        # and reporting a mismatch that never happened, while the real loss of
+        # the current receipt went unreported.
+        current_by_key: dict[str, tuple[str, dict | None]] = {}
         missing: list[str] = []
         for request_id in latest["receipt_ids"]:
             receipt = self._load_receipt(request_id)
-            if receipt is None:
-                # An unloadable receipt is drift, not a skip: the artifact it
-                # covered can no longer be verified, and silence here is a
-                # false "clean" for exactly the file most likely tampered.
+            rel = (receipt["artifact_path"] if receipt is not None
+                   else self._historical_effect_path(request_id))
+            if rel is None:
+                # Unloadable AND unattributable: it can only be reported as
+                # the lost receipt it is (see _historical_effect_path).
                 if request_id not in missing:
                     missing.append(request_id)
                 continue
@@ -539,13 +547,19 @@ class Mission:
             # str.casefold() would map two genuinely distinct files onto one
             # key here, and the loser would vanish from the drift check
             # entirely (see _ascii_case_fold).
-            key = receipt["artifact_path"]
-            key = _normalize_relpath(key)
+            key = _normalize_relpath(rel)
             if os.name == "nt":
                 key = _ascii_case_fold(key)
-            latest_by_key[key] = receipt
+            current_by_key[key] = (request_id, receipt)
         mismatched: list[str] = []
-        for receipt in latest_by_key.values():
+        for request_id, receipt in current_by_key.values():
+            if receipt is None:
+                # An unloadable receipt is drift, not a skip: the artifact it
+                # covered can no longer be verified, and silence here is a
+                # false "clean" for exactly the file most likely tampered.
+                if request_id not in missing:
+                    missing.append(request_id)
+                continue
             rel = receipt["artifact_path"]
             target = self.workspace / rel
             actual = sha256_file(target) if target.exists() else None

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -543,6 +543,46 @@ def test_drift_marker_matches_by_artifact(workspace: Path) -> None:
           st["state"]["unresolved_verdicts"] == [] and st["status"] == "active")
 
 
+def test_superseded_receipt_never_shadows_the_current_one(workspace: Path) -> None:
+    """One artifact, one current receipt. receipt_ids is append-ordered, so
+    the last id covering a path supersedes the earlier ones -- and that
+    attribution must not depend on the current receipt still being loadable.
+    Otherwise a lost newest receipt silently promotes a superseded older one
+    back to authority: resume compares live content against stale ground
+    truth, reports a mismatch that never happened, and says nothing about
+    the receipt that actually went missing. Converged on independently by
+    both reviewers of PR #119 (epistemic-skills#120)."""
+    m = open_mission(workspace, "m-supersede", "One artifact, one receipt.")
+    m.approve()
+    m.record_effect("notes/a.md", "v1", "req-1")
+    (workspace / "notes" / "a.md").write_text("tampered", encoding="utf-8")
+    check("supersede-drift-detected", m.resume() == ["notes/a.md"])
+
+    m.reconcile("notes/a.md", "v2", "req-2")
+    check("supersede-reconciled", m.status()["status"] == "active")
+    check("supersede-both-ids-retained",
+          m.status()["receipt_ids"] == ["req-1", "req-2"])
+
+    # the CURRENT receipt is lost; the superseded one must not stand in
+    m.store.receipt_path("req-2").unlink()
+    findings = m.resume()
+    check("supersede-only-real-finding",
+          findings == ["RECEIPT-MISSING:req-2"])
+    check("supersede-no-phantom-drift",
+          "notes/a.md" not in findings)
+    st = m.status()
+    check("supersede-no-phantom-marker",
+          st["state"]["unresolved_verdicts"] == ["RECEIPT-MISSING:req-2"])
+
+    # and the honest recovery path still works from there
+    m.acknowledge_receipt_loss("req-2")
+    check("supersede-recover-obligation",
+          m.status()["state"]["unresolved_verdicts"] == ["RECOVER:notes/a.md"])
+    m.record_effect("notes/a.md", "v3", "req-3")
+    check("supersede-recovered-clean",
+          m.status()["status"] == "active" and m.resume() == [])
+
+
 def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
     """One receipt must not retire two unrelated obligations (merge-gate
     blocker 1): drift clears through reconcile with a FRESH id; the loss
@@ -740,6 +780,7 @@ TESTS = [
     test_distinct_files_never_share_an_obligation,
     test_obligations_match_by_artifact_not_by_string,
     test_drift_marker_matches_by_artifact,
+    test_superseded_receipt_never_shadows_the_current_one,
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,


### PR DESCRIPTION
Closes #120.

## The defect

Both independent reviewers of #119 converged on this from different angles, which is why it went to the front of the wave-2 queue: it is a defect in the drift oracle itself, and the drift oracle is custody's only real teeth.

`reconcile()` mints a new receipt for a path without retiring the old one, and `resume()`'s per-path keying only considered **loadable** receipts. So when the current receipt was lost, the superseded older one silently became the authority again. Two wrong answers from one gap:

1. a **phantom drift finding** — live content compared against stale ground truth, reporting a mismatch that never happened; and
2. **silence about the real loss** — the receipt that actually went missing was never reported.

## The fix

Attribute every receipt id to an artifact **before** deciding anything: from the receipt when it loads, and from the hash-chained `effect:` note via `_historical_effect_path` when it does not. `receipt_ids` is append-ordered, so the last id covering a path is the current one — and a superseded receipt is never consulted again, loadable or not.

`receipt_ids` deliberately keeps every id. Supersession is about which receipt speaks for an artifact *now*, not about erasing that an earlier one existed.

Note this reuses the chain-lookup built in #119 for a second purpose. That machinery exists because a reviewer refuted my claim that a lost receipt's path was unknowable — it is recorded in the chain. That correction keeps paying.

## Verification

All 5 suites green. The regression test walks the exact reported sequence and then **continues through the honest recovery path** (acknowledge the loss → re-cover → clean), so it proves the fix leaves the mission in a working state rather than merely suppressing the phantom finding.

Wants independent adversarial review before merge, per the pattern that found 9 defects on this contract — 3 of them on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ