### PR TITLE
feat(mission-custody): receipt continuity — surface the gap drift cannot see

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -90,6 +90,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_status = sub.add_parser("status", parents=[common])
     p_status.add_argument("--brief", action="store_true")
 
+    sub.add_parser("audit", parents=[common])
+
     p_amend = sub.add_parser("amend", parents=[common])
     p_amend.add_argument("--text", required=True)
 
@@ -170,6 +172,11 @@ def dispatch(args: argparse.Namespace) -> int:
     elif args.command == "status":
         latest = mission.status()
         _print_status(_brief(latest) if args.brief else latest)
+    elif args.command == "audit":
+        breaks = mission.continuity_breaks()
+        _print_status({"record": "continuity-report@1",
+                        "continuity_breaks": breaks})
+        return 3 if breaks else 0
     elif args.command == "amend":
         print(mission.amend_authority(args.text))
     elif args.command == "note":
@@ -189,6 +196,17 @@ def dispatch(args: argparse.Namespace) -> int:
             vacuous = " -- vacuously (no effects recorded)" if n == 0 else ""
             print(f"resume: clean; {n} receipt id(s) on record{vacuous}",
                   file=sys.stderr)
+        # A continuity break is not drift and raises no obligation, but a
+        # clean resume is exactly where its absence would be misread as
+        # "nothing happened here" -- so it rides alongside the verdict.
+        unanswered = [b for b in mission.continuity_breaks()
+                      if not b["already_reconciled"]]
+        if unanswered:
+            paths = ", ".join(sorted({b["artifact_path"] for b in unanswered}))
+            print(f"resume: {len(unanswered)} unreconciled continuity "
+                  f"break(s) -- the artifact changed between receipted events "
+                  f"with no reconciliation answering for it: {paths}; run "
+                  "`audit` for detail", file=sys.stderr)
         return 3 if drift else 0
     elif args.command == "reconcile":
         receipt = mission.reconcile(args.path, _read_content(args),

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -330,6 +330,15 @@ class Mission:
             raise CustodyError(
                 f"request_id {request_id!r} was retired by an acknowledged "
                 "receipt loss and can never be reused -- use a fresh id")
+        if request_id in set(self._all_receipt_ids_ever()):
+            # An id whose receipt file merely vanished is NOT free for reuse
+            # either: the chain still remembers what it was minted against,
+            # and rebinding it silently backdates the new write to the old
+            # event -- which made a legitimate reconciliation read as
+            # unreconciled (merge-gate review of #125).
+            raise CustodyError(
+                f"request_id {request_id!r} is already recorded in this "
+                "mission's history and can never be reused -- use a fresh id")
         target = self._resolve_artifact_path(artifact_relpath)
         before_sha = sha256_file(target) if target.exists() else None
         data = content.encode("utf-8")
@@ -394,6 +403,21 @@ class Mission:
                 return None
             prev_ids, prev_notes = ids, notes
         return None
+
+    def _all_receipt_ids_ever(self) -> list[str]:
+        """Every request id ever admitted to receipt_ids, in the order the
+        chain admitted it -- including ids since retired, which the current
+        list no longer carries. The chain is the only place the full order
+        survives."""
+        seen: list[str] = []
+        known: set[str] = set()
+        for cp_path in self.store.checkpoint_paths():
+            record = json.loads(cp_path.read_text(encoding="utf-8"))
+            for request_id in record["receipt_ids"]:
+                if request_id not in known:
+                    known.add(request_id)
+                    seen.append(request_id)
+        return seen
 
     def _retired_receipt_ids(self, latest: dict) -> set[str]:
         """Ids whose loss was acknowledged. Retirement is permanent and lives
@@ -539,18 +563,34 @@ class Mission:
         discharged, so making it an obligation would create a marker with no
         exit -- the wedge RECOVER-UNKNOWN was rejected for. Surfaced, not
         enforced."""
-        by_path: dict[str, list[dict]] = {}
-        for request_id in self.status()["receipt_ids"]:
+        # Order comes from the CHAIN, not from the current receipt_ids list.
+        # Retirement removes a lost id from that list, so zipping survivors
+        # would compare two receipts that were never adjacent -- inventing a
+        # break across the gap where the retired one honestly sat. That fires
+        # on the ordinary sanctioned recovery flow, which would train stewards
+        # to ignore the signal on day one.
+        by_path: dict[str, list[str]] = {}
+        for request_id in self._all_receipt_ids_ever():
             receipt = self._load_receipt(request_id)
-            if receipt is None:
+            rel = (receipt["artifact_path"] if receipt is not None
+                   else self._historical_effect_path(request_id))
+            if rel is None:
                 continue
-            key = _normalize_relpath(receipt["artifact_path"])
+            key = _normalize_relpath(rel)
             if os.name == "nt":
                 key = _ascii_case_fold(key)
-            by_path.setdefault(key, []).append(receipt)
+            by_path.setdefault(key, []).append(request_id)
         breaks: list[dict] = []
-        for receipts in by_path.values():
-            for prior, nxt in zip(receipts, receipts[1:]):
+        for ids in by_path.values():
+            for prior_id, next_id in zip(ids, ids[1:]):
+                prior = self._load_receipt(prior_id)
+                nxt = self._load_receipt(next_id)
+                if prior is None or nxt is None:
+                    # A gap we cannot read is not evidence of a break. The
+                    # missing receipt is already reported by resume as its own
+                    # finding; claiming a mismatch across it would be asserting
+                    # something this data cannot support.
+                    continue
                 if nxt["before_sha256"] == prior["after_sha256"]:
                     continue
                 # A reconciliation FOLLOWS a mutation that drift detection

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -367,14 +367,18 @@ class Mission:
         # trustworthy source for a claim about that id.
         return record if record.get("request_id") == request_id else None
 
-    def _historical_effect_path(self, request_id: str) -> str | None:
+    def _historical_effect_path(self, request_id: str, kind: bool = False) -> str | None:
         """The artifact path this request id was minted against, read from the
         hash-chained checkpoint history: the effect note appended by the very
         revision that put the id into receipt_ids. A lost receipt's path is
         NOT unknowable -- the chain remembers it, and interior checkpoints are
         tamper-evident, so this is a sounder authority than a receipt file
         anyone able to write the receipts dir could have replaced.
-        None when underivable (treated as unprovable, never as agreement)."""
+        None when underivable (treated as unprovable, never as agreement).
+
+        With kind=True, returns HOW it was minted instead ('effect' or
+        'reconciled') -- the same note that records the path records whether
+        the write was an ordinary effect or a reconciliation."""
         prev_ids: list[str] = []
         prev_notes: list[str] = []
         for cp_path in self.store.checkpoint_paths():
@@ -385,7 +389,8 @@ class Mission:
                 for note in notes[len(prev_notes):]:
                     for prefix in ("effect: ", "reconciled: "):
                         if note.startswith(prefix):
-                            return note[len(prefix):]
+                            return note[len(prefix):] if not kind \
+                                else prefix.rstrip(": ")
                 return None
             prev_ids, prev_notes = ids, notes
         return None
@@ -516,6 +521,55 @@ class Mission:
             raise IllegalTransition(f"cannot set_frontier: status is {latest['status']!r}")
         new = self._write_next(latest, path, status=latest["status"], frontier=text)
         return new["revision"]
+
+    def continuity_breaks(self) -> list[dict]:
+        """Where an artifact changed between two receipted events without a
+        receipted event of its own.
+
+        Each receipt records the artifact's hash BEFORE its write and AFTER.
+        Chained per path those must meet: receipt[n].before_sha256 ==
+        receipt[n-1].after_sha256. A gap is positive evidence of unreceipted
+        mutation -- including the one case drift detection structurally
+        cannot see, where a steward re-effects over a file it never resumed
+        against, so the current receipt truthfully describes content nobody
+        ever sanctioned. The evidence was always in the receipts; nothing
+        read it.
+
+        Read-only, and it raises NOTHING. A break is history: it cannot be
+        discharged, so making it an obligation would create a marker with no
+        exit -- the wedge RECOVER-UNKNOWN was rejected for. Surfaced, not
+        enforced."""
+        by_path: dict[str, list[dict]] = {}
+        for request_id in self.status()["receipt_ids"]:
+            receipt = self._load_receipt(request_id)
+            if receipt is None:
+                continue
+            key = _normalize_relpath(receipt["artifact_path"])
+            if os.name == "nt":
+                key = _ascii_case_fold(key)
+            by_path.setdefault(key, []).append(receipt)
+        breaks: list[dict] = []
+        for receipts in by_path.values():
+            for prior, nxt in zip(receipts, receipts[1:]):
+                if nxt["before_sha256"] == prior["after_sha256"]:
+                    continue
+                # A reconciliation FOLLOWS a mutation that drift detection
+                # already caught and the steward already answered for. The
+                # break is real either way, but only an unreconciled one is
+                # news -- that is the case nothing else in the contract sees.
+                reconciled = self._historical_effect_path(
+                    nxt["request_id"], kind=True) == "reconciled"
+                breaks.append({
+                    "artifact_path": nxt["artifact_path"],
+                    "prior_request_id": prior["request_id"],
+                    "request_id": nxt["request_id"],
+                    "expected_before_sha256": prior["after_sha256"],
+                    "observed_before_sha256": nxt["before_sha256"],
+                    "no_op_write": nxt["before_sha256"] == nxt["after_sha256"],
+                    "already_reconciled": reconciled,
+                })
+        breaks.sort(key=lambda b: (b["artifact_path"], b["request_id"]))
+        return breaks
 
     def resume(self) -> list[str]:
         latest, path = self.store.load_latest()

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -629,6 +629,66 @@ def test_continuity_surfaces_unreceipted_mutation(workspace: Path) -> None:
           and [b for b in breaks if not b["already_reconciled"]] == breaks)
 
 
+def test_continuity_is_silent_on_sanctioned_recovery(workspace: Path) -> None:
+    """The check must not fire on the recovery flow this contract built.
+    Retirement removes the lost id from receipt_ids, so ordering the chain
+    from that list compared two receipts that were never adjacent and
+    invented a break across the gap where the retired one honestly sat --
+    firing on ordinary correct operation, which trains stewards to ignore
+    the signal (merge-gate review of #125). Order comes from the chain."""
+    m = open_mission(workspace, "m-mid-retire", "Silence on correct operation.")
+    m.approve()
+    m.record_effect("P.txt", "v1", "id-A")
+    m.record_effect("P.txt", "v2", "id-B")
+    m.store.receipt_path("id-B").unlink()
+    m.resume()
+    m.acknowledge_receipt_loss("id-B")
+    m.record_effect("P.txt", "v3-recovered", "id-C")
+
+    st = m.status()
+    check("sanctioned-recovery-is-clean",
+          st["state"]["unresolved_verdicts"] == [] and st["status"] == "active")
+    check("sanctioned-recovery-no-phantom-break", m.continuity_breaks() == [])
+
+    # deeper: three receipts, the LAST retired, then recovered
+    m2 = open_mission(workspace, "m-deep-retire", "Deeper chain.")
+    m2.approve()
+    for content, rid in (("v1", "A"), ("v2", "B"), ("v3", "C")):
+        m2.record_effect("Q.txt", content, rid)
+    m2.store.receipt_path("C").unlink()
+    m2.resume()
+    m2.acknowledge_receipt_loss("C")
+    m2.record_effect("Q.txt", "v4", "D")
+    check("deep-recovery-no-phantom-break", m2.continuity_breaks() == [])
+
+    # and the real thing is still caught (a fix that silences everything is
+    # worse than the bug it fixes)
+    (workspace / "Q.txt").write_text("TAMPERED", encoding="utf-8")
+    m2.record_effect("Q.txt", "TAMPERED", "E")
+    real = m2.continuity_breaks()
+    check("real-tampering-still-caught",
+          len(real) == 1 and real[0]["request_id"] == "E"
+          and real[0]["already_reconciled"] is False)
+
+
+def test_request_ids_are_never_reusable(workspace: Path) -> None:
+    """An id whose receipt file merely vanished is not free for reuse: the
+    chain still remembers what it was minted against, so rebinding it
+    backdates the new write to the old event -- which made a legitimate
+    reconciliation read as unreconciled (merge-gate review of #125)."""
+    m = open_mission(workspace, "m-id-reuse", "Ids are spent when used.")
+    m.approve()
+    m.record_effect("x.md", "v1", "dup")
+    m.store.receipt_path("dup").unlink()
+    try:
+        m.record_effect("y.md", "other", "dup")
+        check("id-reuse-refused-after-receipt-vanishes", False)
+    except CustodyError:
+        check("id-reuse-refused-after-receipt-vanishes", True)
+    check("id-reuse-no-artifact-written",
+          not (workspace / "y.md").exists())
+
+
 def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
     """One receipt must not retire two unrelated obligations (merge-gate
     blocker 1): drift clears through reconcile with a FRESH id; the loss
@@ -828,6 +888,8 @@ TESTS = [
     test_drift_marker_matches_by_artifact,
     test_superseded_receipt_never_shadows_the_current_one,
     test_continuity_surfaces_unreceipted_mutation,
+    test_continuity_is_silent_on_sanctioned_recovery,
+    test_request_ids_are_never_reusable,
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -583,6 +583,52 @@ def test_superseded_receipt_never_shadows_the_current_one(workspace: Path) -> No
           m.status()["status"] == "active" and m.resume() == [])
 
 
+def test_continuity_surfaces_unreceipted_mutation(workspace: Path) -> None:
+    """The one custody gap drift detection structurally cannot see: a steward
+    re-effects over a tampered file WITHOUT resuming first, so the current
+    receipt truthfully describes content nobody sanctioned and resume reads
+    clean forever. The evidence was always in the receipts -- each records the
+    artifact hash before and after its own write -- and nothing read it."""
+    m = open_mission(workspace, "m-continuity", "Surface the unseen gap.")
+    m.approve()
+    m.record_effect("notes/a.md", "v1", "req-1")
+    m.record_effect("notes/a.md", "v2", "req-2")
+    check("continuity-clean-chain", m.continuity_breaks() == [])
+
+    (workspace / "notes" / "a.md").write_text("TAMPERED", encoding="utf-8")
+    m.record_effect("notes/a.md", "TAMPERED", "req-3")
+    check("continuity-drift-oracle-blind", m.resume() == [])
+
+    breaks = m.continuity_breaks()
+    check("continuity-break-found", len(breaks) == 1)
+    b = breaks[0]
+    check("continuity-names-artifact", b["artifact_path"] == "notes/a.md")
+    check("continuity-names-both-receipts",
+          b["prior_request_id"] == "req-2" and b["request_id"] == "req-3")
+    check("continuity-flags-no-op-write", b["no_op_write"] is True)
+    check("continuity-raises-no-obligation",
+          m.status()["state"]["unresolved_verdicts"] == []
+          and m.status()["status"] == "active")
+
+    # honest legitimate history stays clean: reconcile after real drift is a
+    # receipted event and must NOT read as a break
+    m2 = open_mission(workspace, "m-continuity-ok", "Legitimate history.")
+    m2.approve()
+    m2.record_effect("notes/b.md", "v1", "r1")
+    (workspace / "notes" / "b.md").write_text("drifted", encoding="utf-8")
+    m2.resume()
+    m2.reconcile("notes/b.md", "v1", "r2")
+    # a reconciliation FOLLOWS a real mutation, so the break is real -- but it
+    # is answered for, and only unanswered breaks are news
+    rec = m2.continuity_breaks()
+    check("continuity-reconcile-break-recorded", len(rec) == 1)
+    check("continuity-reconcile-marked-answered",
+          rec[0]["already_reconciled"] is True)
+    check("continuity-unanswered-only-in-the-blind-case",
+          [b for b in rec if not b["already_reconciled"]] == []
+          and [b for b in breaks if not b["already_reconciled"]] == breaks)
+
+
 def test_reconcile_clears_exactly_one_marker(workspace: Path) -> None:
     """One receipt must not retire two unrelated obligations (merge-gate
     blocker 1): drift clears through reconcile with a FRESH id; the loss
@@ -781,6 +827,7 @@ TESTS = [
     test_obligations_match_by_artifact_not_by_string,
     test_drift_marker_matches_by_artifact,
     test_superseded_receipt_never_shadows_the_current_one,
+    test_continuity_surfaces_unreceipted_mutation,
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -34,7 +34,10 @@ else.
    exit 3: reconcile each drifted artifact (re-verify against live state
    first); a RECEIPT-MISSING finding clears only via `acknowledge-loss` —
    lost provenance is recorded, never re-minted — then re-cover the artifact
-   with a fresh effect. Then continue.
+   with a fresh effect. Then continue. A resume that reports an
+   UNRECONCILED continuity break is telling you an artifact changed between
+   two receipted events with nothing answering for it -- `audit` names the
+   pair; that gap is the one drift detection cannot see.
 3. **Advance** — one bounded step inside authority. Durable workspace files go
    through `effect --path <ws-relative> --content-file <file> --request-id <id>`
    IN PLACE of Write/Edit — effect IS the write: it writes the file and mints


### PR DESCRIPTION
Refs #124 (first half; the tail-anchor residue recorded there stays with #118).

## The gap

`resume()` compares live content against the **current** receipt for a path, which makes it structurally blind to one sequence: a steward re-effects over a tampered file *without resuming first*. The new receipt then truthfully describes content nobody sanctioned, and the mission reads clean forever. No tampering of custody state is involved — it is reachable through ordinary API calls.

Found by the independent auditor of #123, while probing a question I had raised against my own work.

## The insight

The evidence was **already in the receipts and nothing read it.** Every receipt records the artifact's hash before its write and after. Chained per path, those must meet — `receipt[n].before_sha256 == receipt[n-1].after_sha256` — and a gap is positive proof of an unreceipted mutation between two receipted events.

## What landed

- `continuity_breaks()` walks `receipt_ids` per path and reports each break with both receipt ids, expected vs observed hash, whether the write was a **no-op** (re-effecting byte-identical tampered content — itself an odd signal), and whether a reconciliation already answered for it.
- **The reconciled distinction is load-bearing.** A reconciliation *follows* a mutation drift already caught, so those breaks are real but answered; treating them the same as unanswered ones would make every legitimate recovery look like an incident. Only unreconciled breaks are surfaced on `resume`. My first test asserted reconcile produced no break at all — the code was right and the test was wrong, which is what forced the distinction.
- New `audit` subcommand prints the full report; exit 3 when breaks exist.
- `resume` prints one stderr line when unreconciled breaks exist, alongside its existing verdict.

## Deliberately raises no obligation

A continuity break is **history**: it cannot be discharged. A marker for it would have no exit — the same wedge `RECOVER-UNKNOWN` was rejected for earlier in this arc. It is surfaced, not enforced.

## Verification

All 5 suites green. Tests cover the blind case end to end (drift oracle reports clean while continuity reports the break), the no-op flag, that no obligation is raised, and that a legitimate drift→reconcile history is recorded as answered rather than as news.

Wants independent adversarial review, per the pattern that has found 9 defects on this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ