### PR TITLE
docs(mission-custody): a retro ruling nobody can read did not happen

### DIFF
--- a/docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md
+++ b/docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md
@@ -40,3 +40,30 @@ Fill after the tracer mission closes (or aborts). This retro — not the build �
 - [ ] Park (custody did not change the outcome)
 
 Rationale:
+
+## Consumption — a ruling nobody can read did not happen
+
+A retro decides something. That decision has to reach the place the NEXT
+steward actually reads, which is never this file: the next steward loads
+`skills/manifest/SKILL.md` and the contract, not the closed mission's record.
+
+The first time this was skipped, the tracer's "build teeth" ruling sat on an
+unpushed branch of a different repo while the shipped skill text still told
+every successor that Stage C was "gated on the tracer retro" — the decision
+existed and was invisible for a day, and the successor mission ran the exact
+actuators the ruling named, unguarded.
+
+Do not close this retro until each is true or explicitly N/A:
+
+- [ ] The ruling is an issue or PR in the repo that owns the skill and the
+      contract — not only a line in this file.
+- [ ] Any claim in `SKILL.md` that this retro just made false is corrected in
+      that same change (search it for the gate you were deciding).
+- [ ] The mission record is pushed, not local-only. A record that lives on one
+      box is one disk failure from never having existed (SAFETY-5).
+- [ ] Anything the mission proved about the CONTRACT — a defect, a missing
+      capability, a residue worth disclosing — is filed where the contract's
+      maintainers look, with the evidence that established it.
+- [ ] Scrub before publishing: mission records sweep up whatever sits beside
+      them. Harness session data (`.host-context/`) has carried verbatim
+      operator prompts from unrelated sessions.

--- a/docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md
+++ b/docs/superpowers/plans/2026-08-11-mission-custody-tracer-retro-template.md
@@ -67,3 +67,18 @@ Do not close this retro until each is true or explicitly N/A:
 - [ ] Scrub before publishing: mission records sweep up whatever sits beside
       them. Harness session data (`.host-context/`) has carried verbatim
       operator prompts from unrelated sessions.
+- [ ] The closing verdict — which box, and why — is delivered explicitly to
+      whoever ratifies it, and never inferred from the steward going idle,
+      available, or quiet. A ruling that exists only as a state nobody
+      confirmed receiving is the same failure as a ruling on an unpushed
+      branch nobody pointed at, one layer up. (Lived, not imagined: during
+      the review that produced this checklist, a reviewer's verdict failed
+      to deliver and was followed by an idle signal; reading that silence as
+      approval would have merged unreviewed work.)
+
+This checklist is convention-held. Nothing here mechanically stops a steward
+from ticking the first box, intending the second "shortly," and closing
+anyway — the same honesty dependency as the custody layer it governs, and it
+should not be described as more. The mechanical version, if it is ever worth
+building, is a CI check that greps `SKILL.md` for gate language contradicted
+by a linked, closed retro ruling.


### PR DESCRIPTION
Documentation only. Closes the structural failure this arc surfaced.

## What went wrong

The tracer retro **ruled Stage C in** ("build teeth… scoped to the successor mission's real actuators"). That ruling then sat on an unpushed branch of a *different repo* while the shipped `skills/manifest/SKILL.md` still told every successor steward that Stage C was "gated on the tracer retro." The decision existed and was invisible — and the successor mission proceeded to run the exact actuator classes the ruling named, unguarded.

Nothing in the flow carried it forward, because the retro template ended at `Rationale:`. The lesson's designated carrier (the retro) and its consumer (the next steward, reading SKILL.md) were disconnected.

## What this adds

A consumption checklist that must clear before a retro closes: file the ruling where the skill and contract live, correct any `SKILL.md` claim the retro just falsified, push the mission record off the box (SAFETY-5), file what the mission proved about the contract, and scrub harness session data before publishing.

**Every item is something that actually went wrong once**, not a precaution someone imagined:

| Item | The incident |
|---|---|
| File the ruling in the skill's repo | Stage-C ruling stranded on a local branch |
| Correct falsified SKILL.md claims | Shipped text said "gated on the tracer retro" after the retro had ruled |
| Push the record | Entire tracer record was a single local commit |
| File contract findings | 11 defects found this arc; the ones that got issues are the ones that survived |
| Scrub before publishing | The record commit swept in 19 host-context files with verbatim operator prompts from an unrelated session |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ