### PR TITLE
docs(mission-custody): name the receipt-visibility asymmetry (refs #124)

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
@@ -11,3 +11,17 @@
   acting outside the mission channel is out of scope and must not be claimed
   as prevented.
 - Receipts are hashed, not signed. No third-party-verifiable claim is made.
+- Receipt visibility is ASYMMETRIC by design, and deleting a receipt file is
+  not equally visible in both cases. Deleting the CURRENT receipt for a path
+  is caught: `resume` reports `RECEIPT-MISSING`. Deleting a SUPERSEDED one is
+  not, and if that superseded receipt was the far side of a continuity break,
+  the break becomes invisible to every reporting surface -- `resume` only
+  consults the current receipt per path, and `continuity_breaks()` will not
+  assert a mismatch across a receipt it cannot load. The alternative
+  (bridging the gap and comparing the surviving neighbours) was constructed
+  and rejected: it reintroduces false positives on the far more common honest
+  history where an intervening write legitimately changed the content and its
+  receipt was later lost. Deleting receipt files requires filesystem access
+  outside the mission channel, which this document already places out of
+  scope; this entry names the asymmetry so it is a known property rather than
+  a rediscovery.

--- a/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
@@ -18,10 +18,14 @@
   the break becomes invisible to every reporting surface -- `resume` only
   consults the current receipt per path, and `continuity_breaks()` will not
   assert a mismatch across a receipt it cannot load. The alternative
-  (bridging the gap and comparing the surviving neighbours) was constructed
-  and rejected: it reintroduces false positives on the far more common honest
-  history where an intervening write legitimately changed the content and its
-  receipt was later lost. Deleting receipt files requires filesystem access
+  (bridging the gap and comparing the surviving neighbours) was rejected on
+  evidence: against an honest history where an intervening write legitimately
+  changed the content and its receipt was later lost, the neighbour-to-
+  neighbour hash comparison such an implementation would perform was computed
+  by hand from the real receipts, and it does not match -- it would report a
+  break that never happened. No bridging code was written and run; that
+  comparison is arithmetic over recorded hashes, which is the whole of what
+  the implementation would do. Deleting receipt files requires filesystem access
   outside the mission channel, which this document already places out of
   scope; this entry names the asymmetry so it is a known property rather than
   a rediscovery.

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -562,7 +562,13 @@ class Mission:
         Read-only, and it raises NOTHING. A break is history: it cannot be
         discharged, so making it an obligation would create a marker with no
         exit -- the wedge RECOVER-UNKNOWN was rejected for. Surfaced, not
-        enforced."""
+        enforced.
+
+        Visibility is asymmetric and SECURITY.md names it: a break whose far
+        receipt was superseded AND then deleted is invisible here, because
+        nothing may be asserted across a receipt that cannot be loaded.
+        Bridging the gap instead would fabricate breaks on honest histories
+        where an intervening write legitimately changed the content."""
         # Order comes from the CHAIN, not from the current receipt_ids list.
         # Retirement removes a lost id from that list, so zipping survivors
         # would compare two receipts that were never adjacent -- inventing a


### PR DESCRIPTION
Documentation only; no behavior change. All 5 suites green.

Independent review of #125 found a real, narrow gap and — unusually — argued against fixing it, **with a constructed control case rather than an assertion**. Recording both the gap and the reasoning so neither has to be rediscovered.

**The gap:** deleting the CURRENT receipt for a path is caught (`resume` reports `RECEIPT-MISSING`). Deleting a SUPERSEDED one is not — and if that receipt was the far side of a continuity break, the break becomes invisible to every reporting surface, because `resume` only consults the current receipt per path and `continuity_breaks()` will not assert a mismatch across a receipt it cannot load.

**Why it is not fixed:** the obvious remedy — bridge the gap, compare the surviving neighbours — was constructed and tested against an honest history where an intervening write legitimately changed the content and its receipt was later lost. Bridging flags a break that never happened. It trades a rare, filesystem-access-gated invisibility for false positives on the common case, which is precisely the regression the previous round of this feature existed to remove.

Deleting receipt files requires access outside the mission channel, which SECURITY.md already places out of scope. This entry names the asymmetry so it is a known property of the design rather than a surprise.

Also worth recording: this is the second time in this arc that the honest answer was "disclose, don't patch" — the first being `RECOVER-UNKNOWN`, where the proposed marker would have had no discharge path. Both times the alternative was worse than the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ