### PR TITLE
feat(mission-custody): Stage-C PreToolUse custody enforcement hook

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -18,6 +18,14 @@
     "handoff"
   ],
   "skills": "./plugins/epistemic-skills/skills/",
+  "hooks": [
+    {
+      "event": "PreToolUse",
+      "matcher": "Bash|Write|Edit",
+      "command": "python ./plugins/epistemic-skills/contracts/mission-custody/custody_hook.py --harness kimi",
+      "timeout": 10
+    }
+  ],
   "skillInstructions": "Kimi Code tool mapping for Epistemic Skills:\n\n- When a skill asks the user a question, asks for a choice, or presents multiple-choice options, call Kimi Code's `AskUserQuestion` tool. Provide 1 question with 2-4 concrete options; put the recommended option first and suffix its label with `(Recommended)`. Do not render choices as plain assistant text unless `AskUserQuestion` is unavailable or the session is in auto permission mode.\n- When a skill refers to `TodoWrite` or a todo list, use Kimi Code's `TodoList` tool.\n- When a skill dispatches subagents or role agents \u2014 gauntlet Step 5 role panel, evidence-locked-uat actor / blinded verifier / deterministic judge \u2014 use Kimi Code's `Agent` tool. Do not pass `general-purpose` as `subagent_type`. Use `coder` for implementation and review roles, `explore` for read-only investigation, and `plan` for read-only design. Paste the full role definition from this plugin's `agents/<role>.md` into the subagent prompt; each role agent is a separate `Agent` call so contexts stay isolated. Keep dependent role calls sequential; use parallel or background `Agent` calls only for roles that are independent by design.\n- When a skill refers to the `Skill` tool, use Kimi Code's native `Skill` tool.\n- Use Kimi Code's `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `FetchURL`, and `WebSearch` tools by their actual exposed names. Search file contents with `Grep`; find files by path or pattern with `Glob`.\n- Run the gauntlet helper scripts (`skills/gauntlet/scripts/*.py`, stdlib-only) with `python` via `Bash`.",
   "interface": {
     "displayName": "Epistemic Skills",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -21,7 +21,7 @@
   "hooks": [
     {
       "event": "PreToolUse",
-      "matcher": "Bash|Write|Edit",
+      "matcher": "Bash|Write|Edit|mcp__.*",
       "command": "python ./plugins/epistemic-skills/contracts/mission-custody/custody_hook.py --harness kimi",
       "timeout": 10
     }

--- a/docs/superpowers/plans/2026-08-12-stage-c-custody-hook.md
+++ b/docs/superpowers/plans/2026-08-12-stage-c-custody-hook.md
@@ -1,0 +1,1314 @@
+# Stage-C Custody Enforcement Hook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship es#117 — a PreToolUse custody-enforcement hook that gates a mission's real actuators (arr API mutations, filesystem moves) on operator-approved, manifest-resident guard rules, shipped inert.
+
+**Architecture:** Two additive optional fields on `mission-manifest@1` authority (`guard_mode`, `actuator_guards`); a new pure evaluator module `custody_gate.py`; a `gate` CLI verb; a stdlib hook script `custody_hook.py` with per-harness payload adapters (claude/kimi/codex/cursor/gemini(+agy)/generic); per-harness wiring files. Hook never mutates chain state; matches append to `missions/<id>/guard-log.jsonl`.
+
+**Tech Stack:** Python 3.11 stdlib only (repo constraint — validation is hand-rolled, no jsonschema). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md` (same worktree).
+
+## Global Constraints
+
+- All work in worktree `Y:/dev/es-wt-stage-c-hook`, branch `agent/stage-c-custody-hook` (cut from ES main `2931d386`). Never touch the main checkout (RULE-028) or auditor worktrees.
+- Contract dir referred to below as `MC/` = `plugins/epistemic-skills/contracts/mission-custody/`.
+- Stdlib only. Validation lives in `verify_mission_custody.py` (hand-rolled); `atomic_write_json` validates every write — a manifest carrying guard fields cannot be written until Task 1 lands.
+- **Case folding: NEVER `str.casefold()`** (ß→ss expansion retires custody of the wrong file — PR #122). Reuse `_ascii_case_fold` / `_normalize_relpath` from `custody_mission.py`.
+- Over-matching bias: a false block names its rule and is recoverable via amend; a false allow silently retires custody. Regexes err broad.
+- Tests are plain scripts (`python test_x.py`, exit 0 = green), using the module-level `FAILURES` list + `check(name, cond)` pattern from existing test files. No pytest.
+- Black-box CLI tests drive `custody_cli.py` via `subprocess` exactly as `test_custody_cli.py` does.
+- **Every `git commit` step requires an explicit operator GO before execution** (fleet consent guard, per-session). Commits are DCO-signed (`git commit --signoff`). Batches of commits per GO are fine if the operator says so.
+- Exit-code contract (existing, do not regress): 0 success; 2 usage/refusal; 3 drift on `resume` / breaks on `audit`. `gate` adds: 2 = block.
+- The hook must fail open: any exception, malformed payload, missing mission, or timeout → exit 0. Denial travels ONLY via the deliberate exit-2/decision-JSON path.
+- MSYS2 on this machine: `export MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'` for path/revspec args.
+
+---
+
+### Task 1: Validator + schema support for guard fields
+
+**Files:**
+- Modify: `MC/verify_mission_custody.py` (AUTHORITY_FIELDS at lines 34-37; `validate_manifest` at lines 80-135)
+- Modify: `MC/mission-manifest.schema.json`
+- Create: `MC/examples/valid-manifest-guards.json`
+- Create: `MC/examples/invalid-manifest-guard-bad-mode.json`
+- Create: `MC/examples/invalid-manifest-guard-empty-rule.json`
+- Create: `MC/examples/invalid-manifest-guard-bad-regex.json`
+- Create: `MC/examples/invalid-manifest-guard-mode-without-guards.json`
+- Create: `MC/examples/invalid-manifest-guard-unknown-field.json`
+- Test: `MC/test_mission_custody.py` (add tests at end; it already walks `examples/`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `validate_manifest` accepts authority objects optionally carrying `guard_mode` (`"audit"|"enforce"`) and `actuator_guards` (list of guard rules); every other authority object validates exactly as before. Guard rule shape: `{"name": str, "tool_names": [str...], "command_regexes": [str...], "path_globs": [str...]}` — `name`/`tool_names` required, both pattern lists required (either may be `[]`, but at least one pattern total across the two), no unknown keys. Later tasks rely on this exact rule shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `MC/test_mission_custody.py`:
+
+```python
+def test_manifest_guards_valid_example() -> None:
+    check("manifest-guards-valid-example",
+          validate_record(load("valid-manifest-guards.json")) == [])
+
+
+def test_manifest_guard_examples_invalid() -> None:
+    for name in (
+        "invalid-manifest-guard-bad-mode.json",
+        "invalid-manifest-guard-empty-rule.json",
+        "invalid-manifest-guard-bad-regex.json",
+        "invalid-manifest-guard-mode-without-guards.json",
+        "invalid-manifest-guard-unknown-field.json",
+    ):
+        check(f"manifest-{name}", validate_record(load(name)) != [])
+
+
+def test_manifest_guards_optional_absent() -> None:
+    # The pre-change minimal manifest must still validate: fields are additive.
+    check("manifest-guards-optional-absent",
+          validate_record(valid_manifest()) == [])
+
+
+def test_manifest_guard_rules_shape() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["guard_mode"] = "audit"
+    rec["authority"]["actuator_guards"] = [{
+        "name": "arr", "tool_names": ["Bash"],
+        "command_regexes": ["7878"], "path_globs": []}]
+    check("manifest-guard-rules-inline-valid", validate_record(rec) == [])
+    bad = copy.deepcopy(rec)
+    bad["authority"]["actuator_guards"][0]["tool_names"] = []
+    check("manifest-guard-empty-tool-names", validate_record(bad) != [])
+```
+
+- [ ] **Step 2: Create the example files**
+
+`valid-manifest-guards.json` = `valid-manifest-minimal.json` plus, inside `authority`:
+
+```json
+"guard_mode": "audit",
+"actuator_guards": [
+  {"name": "arr-api-mutations", "tool_names": ["Bash"],
+   "command_regexes": ["https?://[^\\s]*:(7878|8989|8686|9696)/api/"],
+   "path_globs": []},
+  {"name": "media-fs-moves", "tool_names": ["Bash", "Write", "Edit"],
+   "command_regexes": ["\\b(mv|robocopy|rsync|Move-Item)\\b[^\\n]*[Mm]edia"],
+   "path_globs": ["M:/Media/**", "//10.10.10.107/Media/**"]}
+]
+```
+
+`invalid-manifest-guard-bad-mode.json`: same but `"guard_mode": "block"`.
+`invalid-manifest-guard-empty-rule.json`: rule with `"command_regexes": []` and `"path_globs": []`.
+`invalid-manifest-guard-bad-regex.json`: `"command_regexes": ["([unclosed"]`.
+`invalid-manifest-guard-mode-without-guards.json`: `"guard_mode": "audit"` with no `actuator_guards` key.
+`invalid-manifest-guard-unknown-field.json`: rule carrying `"action": "block"`.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `python MC/test_mission_custody.py`
+Expected: FAIL on all five new `manifest-guard*`/`manifest-invalid*` checks (unknown-field errors).
+
+- [ ] **Step 4: Implement validator support**
+
+In `MC/verify_mission_custody.py`:
+
+```python
+# after AUTHORITY_FIELDS (line 37)
+AUTHORITY_OPTIONAL_FIELDS = {"guard_mode", "actuator_guards"}
+GUARD_MODES = {"audit", "enforce"}
+GUARD_RULE_FIELDS = {"name", "tool_names", "command_regexes", "path_globs"}
+GUARD_RULE_REQUIRED = {"name", "tool_names", "command_regexes", "path_globs"}
+```
+
+In `validate_manifest`, replace the exact-fields call on authority with required+allowed handling, then add guard validation:
+
+```python
+    # was: _check_exact_fields(errors, auth, AUTHORITY_FIELDS, "authority")
+    for key in auth:
+        if key not in AUTHORITY_FIELDS | AUTHORITY_OPTIONAL_FIELDS:
+            errors.append(f"authority.{key}: unknown field")
+    for key in AUTHORITY_FIELDS:
+        if key not in auth:
+            errors.append(f"authority.{key}: missing")
+    if not errors:
+        # ... existing operator_ref/instruction/amendments/list checks unchanged ...
+        mode = auth.get("guard_mode")
+        guards = auth.get("actuator_guards")
+        if mode is not None:
+            _require(errors, mode in GUARD_MODES,
+                     "authority.guard_mode", "must be 'audit' or 'enforce'")
+            _require(errors, isinstance(guards, list) and bool(guards),
+                     "authority.guard_mode",
+                     "guard_mode requires a non-empty actuator_guards list")
+        if guards is not None:
+            ok = isinstance(guards, list)
+            if ok:
+                for rule in guards:
+                    if not isinstance(rule, dict) or set(rule) != GUARD_RULE_FIELDS:
+                        ok = False
+                        break
+                    if not (isinstance(rule["name"], str) and rule["name"]):
+                        ok = False
+                        break
+                    if not _str_list(rule["tool_names"]):
+                        ok = False
+                        break
+                    patterns = []
+                    for field in ("command_regexes", "path_globs"):
+                        value = rule[field]
+                        if not isinstance(value, list) or not all(
+                                isinstance(p, str) for p in value):
+                            ok = False
+                            break
+                        patterns.extend(value)
+                    if not ok:
+                        break
+                    if not patterns:
+                        ok = False  # a patternless rule matches nothing -> inert by accident
+                        break
+                    for pattern in rule["command_regexes"]:
+                        try:
+                            re.compile(pattern)
+                        except re.error:
+                            ok = False
+                            break
+                    if not ok:
+                        break
+            _require(errors, ok, "authority.actuator_guards",
+                     "list of {name, tool_names, command_regexes, path_globs} "
+                     "rules; tool_names non-empty; >=1 pattern; regexes must compile")
+```
+
+Also update `MC/mission-manifest.schema.json`: add to `authority.required`… nothing (fields are optional); add to `authority.properties`:
+
+```json
+"guard_mode": {"enum": ["audit", "enforce"]},
+"actuator_guards": {"type": "array", "minItems": 1, "items": {
+  "type": "object", "additionalProperties": false,
+  "required": ["name", "tool_names", "command_regexes", "path_globs"],
+  "properties": {
+    "name": {"type": "string", "minLength": 1},
+    "tool_names": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
+    "command_regexes": {"type": "array", "items": {"type": "string"}},
+    "path_globs": {"type": "array", "items": {"type": "string"}}
+  }}}
+```
+
+(`additionalProperties: false` on authority stays — the schema json now names the two new keys.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python MC/test_mission_custody.py`
+Expected: PASS all (exit 0), including every pre-existing invalid-* example still failing validation.
+
+- [ ] **Step 6: Commit (operator GO required)**
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody/
+git commit --signoff -m "feat(mission-custody): validate optional actuator_guards + guard_mode on mission-manifest@1 (refs #117)"
+```
+
+---
+
+### Task 2: Mission lifecycle support (open / amend / tamper rule)
+
+**Files:**
+- Modify: `MC/custody_mission.py` (`Mission.open` lines 128-178; `_verify_manifest` lines 220-265; `amend_authority` lines 495-525)
+- Test: `MC/test_custody_mission.py` (append)
+
+**Interfaces:**
+- Consumes: Task 1's validator (writes with guard fields now pass `atomic_write_json`).
+- Produces:
+  - `Mission.open(..., guard_mode: str | None = None, actuator_guards: list | None = None)` — both keyword-only, appended after `acceptable_costs`. Fields are written into `authority` only when `actuator_guards is not None` (`guard_mode` written only when not None).
+  - `Mission.amend_authority(text, *, guard_mode=_UNSET, actuator_guards=_UNSET)` — sentinel `_UNSET = object()` at module level; a non-sentinel value REPLACES the field in the amended manifest (empty list clears guards).
+  - `_verify_manifest` new rule: guard fields may differ from the origin manifest ONLY when `authority.amendments` is non-empty on the latest checkpoint; otherwise `CustodyError("tampered")`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `MC/test_custody_mission.py` (follow its existing fixture style for creating a workspace + mission; reuse its helpers):
+
+```python
+def test_open_with_guards_roundtrip() -> None:
+    # open a mission with guards + mode; checkpoint r1 must validate and carry them
+    ws = _tmp_workspace()  # use the file's existing workspace helper
+    guards = [{"name": "g", "tool_names": ["Bash"],
+               "command_regexes": ["rm"], "path_globs": []}]
+    m = Mission.open(ws, "guard-open", "do the thing", "operator:test",
+                     "agent:test", actor="agent:test",
+                     guard_mode="audit", actuator_guards=guards)
+    latest, _ = m.store.load_latest()
+    auth = latest["manifest"]["authority"]
+    check("open-guards-roundtrip",
+          auth["guard_mode"] == "audit" and auth["actuator_guards"] == guards)
+
+
+def test_open_without_guards_omits_fields() -> None:
+    ws = _tmp_workspace()
+    m = Mission.open(ws, "guard-less", "do the thing", "operator:test",
+                     "agent:test", actor="agent:test")
+    latest, _ = m.store.load_latest()
+    auth = latest["manifest"]["authority"]
+    check("open-guardless-omits-fields",
+          "guard_mode" not in auth and "actuator_guards" not in auth)
+
+
+def test_amend_changes_guards() -> None:
+    ws = _tmp_workspace()
+    m = Mission.open(ws, "guard-amend", "i", "operator:test", "agent:test",
+                     actor="agent:test")
+    m.approve()
+    rev = m.amend_authority(
+        "operator: arm the hook in audit mode",
+        guard_mode="audit",
+        actuator_guards=[{"name": "g", "tool_names": ["Bash"],
+                          "command_regexes": ["rm"], "path_globs": []}])
+    latest, _ = m.store.load_latest()
+    check("amend-guards-landed",
+          latest["manifest"]["authority"]["guard_mode"] == "audit"
+          and latest["revision"] == rev)
+
+
+def test_tail_guard_tamper_without_amendment_detected() -> None:
+    ws = _tmp_workspace()
+    m = Mission.open(ws, "guard-tamper", "i", "operator:test", "agent:test",
+                     actor="agent:test")
+    m.approve()
+    # Forge a tail checkpoint: same chain, guards added by hand, no amendment.
+    latest, path = m.store.load_latest()
+    forged = json.loads(json.dumps(latest))
+    forged["revision"] = latest["revision"] + 1
+    forged["prev_checkpoint_sha256"] = sha256_file(path)
+    forged["manifest"]["authority"]["actuator_guards"] = [
+        {"name": "x", "tool_names": ["Bash"], "command_regexes": ["a"],
+         "path_globs": []}]
+    forged["manifest"]["authority"]["guard_mode"] = "audit"
+    m.store.write_checkpoint(forged)
+    try:
+        m.note("probe")
+        check("tail-guard-tamper-detected", False)
+    except CustodyError:
+        check("tail-guard-tamper-detected", True)
+```
+
+(Imports `sha256_file` from `custody_store` — add to the test file's import block.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python MC/test_custody_mission.py`
+Expected: FAIL — `TypeError: unexpected keyword argument 'guard_mode'` on open/amend tests.
+
+- [ ] **Step 3: Implement**
+
+In `MC/custody_mission.py`:
+
+Module level, near `_OPEN_STATES`:
+
+```python
+_UNSET = object()  # amend sentinel: distinguishes "leave alone" from "clear"
+_GUARD_AUTHORITY_KEYS = ("actuator_guards", "guard_mode")
+```
+
+`Mission.open` — extend signature and manifest build:
+
+```python
+        acceptable_costs: list[str] | None = None,
+        guard_mode: str | None = None,
+        actuator_guards: list | None = None) -> "Mission":
+```
+
+```python
+            "authority": {
+                ...existing keys...,
+                **({"actuator_guards": actuator_guards} if actuator_guards is not None else {}),
+                **({"guard_mode": guard_mode} if guard_mode is not None else {}),
+            },
+```
+
+`_verify_manifest` — after zeroing amendments on both deep copies (current lines 257-258), add:
+
+```python
+        # Guard fields are authority too: they may change only via amend, and
+        # amend always appends the operator's verbatim grant -- so a guard
+        # difference without any recorded amendment is tampering. (A forged
+        # amendment stays possible on the unsealed tail; that is the es#118
+        # residue, disclosed in SECURITY.md, not something this check invents
+        # coverage for.)
+        origin_guards = {k: origin_rest["authority"].pop(k, None)
+                         for k in _GUARD_AUTHORITY_KEYS}
+        latest_guards = {k: latest_rest["authority"].pop(k, None)
+                         for k in _GUARD_AUTHORITY_KEYS}
+        if origin_guards != latest_guards and not latest_amendments:
+            raise CustodyError(
+                "actuator guards changed with no authority amendment "
+                "recorded (tampered)")
+```
+
+(This must sit BEFORE the `origin_rest != latest_rest` comparison, which then runs unchanged on the stripped copies.)
+
+`amend_authority` — new signature and application:
+
+```python
+    def amend_authority(self, text: str, *, guard_mode=_UNSET,
+                        actuator_guards=_UNSET) -> int:
+```
+
+after the amendments append:
+
+```python
+        if actuator_guards is not _UNSET:
+            manifest["authority"]["actuator_guards"] = actuator_guards
+        if guard_mode is not _UNSET:
+            manifest["authority"]["guard_mode"] = guard_mode
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python MC/test_custody_mission.py`
+Expected: PASS all (exit 0), including all pre-existing tamper tests.
+
+- [ ] **Step 5: Commit (operator GO required)**
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody/
+git commit --signoff -m "feat(mission-custody): open/amend carry actuator guards; guard change without amendment reads as tamper (refs #117)"
+```
+
+---
+
+### Task 3: The gate evaluator (`custody_gate.py`)
+
+**Files:**
+- Create: `MC/custody_gate.py`
+- Test: `MC/test_custody_gate.py` (create)
+
+**Interfaces:**
+- Consumes: `Mission.load` / `mission.status()` from `custody_mission`; `_ascii_case_fold`, `_normalize_relpath` from `custody_mission`; `MissionStore.mission_dir`.
+- Produces (Task 4's CLI and Task 5's hook rely on exactly these):
+  - `evaluate(authority: dict, tool_call: dict) -> dict` — pure. `tool_call` = `{"tool_name": str, "command": str|None, "file_path": str|None}`. Returns `{"decision": "allow"|"block", "matched": bool, "rule": str|None, "mode": str, "reason": str}`.
+  - `run_gate(workspace: Path, tool_call: dict, *, actor: str, session_id: str = "", harness: str = "") -> dict` — loads the active mission, evaluates, appends to `guard-log.jsonl` on match, returns the verdict dict. Raises nothing for no-mission (returns allow with reason).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `MC/test_custody_gate.py` (script style, `check()` pattern, tempfile workspaces; build missions via `Mission.open` directly):
+
+```python
+#!/usr/bin/env python3
+"""Unit + integration tests for custody_gate.py."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from custody_gate import evaluate, run_gate  # noqa: E402
+from custody_mission import Mission  # noqa: E402
+from custody_store import sha256_file  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+GUARDS = [
+    {"name": "arr-api", "tool_names": ["Bash"],
+     "command_regexes": [r":7878/api"], "path_globs": []},
+    {"name": "media-moves", "tool_names": ["Bash", "Write", "Edit"],
+     "command_regexes": [r"\b(mv|robocopy)\b[^\n]*[Mm]edia"],
+     "path_globs": ["M:/Media/**"]},
+]
+
+
+def auth(mode: str | None, guards=None) -> dict:
+    out: dict = {}
+    if mode is not None:
+        out["guard_mode"] = mode
+    if guards is not None:
+        out["actuator_guards"] = guards
+    return out
+
+
+def test_evaluate_inert() -> None:
+    call = {"tool_name": "Bash", "command": "curl :7878/api", "file_path": None}
+    check("eval-inert-no-fields", evaluate(auth(None), call)["decision"] == "allow")
+    check("eval-inert-guards-no-mode",
+          evaluate(auth(None, GUARDS), call)["decision"] == "allow")
+
+
+def test_evaluate_modes() -> None:
+    call = {"tool_name": "Bash", "command": "curl :7878/api", "file_path": None}
+    v = evaluate(auth("audit", GUARDS), call)
+    check("eval-audit-allows-matched",
+          v["decision"] == "allow" and v["matched"] and v["rule"] == "arr-api")
+    v = evaluate(auth("enforce", GUARDS), call)
+    check("eval-enforce-blocks",
+          v["decision"] == "block" and v["rule"] == "arr-api")
+
+
+def test_evaluate_tool_gate() -> None:
+    call = {"tool_name": "Read", "command": None, "file_path": "M:/Media/x.mkv"}
+    v = evaluate(auth("enforce", GUARDS), call)
+    check("eval-tool-not-in-rule", not v["matched"] and v["decision"] == "allow")
+    call = {"tool_name": "Write", "command": None, "file_path": "M:/Media/x.mkv"}
+    v = evaluate(auth("enforce", GUARDS), call)
+    check("eval-glob-match", v["matched"] and v["rule"] == "media-moves")
+    call = {"tool_name": "Write", "command": None, "file_path": "M:/Other/x.mkv"}
+    check("eval-glob-no-match", not evaluate(auth("enforce", GUARDS), call)["matched"])
+
+
+def test_evaluate_case_fold_is_ascii_only() -> None:
+    guards = [{"name": "g", "tool_names": ["Write"], "command_regexes": [],
+               "path_globs": ["M:/Media/STRASSE/**"]}]
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "M:/Media/strasse/x"}  # ß-folded spelling
+    # NTFS folds A-Z only: 'strasse' (with eszett in the glob) must NOT match
+    # a different codepoint sequence. Build both spellings explicitly:
+    glob_eszett = ["M:/Media/stra\u00dfe/**"]
+    guards[0]["path_globs"] = glob_eszett
+    check("eval-no-eszett-fold",
+          not evaluate(auth("enforce", guards), call)["matched"])
+    call_ascii = {"tool_name": "Write", "command": None,
+                  "file_path": "m:/media/stra\u00dfe/x"}
+    if sys.platform.startswith("win"):
+        check("eval-ascii-fold-nt",
+              evaluate(auth("enforce", guards), call_ascii)["matched"])
+
+
+def test_run_gate_chain_untouched_and_log() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "gate-it", "i", "operator:test", "agent:test",
+                         actor="agent:test", guard_mode="audit",
+                         actuator_guards=GUARDS)
+        m.approve()
+        before = {p.name: sha256_file(p)
+                  for p in sorted((ws / "missions" / "gate-it").rglob("*.json"))}
+        call = {"tool_name": "Bash", "command": "curl :7878/api", "file_path": None}
+        v = run_gate(ws, call, actor="hook:custody-gate", session_id="s1",
+                     harness="test")
+        after = {p.name: sha256_file(p)
+                 for p in sorted((ws / "missions" / "gate-it").rglob("*.json"))}
+        check("run-gate-allows-audit", v["decision"] == "allow" and v["matched"])
+        check("run-gate-chain-byte-identical", before == after)
+        log = ws / "missions" / "gate-it" / "guard-log.jsonl"
+        check("run-gate-log-written", log.is_file())
+        entry = json.loads(log.read_text(encoding="utf-8").splitlines()[-1])
+        check("run-gate-log-fields",
+              entry["rule"] == "arr-api" and entry["session_id"] == "s1"
+              and entry["mode"] == "audit")
+        # No match -> no log line
+        n_lines = len(log.read_text(encoding="utf-8").splitlines())
+        run_gate(ws, {"tool_name": "Read", "command": None, "file_path": "x"},
+                 actor="hook:custody-gate")
+        check("run-gate-no-match-no-log",
+              len(log.read_text(encoding="utf-8").splitlines()) == n_lines)
+
+
+def test_run_gate_no_mission_allows() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        v = run_gate(Path(tmp), {"tool_name": "Bash", "command": "rm -rf /",
+                                 "file_path": None}, actor="hook:custody-gate")
+        check("run-gate-no-mission-allow",
+              v["decision"] == "allow" and not v["matched"])
+
+
+if __name__ == "__main__":
+    for fn in list(globals().values()):
+        if callable(fn) and getattr(fn, "__name__", "").startswith("test_"):
+            fn()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILURES")
+        sys.exit(1)
+    print("all green")
+```
+
+(Note: `test_open` helpers in existing files use their own conventions; this file is self-contained on purpose.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python MC/test_custody_gate.py`
+Expected: ImportError — `custody_gate` does not exist.
+
+- [ ] **Step 3: Implement `MC/custody_gate.py`**
+
+```python
+#!/usr/bin/env python3
+"""Stage-C gate: evaluate a harness tool call against the active mission's
+operator-approved actuator guards (mission-manifest@1 optional fields).
+
+Read-only by contract: the only write anywhere in this module is an append to
+missions/<id>/guard-log.jsonl on a MATCH -- the checkpoint chain is never
+touched (verified by test: run-gate-chain-byte-identical). The checkpoint read
+goes through MissionStore.load_latest, so the manifest evaluated is the
+chain-verified latest.
+
+Matching is deliberately over-broad (handoff error-direction lesson): a false
+block names its rule and is discharged by an amend; a false allow silently
+retires custody of the actuator class the tracer retro named.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from custody_mission import (
+    Mission,
+    MultipleActiveMissions,
+    NoActiveMission,
+    _ascii_case_fold,
+    _normalize_relpath,
+)
+
+GUARD_LOG_NAME = "guard-log.jsonl"
+_PREVIEW = 120
+
+
+def _glob_regex(glob: str) -> "re.Pattern[str]":
+    """Translate a path glob: '**' crosses separators, '*'/'?' stay in-segment.
+    Paths are normalized ('\\' -> '/', no './', no trailing '/') before match;
+    on NT both sides fold A-Z only (_ascii_case_fold -- never str.casefold)."""
+    out: list[str] = []
+    i = 0
+    while i < len(glob):
+        if glob[i] == "*":
+            if glob[i:i + 2] == "**":
+                out.append(".*")
+                i += 2
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif glob[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(glob[i]))
+            i += 1
+    return re.compile("".join(out) + "$", re.DOTALL)
+
+
+def _fold(text: str) -> str:
+    return _ascii_case_fold(text) if os.name == "nt" else text
+
+
+def _norm_path(path: str) -> str:
+    return _fold(_normalize_relpath(path.replace("\\", "/")))
+
+
+def _tool_in(rule: dict, tool_name: str) -> bool:
+    return tool_name in rule["tool_names"]
+
+
+def _patterns_match(rule: dict, tool_call: dict) -> bool:
+    command = tool_call.get("command")
+    if command:
+        for pattern in rule["command_regexes"]:
+            if re.search(pattern, command):
+                return True
+    file_path = tool_call.get("file_path")
+    if file_path:
+        target = _norm_path(file_path)
+        for glob in rule["path_globs"]:
+            if _glob_regex(_fold(_normalize_relpath(glob))).match(target):
+                return True
+    return False
+
+
+def evaluate(authority: dict, tool_call: dict) -> dict:
+    mode = authority.get("guard_mode")
+    guards = authority.get("actuator_guards")
+    if not mode or not guards:
+        return {"decision": "allow", "matched": False, "rule": None,
+                "mode": mode or "inert", "reason": "no guards armed"}
+    for rule in guards:
+        if _tool_in(rule, tool_call.get("tool_name", "")) \
+                and _patterns_match(rule, tool_call):
+            if mode == "enforce":
+                return {"decision": "block", "matched": True,
+                        "rule": rule["name"], "mode": mode,
+                        "reason": (
+                            f"custody guard '{rule['name']}' matched this call; "
+                            "the mission envelope does not discharge it -- record "
+                            "an operator grant via `amend` or stop")}
+            return {"decision": "allow", "matched": True, "rule": rule["name"],
+                    "mode": mode,
+                    "reason": f"custody guard '{rule['name']}' matched (audit mode)"}
+    return {"decision": "allow", "matched": False, "rule": None,
+            "mode": mode, "reason": "no guard matched"}
+
+
+def _append_guard_log(mission_dir: Path, entry: dict) -> None:
+    path = mission_dir / GUARD_LOG_NAME
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def run_gate(workspace: Path, tool_call: dict, *, actor: str,
+             session_id: str = "", harness: str = "") -> dict:
+    workspace = Path(workspace)
+    try:
+        mission = Mission.load(workspace, actor=actor)
+    except (NoActiveMission, MultipleActiveMissions) as exc:
+        return {"decision": "allow", "matched": False, "rule": None,
+                "mode": "inert", "reason": f"gate inert: {type(exc).__name__}"}
+    latest = mission.status()
+    verdict = evaluate(latest["manifest"]["authority"], tool_call)
+    if verdict["matched"]:
+        command = tool_call.get("command") or ""
+        entry = {
+            "utc": latest["written_utc"],  # see note below
+            "actor": actor,
+            "session_id": session_id,
+            "harness": harness,
+            "mode": verdict["mode"],
+            "decision": verdict["decision"],
+            "rule": verdict["rule"],
+            "tool_name": tool_call.get("tool_name", ""),
+            "command_preview": command[:_PREVIEW],
+            "file_path": tool_call.get("file_path"),
+        }
+        _append_guard_log(mission.store.mission_dir, entry)
+    return verdict
+```
+
+Implementation note for the executor: use `custody_mission.now_utc()` for the log entry's `utc`, not the checkpoint's `written_utc` (import it; the sketch above marks the spot).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python MC/test_custody_gate.py`
+Expected: PASS all (exit 0).
+
+- [ ] **Step 5: Commit (operator GO required)**
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody/
+git commit --signoff -m "feat(mission-custody): custody_gate evaluator -- read-only, log-on-match, ascii-only case fold (refs #117)"
+```
+
+---
+
+### Task 4: CLI — `gate` verb + `open`/`amend` flags
+
+**Files:**
+- Modify: `MC/custody_cli.py` (`build_parser` lines 68-134; `dispatch` lines 153-228; module docstring lines 1-17)
+- Test: `MC/test_custody_cli.py` (append)
+
+**Interfaces:**
+- Consumes: `custody_gate.run_gate` (Task 3); `Mission.open`/`amend_authority` new kwargs (Task 2).
+- Produces:
+  - `custody_cli.py gate --workspace W --actor A [--input-file F]` — tool-call JSON on stdin or from file; prints verdict JSON on stdout; exit 0 allow / 2 block.
+  - `open --guards-file F --guard-mode audit|enforce` (both optional; `--guard-mode` without `--guards-file` → usage error exit 2).
+  - `amend --text T [--guards-file F] [--guard-mode MODE]` (flags optional; `--guards-file` with `[]` clears guards).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `MC/test_custody_cli.py` (uses its existing `run()` subprocess helper + workspace fixture style):
+
+```python
+def test_gate_verb(tmp: Path) -> None:
+    # open an enforced mission guarding 'rm -rf'
+    guards = [{"name": "no-rm", "tool_names": ["Bash"],
+               "command_regexes": ["rm -rf"], "path_globs": []}]
+    gfile = tmp / "guards.json"
+    gfile.write_text(json.dumps(guards), encoding="utf-8")
+    run("open", "--workspace", str(tmp), "--actor", "agent:t",
+        "--mission-id", "gate-cli", "--instruction", "i",
+        "--operator", "operator:t", "--steward", "agent:t",
+        "--guards-file", str(gfile), "--guard-mode", "enforce")
+    run("approve", "--workspace", str(tmp), "--actor", "agent:t")
+    blocked = subprocess.run(
+        [sys.executable, str(CLI), "gate", "--workspace", str(tmp),
+         "--actor", "hook:custody-gate"],
+        input=json.dumps({"tool_name": "Bash", "command": "rm -rf x",
+                          "file_path": None}),
+        capture_output=True, text=True)
+    check("gate-blocks-enforced", blocked.returncode == 2)
+    verdict = json.loads(blocked.stdout)
+    check("gate-verdict-fields",
+          verdict["decision"] == "block" and verdict["rule"] == "no-rm")
+    allowed = subprocess.run(
+        [sys.executable, str(CLI), "gate", "--workspace", str(tmp),
+         "--actor", "hook:custody-gate"],
+        input=json.dumps({"tool_name": "Bash", "command": "ls",
+                          "file_path": None}),
+        capture_output=True, text=True)
+    check("gate-allows-unmatched", allowed.returncode == 0)
+
+
+def test_gate_no_mission_allows(tmp: Path) -> None:
+    res = subprocess.run(
+        [sys.executable, str(CLI), "gate", "--workspace", str(tmp),
+         "--actor", "hook:custody-gate"],
+        input=json.dumps({"tool_name": "Bash", "command": "rm -rf /"}),
+        capture_output=True, text=True)
+    check("gate-no-mission-exit-0", res.returncode == 0)
+
+
+def test_open_guard_mode_without_guards_refused(tmp: Path) -> None:
+    res = run("open", "--workspace", str(tmp), "--actor", "agent:t",
+              "--mission-id", "bad-open", "--instruction", "i",
+              "--operator", "operator:t", "--steward", "agent:t",
+              "--guard-mode", "audit")
+    check("open-mode-without-guards-refused", res.returncode == 2)
+
+
+def test_amend_guard_mode_flag(tmp: Path) -> None:
+    run("open", "--workspace", str(tmp), "--actor", "agent:t",
+        "--mission-id", "amend-cli", "--instruction", "i",
+        "--operator", "operator:t", "--steward", "agent:t")
+    run("approve", "--workspace", str(tmp), "--actor", "agent:t")
+    guards = [{"name": "g", "tool_names": ["Bash"],
+               "command_regexes": ["x"], "path_globs": []}]
+    gfile = tmp / "g.json"
+    gfile.write_text(json.dumps(guards), encoding="utf-8")
+    res = run("amend", "--workspace", str(tmp), "--actor", "agent:t",
+              "--text", "operator: arm audit mode",
+              "--guards-file", str(gfile), "--guard-mode", "audit")
+    check("amend-guards-accepted", res.returncode == 0)
+```
+
+(Adapt `tmp` to the file's actual fixture convention — `test_custody_cli.py` uses `tempfile` contexts; match what is there.)
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python MC/test_custody_cli.py`
+Expected: FAIL — `invalid choice: 'gate'` / unrecognized arguments.
+
+- [ ] **Step 3: Implement**
+
+In `build_parser`:
+
+```python
+    p_open.add_argument("--guards-file", dest="guards_file")
+    p_open.add_argument("--guard-mode", dest="guard_mode",
+                        choices=["audit", "enforce"])
+```
+
+```python
+    p_amend.add_argument("--guards-file", dest="guards_file")
+    p_amend.add_argument("--guard-mode", dest="guard_mode",
+                         choices=["audit", "enforce"])
+```
+
+```python
+    p_gate = sub.add_parser("gate", parents=[common])
+    p_gate.add_argument("--input-file", dest="input_file")
+```
+
+Helpers (module level):
+
+```python
+def _read_guards_file(path: str) -> list:
+    with open(path, encoding="utf-8") as handle:
+        guards = json.load(handle)
+    if not isinstance(guards, list):
+        raise CustodyError("guards file must contain a JSON list of rules")
+    return guards
+
+
+def _read_tool_call(args: argparse.Namespace) -> dict:
+    # stdin carries the tool-call JSON by default -- argv has a ~32KB ceiling
+    # on Windows and every shell metachar must survive, same reason
+    # --content-file exists. --input-file is the explicit-file escape hatch.
+    raw = (Path(args.input_file).read_text(encoding="utf-8")
+           if args.input_file else sys.stdin.read())
+    try:
+        call = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CustodyError(f"gate: tool-call JSON unreadable: {exc}") from None
+    if not isinstance(call, dict) or not isinstance(call.get("tool_name"), str):
+        raise CustodyError("gate: tool-call JSON needs a string 'tool_name'")
+    call.setdefault("command", None)
+    call.setdefault("file_path", None)
+    return call
+```
+
+In `dispatch`, `open` branch — before `Mission.open`:
+
+```python
+        if args.guard_mode and not args.guards_file:
+            raise CustodyError("--guard-mode requires --guards-file")
+        guards = (_read_guards_file(args.guards_file)
+                  if args.guards_file else None)
+```
+and pass `guard_mode=args.guard_mode, actuator_guards=guards` to `Mission.open`.
+
+`amend` branch:
+
+```python
+    elif args.command == "amend":
+        kwargs: dict = {}
+        if args.guards_file:
+            kwargs["actuator_guards"] = _read_guards_file(args.guards_file)
+        if args.guard_mode:
+            kwargs["guard_mode"] = args.guard_mode
+        print(mission.amend_authority(args.text, **kwargs))
+```
+
+`gate` branch (before the `mission = Mission.load(...)` line — gate does its own load inside `run_gate`, so place it with `open` above that line):
+
+```python
+    if args.command == "gate":
+        from custody_gate import run_gate
+        verdict = run_gate(workspace, _read_tool_call(args), actor=args.actor,
+                           session_id="", harness="cli")
+        _print_status(verdict)
+        return 2 if verdict["decision"] == "block" else 0
+```
+
+Update the module docstring's exit-code line: `gate` exit 2 = block (a guarded actuator fired outside the armed envelope).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python MC/test_custody_cli.py`
+Expected: PASS all (exit 0).
+
+- [ ] **Step 5: Commit (operator GO required)**
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody/
+git commit --signoff -m "feat(mission-custody): gate verb + open/amend guard flags (refs #117)"
+```
+
+---
+
+### Task 5: The hook script (`custody_hook.py`)
+
+**Files:**
+- Create: `MC/custody_hook.py`
+- Test: `MC/test_custody_hook.py` (create)
+
+**Interfaces:**
+- Consumes: `custody_gate.run_gate`.
+- Produces: `python custody_hook.py --harness <name>` reads a harness payload on stdin, exits 0 (allow) or 2 (block, reason on stderr; cursor/gemini may instead emit decision JSON per their docs — see Task 6 verification step). Adapter contract: `ADAPTERS[name](payload: dict) -> dict | None` returning `{"tool_name", "command", "file_path", "session_id", "cwd"}`; `None` = nothing to evaluate → exit 0.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `MC/test_custody_hook.py` — subprocess-driven, one workspace fixture with an enforced guard on `rm -rf`, feeding canonical payloads:
+
+```python
+#!/usr/bin/env python3
+"""End-to-end tests for custody_hook.py: stdin payload -> exit code."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+HOOK = ROOT / "custody_hook.py"
+sys.path.insert(0, str(ROOT))
+from custody_mission import Mission  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+GUARDS = [{"name": "no-rm", "tool_names": ["Bash", "shell", "Shell"],
+           "command_regexes": ["rm -rf"], "path_globs": []}]
+
+
+def run_hook(harness: str, payload: dict | str) -> subprocess.CompletedProcess:
+    raw = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        [sys.executable, str(HOOK), "--harness", harness],
+        input=raw, capture_output=True, text=True)
+
+
+def payloads(cwd: str) -> dict:
+    return {
+        "claude": {"hook_event_name": "PreToolUse", "session_id": "s1",
+                   "cwd": cwd,
+                   "tool_name": "Bash", "tool_input": {"command": "rm -rf x"}},
+        "kimi": {"hook_event_name": "PreToolUse", "session_id": "s2",
+                 "cwd": cwd,
+                 "tool_name": "Bash", "tool_input": {"command": "rm -rf x"}},
+        "codex": {"session_id": "s3", "cwd": cwd,
+                  "tool_name": "Bash", "tool_input": {"command": "rm -rf x"}},
+        "cursor": {"command": "rm -rf x", "cwd": cwd},  # beforeShellExecution
+        "gemini": {"tool_name": "Bash",
+                   "tool_input": {"command": "rm -rf x"}, "cwd": cwd},
+        "generic": {"tool_name": "Bash",
+                    "tool_input": {"command": "rm -rf x"}, "cwd": cwd},
+    }
+
+
+def test_block_per_harness() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-e2e", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        for harness, payload in payloads(tmp).items():
+            res = run_hook(harness, payload)
+            check(f"hook-{harness}-blocks", res.returncode == 2)
+            check(f"hook-{harness}-reason-names-rule",
+                  "no-rm" in (res.stderr + res.stdout))
+
+
+def test_allow_paths() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-allow", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        ok = payloads(tmp)["claude"]
+        ok["tool_input"] = {"command": "ls"}
+        check("hook-unmatched-allows", run_hook("claude", ok).returncode == 0)
+    with tempfile.TemporaryDirectory() as tmp:
+        # no missions dir at all -> inert fast path
+        p = payloads(tmp)["claude"]
+        check("hook-no-missions-dir-allows",
+              run_hook("claude", p).returncode == 0)
+
+
+def test_fail_open() -> None:
+    check("hook-garbage-stdin-allows", run_hook("claude", "not json{{").returncode == 0)
+    check("hook-empty-stdin-allows", run_hook("claude", "").returncode == 0)
+    check("hook-unknown-harness-allows",
+          subprocess.run([sys.executable, str(HOOK), "--harness", "nope"],
+                         input="{}", capture_output=True,
+                         text=True).returncode == 0)
+
+
+if __name__ == "__main__":
+    for fn in list(globals().values()):
+        if callable(fn) and getattr(fn, "__name__", "").startswith("test_"):
+            fn()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILURES")
+        sys.exit(1)
+    print("all green")
+```
+
+Note for executor: the cursor/gemini payload shapes above are placeholders pending the docs-verification in Task 6 — if the official payloads differ, update the adapter AND this fixture to match, and note the source URL in the commit message.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `python MC/test_custody_hook.py`
+Expected: failures — `custody_hook.py` does not exist.
+
+- [ ] **Step 3: Implement `MC/custody_hook.py`**
+
+```python
+#!/usr/bin/env python3
+"""Stage-C PreToolUse hook: harness payload -> custody gate -> exit 0/2.
+
+Fail-open by contract: ANY error (bad JSON, unknown harness, missing cwd,
+no mission, evaluator exception) exits 0. Denial travels only via the
+deliberate block path. Timeout is the harness's (configure <=10s); the inert
+fast path is one directory stat.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def _claude_kimi(payload: dict) -> dict | None:
+    tool_input = payload.get("tool_input") or {}
+    return {
+        "tool_name": payload.get("tool_name", ""),
+        "command": tool_input.get("command"),
+        "file_path": tool_input.get("file_path"),
+        "session_id": payload.get("session_id", ""),
+        "cwd": payload.get("cwd", ""),
+    }
+
+
+def _cursor(payload: dict) -> dict | None:
+    # beforeShellExecution: {"command", "cwd"}; preToolUse carries tool fields.
+    return {
+        "tool_name": payload.get("tool_name", "Shell"),
+        "command": payload.get("command")
+        or (payload.get("tool_input") or {}).get("command"),
+        "file_path": (payload.get("tool_input") or {}).get("file_path"),
+        "session_id": payload.get("session_id", ""),
+        "cwd": payload.get("cwd", ""),
+    }
+
+
+ADAPTERS = {
+    "claude": _claude_kimi,
+    "kimi": _claude_kimi,
+    "codex": _claude_kimi,   # same PreToolUse shape; Task 6 docs-verify
+    "cursor": _cursor,
+    "gemini": _claude_kimi,  # BeforeTool shape; Task 6 docs-verify (agy shares it)
+    "generic": _claude_kimi,
+}
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="custody_hook.py")
+    parser.add_argument("--harness", default="generic")
+    args = parser.parse_args(argv)
+    try:
+        adapter = ADAPTERS[args.harness]
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return 0
+        call = adapter(payload)
+        if not call or not call.get("tool_name") and not call.get("command"):
+            return 0
+        cwd = call.get("cwd") or "."
+        workspace = Path(cwd)
+        if not (workspace / "missions").is_dir():
+            return 0  # inert fast path: no custody state here at all
+        from custody_gate import run_gate
+        verdict = run_gate(
+            workspace,
+            {"tool_name": call["tool_name"], "command": call.get("command"),
+             "file_path": call.get("file_path")},
+            actor="hook:custody-gate",
+            session_id=call.get("session_id", ""), harness=args.harness)
+        if verdict["decision"] == "block":
+            print(f"custody gate: BLOCKED -- {verdict['reason']}",
+                  file=sys.stderr)
+            return 2
+        return 0
+    except Exception:
+        return 0  # fail open, always
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python MC/test_custody_hook.py`
+Expected: PASS all (exit 0).
+
+- [ ] **Step 5: Commit (operator GO required)**
+
+```bash
+git add plugins/epistemic-skills/contracts/mission-custody/
+git commit --signoff -m "feat(mission-custody): custody_hook PreToolUse script with per-harness adapters, fail-open (refs #117)"
+```
+
+---
+
+### Task 6: Harness wiring (docs-verified per harness)
+
+**Files:**
+- Create: `plugins/epistemic-skills/hooks/hooks.json` (Claude Code plugin hooks)
+- Modify: `plugins/epistemic-skills/.kimi-plugin/plugin.json` (add `hooks` array)
+- Create: `plugins/epistemic-skills/hooks/codex-hooks.json` + `plugins/epistemic-skills/hooks/cursor-hooks.json` + `plugins/epistemic-skills/hooks/gemini-settings-snippet.json`
+- Modify: `plugins/epistemic-skills/.cursor-plugin/plugin.json` (add `hooks` key if the docs support plugin-shipped hooks)
+- Modify: root-level manifests (`/.kimi-plugin/plugin.json`, `/.claude-plugin/...`, `/.cursor-plugin/plugin.json`, `/gemini-extension.json`) ONLY IF `packaging/` shows they are hand-maintained siblings rather than generated — inspect `packaging/` first and follow the repo's sync mechanism.
+- Test: manual wiring validation step below (no unit tests for JSON wiring; verification is structural + docs citations)
+
+**Interfaces:**
+- Consumes: `custody_hook.py --harness <name>` (Task 5).
+- Produces: each harness's canonical hook registration pointing at the hook script with the right `--harness` value.
+
+- [ ] **Step 1: Inspect packaging/sync**
+
+Run: `ls packaging/` in the worktree; read the sync/packaging script. Determine whether root-level `.kimi-plugin/`, `.claude-plugin/`, `.cursor-plugin/`, `gemini-extension.json` are generated from `plugins/epistemic-skills/` or hand-maintained. Record the answer in the commit message; wire whichever level(s) are canonical.
+
+- [ ] **Step 2: Claude Code wiring**
+
+Create `plugins/epistemic-skills/hooks/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write|Edit|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/contracts/mission-custody/custody_hook.py\" --harness claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 3: Kimi wiring (docs-verified 2026-08-12: plugin `hooks` array, `event`/`matcher`/`command`/`timeout`, cwd = plugin root, `./` paths allowed)**
+
+Add to `plugins/epistemic-skills/.kimi-plugin/plugin.json`:
+
+```json
+"hooks": [
+  {
+    "event": "PreToolUse",
+    "matcher": "Bash|Write|Edit",
+    "command": "python ./contracts/mission-custody/custody_hook.py --harness kimi",
+    "timeout": 10
+  }
+]
+```
+
+- [ ] **Step 4: Codex / Cursor / Gemini — docs-verify, then wire**
+
+For EACH of the three: fetch the harness's official hook documentation (Codex: docs.openai.com codex hooks; Cursor: cursor.com docs hooks; Gemini CLI: github.com/google-gemini/gemini-cli hooks doc). Confirm: event name, matcher semantics, payload shape, blocking contract (exit 2 vs decision JSON), whether plugin/extension manifests can ship hooks natively. Then:
+
+- If the payload/blocking shape matches the Task 5 adapter: wire it (config JSON in `hooks/` + manifest key where supported + a README install note where only user-level config exists).
+- If it differs: fix the adapter and the Task 5 fixture to match the official schema, rerun `test_custody_hook.py`, and cite the doc URL in the commit.
+- If official docs cannot confirm: ship the wiring file marked unverified and say so in the README table (design's docs-verification gate). Do NOT assert support.
+
+Codex wiring (expected shape — verify): `hooks/codex-hooks.json` with a `PreToolUse` entry matching `Bash|apply_patch|mcp__.*` running `python <plugin>/contracts/mission-custody/custody_hook.py --harness codex`; README note that Codex reads `~/.codex/hooks.json` / project `.codex/hooks.json`.
+
+Cursor wiring (expected shape — verify): `.cursor-plugin/plugin.json` gains `"hooks": "./hooks/cursor-hooks.json"`; that file registers `beforeShellExecution`, `beforeMCPExecution`, `preToolUse` running the hook with `--harness cursor`.
+
+Gemini wiring (expected shape — verify): `hooks/gemini-settings-snippet.json` documenting the `BeforeTool` entry for `~/.gemini/settings.json` (covers Gemini CLI and agy, which share that surface), or `gemini-extension.json` hooks key if officially supported.
+
+- [ ] **Step 5: Structural validation**
+
+Run: `python -c "import json,glob; [json.load(open(f, encoding='utf-8')) for f in glob.glob('plugins/epistemic-skills/hooks/*.json') + ['plugins/epistemic-skills/.kimi-plugin/plugin.json']]; print('json ok')"` from the worktree root.
+Expected: `json ok`.
+
+- [ ] **Step 6: Commit (operator GO required)**
+
+```bash
+git add plugins/epistemic-skills/
+git commit --signoff -m "feat(mission-custody): PreToolUse wiring for claude/kimi/codex/cursor/gemini(+agy) (refs #117)"
+```
+
+---
+
+### Task 7: Retro-consumption docs
+
+**Files:**
+- Modify: `MC/README.md` (the "Harness bindings" section, currently: `Stage C (enforcement) is gated on the tracer retro.`)
+- Modify: `MC/SECURITY.md` (append fail-open + guard-tamper-residue sections)
+- Modify: `plugins/epistemic-skills/skills/manifest/SKILL.md` (the boundary bullet naming es#117)
+
+**Interfaces:**
+- Consumes: Tasks 1-6 landed.
+- Produces: no code interfaces; the retro ruling is recorded as consumed.
+
+- [ ] **Step 1: README edit**
+
+Replace the line `- Stage C (enforcement) is gated on the tracer retro.` with:
+
+```markdown
+- Stage C (enforcement): the tracer retro (2026-08-11, vanta
+  `mission/tracer-media-missing-record` @ `4540ddb`) ruled teeth IN, scoped to
+  the successor mission's real actuators. Shipped as `custody_hook.py` +
+  `gate` (design: `docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md`).
+  Inert by default: a mission arms it by adding operator-approved
+  `actuator_guards` + `guard_mode` to its manifest (`open --guards-file` /
+  `amend --guard-mode`). Harness wiring:
+  | harness | mechanism | verified |
+  |---|---|---|
+  | Claude Code | plugin `hooks/hooks.json` PreToolUse | yes |
+  | Kimi Code | plugin.json `hooks` array | yes (official docs 2026-08-12) |
+  | Codex | `hooks/codex-hooks.json` install note | <yes/no + doc URL> |
+  | Cursor | plugin.json `hooks` key | <yes/no + doc URL> |
+  | Gemini CLI + agy | `~/.gemini/settings.json` BeforeTool snippet | <yes/no + doc URL> |
+  | others | `generic` adapter recipe (below) | by construction |
+```
+
+(Fill the `<yes/no + doc URL>` cells from Task 6 Step 4 outcomes.)
+
+- [ ] **Step 2: SECURITY.md append**
+
+Append a new section:
+
+```markdown
+## Stage-C hook: fail-open and guard-tamper residue
+
+The PreToolUse custody hook is an enforcement layer over convention, not a
+sole barrier. Every supported harness fails open on hook error, timeout, or
+crash (Kimi documents this explicitly; Claude's contract is the same), so a
+broken hook silently reverts enforcement to convention-held. Denial travels
+only via the deliberate exit-2 / decision-JSON path.
+
+Guard matching is deliberately over-broad: a false block names its rule and
+is discharged by an `amend`; a false allow silently retires custody of the
+actuator class.
+
+A guard change without a recorded authority amendment is detected as manifest
+tampering. A guard change accompanied by a FORGED amendment on the unsealed
+tail checkpoint is the same residue class as amendment fabrication today;
+the structural fix (tail anchor) is tracked as es#118.
+```
+
+- [ ] **Step 3: SKILL.md boundary bullet edit**
+
+Replace the bullet beginning `- Custody here is convention-held, not mechanically enforced` with:
+
+```markdown
+- Custody enforcement is opt-in per mission: if the operator armed
+  `actuator_guards` + `guard_mode` (the es#117 Stage-C hook), guarded
+  actuators are mechanically gated -- a block names the rule and is
+  discharged only by an operator-granted `amend`. If the mission carries no
+  guards, custody remains convention-held; say so honestly if asked.
+```
+
+- [ ] **Step 4: Commit (operator GO required)**
+
+```bash
+git add plugins/epistemic-skills/
+git commit --signoff -m "docs(mission-custody): record Stage-C ruling consumed; fail-open + guard-tamper disclosure (refs #117)"
+```
+
+---
+
+### Task 8: Full-suite green + self-review gate
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run every custody test**
+
+```bash
+cd plugins/epistemic-skills/contracts/mission-custody
+for t in test_mission_custody.py test_custody_store.py test_custody_mission.py test_custody_cli.py test_custody_process_proof.py test_custody_gate.py test_custody_hook.py; do python "$t" || echo "FAILED: $t"; done
+python verify_mission_custody.py examples/valid-manifest-minimal.json
+```
+
+Expected: every suite prints all-green / exit 0; every `invalid-*.json` example still fails validation (the valid-manifest check exits 0).
+
+- [ ] **Step 2: Plugin-level checks**
+
+Run the repo's existing plugin validation (check `packaging/` or CI config for the command — e.g. manifest validation that shipped with v5.0.0's "advertised skills" guard) from the worktree root. Expected: green.
+
+- [ ] **Step 3: Diff review**
+
+`git diff 2931d386...HEAD --stat` — expected files only: mission-custody contract files, hooks/ wiring, manifest JSONs, skill/README/SECURITY docs, spec + plan under docs/superpowers/. Anything else is scope creep; drop it.
+
+- [ ] **Step 4: Final commit if anything changed (operator GO required)**
+
+---
+
+## Post-plan (operator-gated, from the goal contract — not plan tasks)
+
+1. requesting-code-review + independent adversarial review of the PR.
+2. PR (`Closes #117`) on operator GO; merge gated mechanically on green checks at the reviewed head SHA.
+3. Deploy to plugin cache; did-it-land hash-verify against the merge SHA.
+4. Evidence-locked live UAT on a scratch mission (audit logs a guarded call → amend to enforce → named-rule block) on Claude Code and Kimi.
+5. Receipt the outcome into `media-library-rebuild` (effect/note + frontier); close es#117.

--- a/docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md
+++ b/docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md
@@ -1,0 +1,184 @@
+# Stage-C custody enforcement hook — design (es#117)
+
+Date: 2026-08-12
+Issue: ZMS-Labs/epistemic-skills#117
+Status: approved by operator (section-by-section, brainstorming session 2026-08-12); goal contract live in the executing session
+
+## Provenance
+
+- Tracer retro (`tracer-media-missing`, RETRO.md on vanta branch
+  `mission/tracer-media-missing-record` @ `4540ddb`, ruling quoted in es#117):
+  **"Build teeth (PreToolUse enforcement boundary earned)… scoped to the successor
+  mission's real actuators (arr acquisition calls, filesystem moves), not built
+  speculatively."**
+- Manifest-efficacy evaluation (receipted into `media-library-rebuild` as
+  `efficacy-eval-2026-08-12`): custody is convention-held; `effect` went unused for
+  43/52 checkpoints of real work; no custody hook exists anywhere in the plugin.
+- This design closes the loop the retro opened. It also carries the issue's second
+  deliverable: the retro-consumption path (the README still says "Stage C is gated
+  on the tracer retro" — after this PR, the ruling is recorded as consumed).
+
+## Operator decisions (2026-08-12, brainstorming)
+
+1. **Harnesses:** all harnesses epistemic-skills ships, plus Antigravity CLI (`agy`)
+   and a generic adapter for the long tail.
+2. **Enforcement staging:** inert → audit-only → enforce (SAFETY-1: ship inert).
+3. **Guard rules location:** in the mission manifest, operator-approved, as additive
+   optional fields within `mission-manifest@1` (no epoch bump).
+4. **Gating mechanism:** Approach A — envelope-compiled gate. The manifest's
+   machine-checkable guard rules ARE the gate; no per-action intent bookkeeping
+   (the 43/52 adoption lesson: friction is where convention-held compliance dies).
+
+## Data model (additive within `mission-manifest@1`)
+
+Two optional fields inside `authority`:
+
+```json
+"authority": {
+  "...": "existing fields unchanged",
+  "guard_mode": "audit",
+  "actuator_guards": [
+    {
+      "name": "arr-api-mutations",
+      "tool_names": ["Bash"],
+      "command_regexes": ["https?://[^\\s]*(7878|8989|8686|9696)[^\\s]*/api/"],
+      "path_globs": []
+    },
+    {
+      "name": "media-fs-moves",
+      "tool_names": ["Bash", "Write", "Edit"],
+      "command_regexes": ["\\b(mv|robocopy|rsync|Move-Item)\\b[^\\n]*[Mm]edia"],
+      "path_globs": ["M:/Media/**", "//10.10.10.107/Media/**"]
+    }
+  ]
+}
+```
+
+Semantics:
+
+- **Guards absent → hook fully inert.** Installing the plugin changes nothing for
+  any mission that does not opt in. This is the ship-inert state.
+- `guard_mode`: `"audit"` | `"enforce"`; absent = inert even if guards exist.
+- **Match:** a tool call matches a rule iff the tool name is in `tool_names` AND at
+  least one pattern matches — `command_regexes` against Bash `tool_input.command`,
+  `path_globs` against Write/Edit `tool_input.file_path`.
+- **Match + audit mode:** allow; append one JSONL line to
+  `missions/<id>/guard-log.jsonl`.
+- **Match + enforce mode:** block (exit 2); stderr names the rule and the discharge
+  path (amend the envelope or stop); the block is also appended to `guard-log.jsonl`.
+- **Mode/guard transitions are authority changes.** Guards and mode are set at
+  `open` via new `--guards-file` / `--guard-mode` flags (a file, to avoid argv
+  bloat) and changed only via `amend` gaining the same two flags; the amend's
+  verbatim operator text is the grant. Guard relaxation leaves the same paper
+  trail as any authority change.
+- **The hook never mutates chain state.** `guard-log.jsonl` is a side observation
+  log (actor recorded as `hook:custody-gate` plus the payload's `session_id`), not
+  a checkpoint. The chain stays writable only by declared stewards.
+- **Deliberate over-matching bias** (per the handoff's error-direction lesson):
+  a false block names its rule and is recoverable in-session via amend; a false
+  allow silently retires custody of the exact actuator class the retro named.
+
+## Gate evaluator (CLI)
+
+New read-only verb in `custody_cli.py`:
+
+```
+python custody_cli.py gate --workspace <root> [--actor hook:custody-gate]
+```
+
+- Reads a normalized tool-call JSON on stdin (`--input-file` escape hatch).
+- Resolves the single active mission pathlessly (same discovery as `resume`).
+- Evaluates the call against the current checkpoint's manifest guards.
+- Prints verdict JSON `{decision, rule, reason, mode}` on stdout.
+- Exit 0 = allow, exit 2 = block (mirrors hook semantics).
+- Never touches chain state; the only write is the `guard-log.jsonl` append on a
+  match.
+
+## Hook script
+
+`contracts/mission-custody/custody_hook.py`, stdlib-only:
+
+```
+python custody_hook.py --harness <claude|kimi|codex|cursor|gemini|generic>
+```
+
+- Reads the harness payload from stdin; the named per-harness adapter normalizes it
+  to `{tool_name, command?, file_path?, session_id, cwd}`.
+- Calls the gate logic **in-process** (imports the contract modules — no subprocess
+  layer, so no RULE-027 escaping surface and no extra process latency).
+- Maps the verdict to the harness's blocking contract: exit 2 with the reason on
+  stderr (claude/kimi/codex/generic), decision JSON on stdout where the platform
+  uses one (cursor; gemini `BeforeTool` — exact schema verified at implementation).
+- Any exception, malformed payload, or missing mission → exit 0 (fail-open,
+  documented).
+- `generic` adapter: normalized `{tool_name, tool_input}` JSON in, exit 0/2 out —
+  the documented recipe for any harness with a PreToolUse-equivalent (Copilot CLI,
+  OpenCode, Pi, Hermes, Grok, …).
+- **agy** (Antigravity CLI) shares Gemini's `~/.gemini/settings.json` hook surface
+  (`BeforeTool`), so the `gemini` adapter covers it; the docs say so.
+
+### Fast path
+
+The hook fires on every matched tool call in every session with the plugin enabled.
+Inert must be near-free: one directory stat for `missions/`; no mission dir →
+immediate exit 0. Armed: one checkpoint read + pattern evaluation. Timeout budget
+10s configured; expected <200ms armed, <20ms inert.
+
+## Harness wiring matrix
+
+| Harness | Wiring artifact | Event/matcher | Status of contract |
+|---|---|---|---|
+| Claude Code | plugin `hooks/hooks.json` | `PreToolUse`, `Bash\|Write\|Edit\|mcp__.*` | Established on this fleet (safety_gate et al.) |
+| Kimi Code | `.kimi-plugin/plugin.json` `hooks` array | `PreToolUse`, tool-name regex | Verified against official docs 2026-08-12 |
+| Codex | `hooks/hooks.json` (user/project level; plugin-level support verified at implementation) | `PreToolUse`, `Bash\|apply_patch\|mcp__.*` | Docs-verify at implementation; hooks on by default in current builds |
+| Cursor | `.cursor-plugin/plugin.json` `hooks` key → `hooks/cursor-hooks.json` | `beforeShellExecution`, `beforeMCPExecution`, `preToolUse` | Docs-verify at implementation |
+| Gemini CLI (+ agy) | `gemini-extension.json` where supported, else documented `~/.gemini/settings.json` snippet | `BeforeTool` | Docs-verify at implementation |
+| Generic | documented wiring recipe | any PreToolUse-equivalent | By construction |
+
+**Docs-verification gate:** every per-harness wiring is verified against that
+harness's official documentation during implementation; a wiring whose contract
+cannot be confirmed from official docs ships marked unverified in the README table
+rather than asserted.
+
+## Fail-open disclosure (SECURITY.md)
+
+Hooks fail open on error/timeout/crash on every platform (Kimi documents this
+explicitly; Claude's contract is the same). SECURITY.md gains a section: the hook
+is an enforcement layer over convention, not a sole barrier; denial travels only
+via exit 2 / decision JSON; guards are only as good as their patterns; the
+over-matching bias is stated.
+
+## Retro-consumption edits (es#117 "also in scope")
+
+- `contracts/mission-custody/README.md`: replace "Stage C (enforcement) is gated on
+  the tracer retro" with the landed ruling — pointer to RETRO.md @ `4540ddb`, this
+  design doc, and the hook's inert-by-default posture.
+- `skills/manifest/SKILL.md` boundary bullet: updated to reflect that the hook
+  exists and is armed per-mission; honest label remains where a mission has not
+  opted in.
+
+## Testing
+
+- `test_custody_gate.py` (contract corpus style):
+  - schema corpus — valid/invalid guard manifests; every `invalid-*` example MUST
+    fail validation (the corpus is the regression suite);
+  - gate evaluator — per-field match/no-match; modes inert/audit/enforce; no
+    mission; mission closed; guard-log written in audit and enforce, not in inert;
+    chain head hash + revision byte-identical across a gate evaluation;
+  - hook end-to-end — each adapter's canonical stdin payload → exit 0/2; malformed
+    payload → exit 0; Windows and POSIX path handling for globs.
+- Live evidence-locked UAT (post-merge, per the goal contract): scratch mission,
+  audit mode logs a guarded call; promote via `amend --guard-mode enforce`; enforce
+  blocks with the named rule; on at least the Claude Code and Kimi wirings.
+
+## Non-goals
+
+- es#118 (contract@2: receipt-hash chaining + tail anchor).
+- es#124 residue (superseded-receipt visibility; disclosed, not patched).
+- Arming any live mission to enforce mode (operator act, not this PR).
+- Speculative actuator coverage: the hook ships with **no** built-in patterns;
+  policy is per-mission and operator-approved. The mechanism is generic; the rules
+  are not ours to write.
+- Actor-identity verification: hook payloads carry no custody actor; `session_id`
+  is logged, not authenticated.
+- O(n²) checkpoint storage (separately tracked, harmless at current revision).

--- a/plugins/epistemic-skills/.cursor-plugin/plugin.json
+++ b/plugins/epistemic-skills/.cursor-plugin/plugin.json
@@ -22,5 +22,6 @@
     "handoff"
   ],
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": "./agents/",
+  "hooks": "./hooks/cursor-hooks.json"
 }

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -21,7 +21,7 @@
   "hooks": [
     {
       "event": "PreToolUse",
-      "matcher": "Bash|Write|Edit",
+      "matcher": "Bash|Write|Edit|mcp__.*",
       "command": "python ./contracts/mission-custody/custody_hook.py --harness kimi",
       "timeout": 10
     }

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -18,6 +18,14 @@
     "handoff"
   ],
   "skills": "./skills/",
+  "hooks": [
+    {
+      "event": "PreToolUse",
+      "matcher": "Bash|Write|Edit",
+      "command": "python ./contracts/mission-custody/custody_hook.py --harness kimi",
+      "timeout": 10
+    }
+  ],
   "skillInstructions": "Kimi Code tool mapping for Epistemic Skills:\n\n- When a skill asks the user a question, asks for a choice, or presents multiple-choice options, call Kimi Code's `AskUserQuestion` tool. Provide 1 question with 2-4 concrete options; put the recommended option first and suffix its label with `(Recommended)`. Do not render choices as plain assistant text unless `AskUserQuestion` is unavailable or the session is in auto permission mode.\n- When a skill refers to `TodoWrite` or a todo list, use Kimi Code's `TodoList` tool.\n- When a skill dispatches subagents or role agents \u2014 gauntlet Step 5 role panel, evidence-locked-uat actor / blinded verifier / deterministic judge \u2014 use Kimi Code's `Agent` tool. Do not pass `general-purpose` as `subagent_type`. Use `coder` for implementation and review roles, `explore` for read-only investigation, and `plan` for read-only design. Paste the full role definition from this plugin's `agents/<role>.md` into the subagent prompt; each role agent is a separate `Agent` call so contexts stay isolated. Keep dependent role calls sequential; use parallel or background `Agent` calls only for roles that are independent by design.\n- When a skill refers to the `Skill` tool, use Kimi Code's native `Skill` tool.\n- Use Kimi Code's `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`, `FetchURL`, and `WebSearch` tools by their actual exposed names. Search file contents with `Grep`; find files by path or pattern with `Glob`.\n- Run the gauntlet helper scripts (`skills/gauntlet/scripts/*.py`, stdlib-only) with `python` via `Bash`.",
   "interface": {
     "displayName": "Epistemic Skills",

--- a/plugins/epistemic-skills/contracts/mission-custody/README.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/README.md
@@ -28,7 +28,11 @@ exists until evidence could support one.
   `gate` (design: `docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md`).
   Inert by default: a mission arms it by adding operator-approved
   `actuator_guards` + `guard_mode` to its manifest (`open --guards-file` /
-  `amend --guard-mode`). Harness wiring:
+  `amend --guard-mode`). The CLI can downgrade enforce -> audit
+  (`amend --guard-mode audit`), but full guard REMOVAL is API-only
+  (`Mission.amend_authority(..., actuator_guards=None)` -- the CLI's
+  `amend --guards-file` with `[]` is refused by validation); plan disarm
+  accordingly mid-incident. Harness wiring:
   | harness | mechanism | verified |
   |---|---|---|
   | Claude Code | plugin `hooks/hooks.json` PreToolUse | yes |
@@ -50,6 +54,11 @@ exists until evidence could support one.
   `command_regexes` match the shell command when there is one, and otherwise
   the full `tool_input` JSON serialized with sorted keys -- so MCP arguments
   (URLs, paths) are coverable by regex, crudely and deliberately over-broad.
+  The haystack is `json.dumps` output: backslashes and quotes in arguments
+  are JSON-escaped before your regex sees them, so prefer matching on
+  `host:port` substrings (e.g. `:7878/api`) over literal Windows paths.
+  Unknown tool names are the operator's responsibility: the validator refuses
+  silently-inert shapes only for the known shell / fs-write / `mcp__` classes.
 
   Mixed-fleet hazard: arming guards writes the new manifest fields into that
   mission's checkpoints, which pre-#117 plugin caches cannot validate (the

--- a/plugins/epistemic-skills/contracts/mission-custody/README.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/README.md
@@ -44,3 +44,14 @@ exists until evidence could support one.
   `file_path`, and a `cwd` naming the workspace that holds `missions/`;
   anything missing degrades to allow (fail-open). Exit 0 allows, exit 2
   blocks with the reason on stderr.
+
+  MCP coverage note: `tool_names` in a guard rule are exact-match against the
+  harness's tool name (`mcp__sonarr__post`, `run_shell_command`, ...);
+  `command_regexes` match the shell command when there is one, and otherwise
+  the full `tool_input` JSON serialized with sorted keys -- so MCP arguments
+  (URLs, paths) are coverable by regex, crudely and deliberately over-broad.
+
+  Mixed-fleet hazard: arming guards writes the new manifest fields into that
+  mission's checkpoints, which pre-#117 plugin caches cannot validate (the
+  armed mission reads as ChainBroken/unreadable there). Update every custody
+  consumer before arming guards on a shared mission.

--- a/plugins/epistemic-skills/contracts/mission-custody/README.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/README.md
@@ -22,4 +22,25 @@ exists until evidence could support one.
 
 - Skill: `manifest`
 - CLI: `plugins/epistemic-skills/contracts/mission-custody/custody_cli.py`
-- Stage C (enforcement) is gated on the tracer retro.
+- Stage C (enforcement): the tracer retro (2026-08-11, vanta
+  `mission/tracer-media-missing-record` @ `4540ddb`) ruled teeth IN, scoped to
+  the successor mission's real actuators. Shipped as `custody_hook.py` +
+  `gate` (design: `docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md`).
+  Inert by default: a mission arms it by adding operator-approved
+  `actuator_guards` + `guard_mode` to its manifest (`open --guards-file` /
+  `amend --guard-mode`). Harness wiring:
+  | harness | mechanism | verified |
+  |---|---|---|
+  | Claude Code | plugin `hooks/hooks.json` PreToolUse | yes |
+  | Kimi Code | plugin.json `hooks` array | yes (official docs 2026-08-12) |
+  | Codex | `hooks/codex-hooks.json` install note | yes — https://developers.openai.com/codex/hooks (2026-08-12): payload shape, exit-2 block, and `~/.codex/hooks.json` / `<repo>/.codex/hooks.json` discovery all confirmed; hosted tools never fire hooks (their docs' caveat, ours too) |
+  | Cursor | plugin.json `hooks` key -> `hooks/cursor-hooks.json` | mostly — https://cursor.com/docs/agent/hooks (2026-08-12) confirms payload shapes and exit-2 block; the plugin manifest `hooks` key is confirmed by https://cursor.com/docs/plugins plus third-party plugins using it, but the CWD plugin-shipped hook commands run from is undocumented (our `./contracts/...` command assumes the plugin root), and a 2026-06 forum report says Cursor CLI ignores plugin-shipped hooks (IDE honors them) |
+  | Gemini CLI + agy | `~/.gemini/settings.json` BeforeTool snippet (`hooks/gemini-settings-snippet.json`) | yes — https://geminicli.com/docs/hooks/reference/ (2026-08-12): payload shape, exit-2 block, millisecond timeout; built-in tool names differ (`run_shell_command` etc.) so guards must name them; agy coverage rests on the shared `~/.gemini/settings.json` surface (third-party evidence) |
+  | others | `generic` adapter recipe (below) | by construction |
+
+  Generic adapter recipe: point any harness that can pipe a JSON tool-call
+  payload to a script at `custody_hook.py --harness generic`. The payload
+  needs `tool_name` plus a `tool_input` object carrying `command` and/or
+  `file_path`, and a `cwd` naming the workspace that holds `missions/`;
+  anything missing degrades to allow (fail-open). Exit 0 allows, exit 2
+  blocks with the reason on stderr.

--- a/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
@@ -29,3 +29,20 @@
   outside the mission channel, which this document already places out of
   scope; this entry names the asymmetry so it is a known property rather than
   a rediscovery.
+
+## Stage-C hook: fail-open and guard-tamper residue
+
+The PreToolUse custody hook is an enforcement layer over convention, not a
+sole barrier. Every supported harness fails open on hook error, timeout, or
+crash (Kimi documents this explicitly; Claude's contract is the same), so a
+broken hook silently reverts enforcement to convention-held. Denial travels
+only via the deliberate exit-2 / decision-JSON path.
+
+Guard matching is deliberately over-broad: a false block names its rule and
+is discharged by an `amend`; a false allow silently retires custody of the
+actuator class.
+
+A guard change without a recorded authority amendment is detected as manifest
+tampering. A guard change accompanied by a FORGED amendment on the unsealed
+tail checkpoint is the same residue class as amendment fabrication today;
+the structural fix (tail anchor) is tracked as es#118.

--- a/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
@@ -42,7 +42,30 @@ Guard matching is deliberately over-broad: a false block names its rule and
 is discharged by an `amend`; a false allow silently retires custody of the
 actuator class.
 
-A guard change without a recorded authority amendment is detected as manifest
-tampering. A guard change accompanied by a FORGED amendment on the unsealed
-tail checkpoint is the same residue class as amendment fabrication today;
-the structural fix (tail anchor) is tracked as es#118.
+A guard change relative to the chain-protected previous checkpoint without a
+NEW recorded authority amendment since that checkpoint is detected as
+manifest tampering (reverting guards to the origin spelling, or riding on an
+earlier unrelated amendment, does not evade this). A guard change accompanied
+by a FORGED amendment on the unsealed tail checkpoint is the same residue
+class as amendment fabrication today; the structural fix (tail anchor) is
+tracked as es#118.
+
+## Stage-C hook: discovery scope, log sensitivity, mixed-fleet hazard
+
+Mission discovery walks up from the payload's cwd to the nearest ancestor
+holding `missions/`. A payload cwd OUTSIDE the workspace tree (or a harness
+that reports no cwd) finds nothing and the gate stays inert: the hook covers
+work reported from inside the mission's tree, not work reported from
+elsewhere.
+
+Guard-log command previews (`command_preview`, up to 120 chars of the matched
+command) may carry secrets embedded in command lines, and mission dirs ride
+sync/commit flows -- treat `guard-log.jsonl` as sensitive at the same level
+as shell history.
+
+Arming guards on a mission writes `actuator_guards` / `guard_mode` into that
+mission's checkpoints, and pre-#117 plugin caches cannot validate those
+fields: their stores will read the armed mission's checkpoints as
+ChainBroken (or skip the mission as unreadable). On a mixed fleet, update
+ALL custody consumers to the #117-or-later plugin before arming guards on
+any shared mission.

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -12,10 +12,12 @@ mission under --workspace on every other command.
 Exit codes: 0 success; 2 usage/refusal (argparse prints usage; a CustodyError
 subclass prints its class name + message to stderr); 3 drift detected on
 `resume`. `gate` adds: exit 2 = block (a guarded actuator fired outside the
-armed envelope), exit 0 = allow. On a clean resume the drift list on stdout
-is empty by contract; a one-line summary goes to stderr so vacuous
-cleanliness (zero receipts on record) is visible instead of indistinguishable
-from verified cleanliness.
+armed envelope), exit 0 = allow. Exit 2 is deliberately uniform across
+usage/refusal/block: a `gate` block is distinguishable by the verdict JSON
+on stdout ("decision": "block"), not by a dedicated exit code. On a clean
+resume the drift list on stdout is empty by contract; a one-line summary
+goes to stderr so vacuous cleanliness (zero receipts on record) is visible
+instead of indistinguishable from verified cleanliness.
 """
 from __future__ import annotations
 

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -11,9 +11,11 @@ mission under --workspace on every other command.
 
 Exit codes: 0 success; 2 usage/refusal (argparse prints usage; a CustodyError
 subclass prints its class name + message to stderr); 3 drift detected on
-`resume`. On a clean resume the drift list on stdout is empty by contract;
-a one-line summary goes to stderr so vacuous cleanliness (zero receipts on
-record) is visible instead of indistinguishable from verified cleanliness.
+`resume`. `gate` adds: exit 2 = block (a guarded actuator fired outside the
+armed envelope), exit 0 = allow. On a clean resume the drift list on stdout
+is empty by contract; a one-line summary goes to stderr so vacuous
+cleanliness (zero receipts on record) is visible instead of indistinguishable
+from verified cleanliness.
 """
 from __future__ import annotations
 
@@ -84,6 +86,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_open.add_argument("--stop-if", action="append", default=[], dest="stop_if")
     p_open.add_argument("--escalate-if", action="append", default=[], dest="escalate_if")
     p_open.add_argument("--cost", action="append", default=[], dest="acceptable_costs")
+    p_open.add_argument("--guards-file", dest="guards_file")
+    p_open.add_argument("--guard-mode", dest="guard_mode",
+                        choices=["audit", "enforce"])
 
     sub.add_parser("approve", parents=[common])
 
@@ -94,6 +99,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_amend = sub.add_parser("amend", parents=[common])
     p_amend.add_argument("--text", required=True)
+    p_amend.add_argument("--guards-file", dest="guards_file")
+    p_amend.add_argument("--guard-mode", dest="guard_mode",
+                         choices=["audit", "enforce"])
+
+    p_gate = sub.add_parser("gate", parents=[common])
+    p_gate.add_argument("--input-file", dest="input_file")
 
     p_note = sub.add_parser("note", parents=[common])
     p_note.add_argument("--text", required=True)
@@ -134,6 +145,31 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _read_guards_file(path: str) -> list:
+    with open(path, encoding="utf-8") as handle:
+        guards = json.load(handle)
+    if not isinstance(guards, list):
+        raise CustodyError("guards file must contain a JSON list of rules")
+    return guards
+
+
+def _read_tool_call(args: argparse.Namespace) -> dict:
+    # stdin carries the tool-call JSON by default -- argv has a ~32KB ceiling
+    # on Windows and every shell metachar must survive, same reason
+    # --content-file exists. --input-file is the explicit-file escape hatch.
+    raw = (Path(args.input_file).read_text(encoding="utf-8")
+           if args.input_file else sys.stdin.read())
+    try:
+        call = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CustodyError(f"gate: tool-call JSON unreadable: {exc}") from None
+    if not isinstance(call, dict) or not isinstance(call.get("tool_name"), str):
+        raise CustodyError("gate: tool-call JSON needs a string 'tool_name'")
+    call.setdefault("command", None)
+    call.setdefault("file_path", None)
+    return call
+
+
 def _brief(checkpoint: dict) -> dict:
     return {
         "mission_id": checkpoint["mission_id"],
@@ -154,6 +190,10 @@ def dispatch(args: argparse.Namespace) -> int:
     workspace = Path(args.workspace)
 
     if args.command == "open":
+        if args.guard_mode and not args.guards_file:
+            raise CustodyError("--guard-mode requires --guards-file")
+        guards = (_read_guards_file(args.guards_file)
+                  if args.guards_file else None)
         Mission.open(
             workspace, mission_id=args.mission_id, instruction=args.instruction,
             operator_ref=args.operator, steward_ref=args.steward,
@@ -161,9 +201,17 @@ def dispatch(args: argparse.Namespace) -> int:
             scope_in=args.scope_in, scope_out=args.scope_out,
             permissions=args.permission, protected_state=args.protected,
             hold_if=args.hold_if, stop_if=args.stop_if, escalate_if=args.escalate_if,
-            acceptable_costs=args.acceptable_costs)
+            acceptable_costs=args.acceptable_costs,
+            guard_mode=args.guard_mode, actuator_guards=guards)
         print(1)  # Mission.open always writes revision 1
         return 0
+
+    if args.command == "gate":
+        from custody_gate import run_gate
+        verdict = run_gate(workspace, _read_tool_call(args), actor=args.actor,
+                           session_id="", harness="cli")
+        _print_status(verdict)
+        return 2 if verdict["decision"] == "block" else 0
 
     mission = Mission.load(workspace, actor=args.actor)
 
@@ -178,7 +226,12 @@ def dispatch(args: argparse.Namespace) -> int:
                         "continuity_breaks": breaks})
         return 3 if breaks else 0
     elif args.command == "amend":
-        print(mission.amend_authority(args.text))
+        kwargs: dict = {}
+        if args.guards_file:
+            kwargs["actuator_guards"] = _read_guards_file(args.guards_file)
+        if args.guard_mode:
+            kwargs["guard_mode"] = args.guard_mode
+        print(mission.amend_authority(args.text, **kwargs))
     elif args.command == "note":
         print(mission.note(args.text))
     elif args.command == "frontier":

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from pathlib import Path
 
 from custody_mission import (
@@ -33,14 +34,22 @@ _PREVIEW = 120
 
 
 def _glob_regex(glob: str) -> "re.Pattern[str]":
-    """Translate a path glob: '**' crosses separators, '*'/'?' stay in-segment.
-    Paths are normalized ('\\' -> '/', no './', no trailing '/') before match;
-    on NT both sides fold A-Z only (_ascii_case_fold -- never str.casefold)."""
+    """Translate a path glob: '**' crosses separators ('**/' matches ZERO or
+    more segments; a trailing '/**' also matches the base path itself),
+    '*'/'?' stay in-segment. Paths are normalized ('\\' -> '/', no './', no
+    trailing '/') before match; on NT both sides fold A-Z only
+    (_ascii_case_fold -- never str.casefold)."""
+    trailing_base = glob.endswith("/**")
+    if trailing_base:
+        glob = glob[:-3]
     out: list[str] = []
     i = 0
     while i < len(glob):
         if glob[i] == "*":
-            if glob[i:i + 2] == "**":
+            if glob[i:i + 3] == "**/":
+                out.append("(?:.*/)?")
+                i += 3
+            elif glob[i:i + 2] == "**":
                 out.append(".*")
                 i += 2
             else:
@@ -52,6 +61,8 @@ def _glob_regex(glob: str) -> "re.Pattern[str]":
         else:
             out.append(re.escape(glob[i]))
             i += 1
+    if trailing_base:
+        out.append("(?:/.*)?")
     return re.compile("".join(out) + "$", re.DOTALL)
 
 
@@ -69,6 +80,15 @@ def _tool_in(rule: dict, tool_name: str) -> bool:
 
 def _patterns_match(rule: dict, tool_call: dict) -> bool:
     command = tool_call.get("command")
+    if not command:
+        # MCP and other non-shell tools carry their payload as structured
+        # arguments, not a command string. Serializing (sorted keys, so the
+        # haystack is deterministic) lets command_regexes cover URLs, paths,
+        # and flags inside those arguments. Deliberately crude: over-matching
+        # is the safe direction, and a false block names its rule.
+        tool_input = tool_call.get("tool_input")
+        if tool_input is not None:
+            command = json.dumps(tool_input, sort_keys=True)
     if command:
         for pattern in rule["command_regexes"]:
             if re.search(pattern, command):
@@ -116,7 +136,17 @@ def run_gate(workspace: Path, tool_call: dict, *, actor: str,
     workspace = Path(workspace)
     try:
         mission = Mission.load(workspace, actor=actor)
-    except (NoActiveMission, MultipleActiveMissions) as exc:
+    except NoActiveMission as exc:
+        return {"decision": "allow", "matched": False, "rule": None,
+                "mode": "inert", "reason": f"gate inert: {type(exc).__name__}"}
+    except MultipleActiveMissions as exc:
+        # Fail-open posture stands (a hook must never brick the tool loop on
+        # discovery ambiguity), but a decoy second mission silently disarming
+        # the gate must not pass quietly.
+        print(f"custody gate: MULTIPLE ACTIVE MISSIONS under {workspace} -- "
+              "gate inert, enforcement degraded to convention-held; resolve "
+              "the duplicate mission dirs before relying on guards",
+              file=sys.stderr)
         return {"decision": "allow", "matched": False, "rule": None,
                 "mode": "inert", "reason": f"gate inert: {type(exc).__name__}"}
     latest = mission.status()
@@ -135,5 +165,13 @@ def run_gate(workspace: Path, tool_call: dict, *, actor: str,
             "command_preview": command[:_PREVIEW],
             "file_path": tool_call.get("file_path"),
         }
-        _append_guard_log(mission.store.mission_dir, entry)
+        try:
+            _append_guard_log(mission.store.mission_dir, entry)
+        except Exception as exc:
+            # The audit append is best-effort; the VERDICT is not. A log
+            # failure must never flip a block into an allow.
+            print(f"custody gate: guard-log append failed "
+                  f"({type(exc).__name__}: {exc}); verdict "
+                  f"{verdict['decision']} stands but was not logged",
+                  file=sys.stderr)
     return verdict

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Stage-C gate: evaluate a harness tool call against the active mission's
+operator-approved actuator guards (mission-manifest@1 optional fields).
+
+Read-only by contract: the only write anywhere in this module is an append to
+missions/<id>/guard-log.jsonl on a MATCH -- the checkpoint chain is never
+touched (verified by test: run-gate-chain-byte-identical). The checkpoint read
+goes through MissionStore.load_latest, so the manifest evaluated is the
+chain-verified latest.
+
+Matching is deliberately over-broad (handoff error-direction lesson): a false
+block names its rule and is discharged by an amend; a false allow silently
+retires custody of the actuator class the tracer retro named.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+from custody_mission import (
+    Mission,
+    MultipleActiveMissions,
+    NoActiveMission,
+    _ascii_case_fold,
+    _normalize_relpath,
+    now_utc,
+)
+
+GUARD_LOG_NAME = "guard-log.jsonl"
+_PREVIEW = 120
+
+
+def _glob_regex(glob: str) -> "re.Pattern[str]":
+    """Translate a path glob: '**' crosses separators, '*'/'?' stay in-segment.
+    Paths are normalized ('\\' -> '/', no './', no trailing '/') before match;
+    on NT both sides fold A-Z only (_ascii_case_fold -- never str.casefold)."""
+    out: list[str] = []
+    i = 0
+    while i < len(glob):
+        if glob[i] == "*":
+            if glob[i:i + 2] == "**":
+                out.append(".*")
+                i += 2
+            else:
+                out.append("[^/]*")
+                i += 1
+        elif glob[i] == "?":
+            out.append("[^/]")
+            i += 1
+        else:
+            out.append(re.escape(glob[i]))
+            i += 1
+    return re.compile("".join(out) + "$", re.DOTALL)
+
+
+def _fold(text: str) -> str:
+    return _ascii_case_fold(text) if os.name == "nt" else text
+
+
+def _norm_path(path: str) -> str:
+    return _fold(_normalize_relpath(path.replace("\\", "/")))
+
+
+def _tool_in(rule: dict, tool_name: str) -> bool:
+    return tool_name in rule["tool_names"]
+
+
+def _patterns_match(rule: dict, tool_call: dict) -> bool:
+    command = tool_call.get("command")
+    if command:
+        for pattern in rule["command_regexes"]:
+            if re.search(pattern, command):
+                return True
+    file_path = tool_call.get("file_path")
+    if file_path:
+        target = _norm_path(file_path)
+        for glob in rule["path_globs"]:
+            if _glob_regex(_fold(_normalize_relpath(glob))).match(target):
+                return True
+    return False
+
+
+def evaluate(authority: dict, tool_call: dict) -> dict:
+    mode = authority.get("guard_mode")
+    guards = authority.get("actuator_guards")
+    if not mode or not guards:
+        return {"decision": "allow", "matched": False, "rule": None,
+                "mode": mode or "inert", "reason": "no guards armed"}
+    for rule in guards:
+        if _tool_in(rule, tool_call.get("tool_name", "")) \
+                and _patterns_match(rule, tool_call):
+            if mode == "enforce":
+                return {"decision": "block", "matched": True,
+                        "rule": rule["name"], "mode": mode,
+                        "reason": (
+                            f"custody guard '{rule['name']}' matched this call; "
+                            "the mission envelope does not discharge it -- record "
+                            "an operator grant via `amend` or stop")}
+            return {"decision": "allow", "matched": True, "rule": rule["name"],
+                    "mode": mode,
+                    "reason": f"custody guard '{rule['name']}' matched (audit mode)"}
+    return {"decision": "allow", "matched": False, "rule": None,
+            "mode": mode, "reason": "no guard matched"}
+
+
+def _append_guard_log(mission_dir: Path, entry: dict) -> None:
+    path = mission_dir / GUARD_LOG_NAME
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def run_gate(workspace: Path, tool_call: dict, *, actor: str,
+             session_id: str = "", harness: str = "") -> dict:
+    workspace = Path(workspace)
+    try:
+        mission = Mission.load(workspace, actor=actor)
+    except (NoActiveMission, MultipleActiveMissions) as exc:
+        return {"decision": "allow", "matched": False, "rule": None,
+                "mode": "inert", "reason": f"gate inert: {type(exc).__name__}"}
+    latest = mission.status()
+    verdict = evaluate(latest["manifest"]["authority"], tool_call)
+    if verdict["matched"]:
+        command = tool_call.get("command") or ""
+        entry = {
+            "utc": now_utc(),
+            "actor": actor,
+            "session_id": session_id,
+            "harness": harness,
+            "mode": verdict["mode"],
+            "decision": verdict["decision"],
+            "rule": verdict["rule"],
+            "tool_name": tool_call.get("tool_name", ""),
+            "command_preview": command[:_PREVIEW],
+            "file_path": tool_call.get("file_path"),
+        }
+        _append_guard_log(mission.store.mission_dir, entry)
+    return verdict

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -4,7 +4,13 @@
 Fail-open by contract: ANY error (bad JSON, unknown harness, missing cwd,
 no mission, evaluator exception) exits 0. Denial travels only via the
 deliberate block path. Timeout is the harness's (configure <=10s); the inert
-fast path is one directory stat.
+fast path is one directory stat per ancestor level.
+
+Mission discovery walks UP from the payload's cwd (git-style) to the nearest
+ancestor holding missions/. Residual, disclosed in SECURITY.md: a payload
+cwd OUTSIDE the workspace tree (or a harness that reports no cwd) finds no
+missions/ and stays inert -- the gate covers work done under the mission's
+tree, not work reported from elsewhere.
 """
 from __future__ import annotations
 
@@ -15,6 +21,19 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from custody_mission import CustodyError
+
+
+def _find_workspace(cwd: str) -> Path | None:
+    current = Path(cwd or ".")
+    while True:
+        if (current / "missions").is_dir():
+            return current
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+
 
 def _claude_kimi(payload: dict) -> dict | None:
     tool_input = payload.get("tool_input") or {}
@@ -22,6 +41,7 @@ def _claude_kimi(payload: dict) -> dict | None:
         "tool_name": payload.get("tool_name", ""),
         "command": tool_input.get("command"),
         "file_path": tool_input.get("file_path"),
+        "tool_input": tool_input or None,
         "session_id": payload.get("session_id", ""),
         "cwd": payload.get("cwd", ""),
     }
@@ -44,6 +64,7 @@ def _cursor(payload: dict) -> dict | None:
         "tool_name": payload.get("tool_name", "Shell"),
         "command": payload.get("command") or tool_input.get("command"),
         "file_path": tool_input.get("file_path"),
+        "tool_input": tool_input or None,
         "session_id": payload.get("session_id", ""),
         "cwd": payload.get("cwd", ""),
     }
@@ -70,23 +91,29 @@ def main(argv: list[str]) -> int:
         if not isinstance(payload, dict):
             return 0
         call = adapter(payload)
-        if not call or not call.get("tool_name") and not call.get("command"):
+        if not call or (not call.get("tool_name") and not call.get("command")):
             return 0
-        cwd = call.get("cwd") or "."
-        workspace = Path(cwd)
-        if not (workspace / "missions").is_dir():
-            return 0  # inert fast path: no custody state here at all
+        workspace = _find_workspace(call.get("cwd") or ".")
+        if workspace is None:
+            return 0  # inert fast path: no custody state at or above cwd
         from custody_gate import run_gate
         verdict = run_gate(
             workspace,
             {"tool_name": call["tool_name"], "command": call.get("command"),
-             "file_path": call.get("file_path")},
+             "file_path": call.get("file_path"),
+             "tool_input": call.get("tool_input")},
             actor="hook:custody-gate",
             session_id=call.get("session_id", ""), harness=args.harness)
         if verdict["decision"] == "block":
             print(f"custody gate: BLOCKED -- {verdict['reason']}",
                   file=sys.stderr)
             return 2
+        return 0
+    except CustodyError as exc:
+        # Fail-open posture stands, but a tamper/custody signal must not be
+        # silent: name it on stderr so the session log carries it.
+        print(f"custody gate: TAMPER/custody error detected, failing open: "
+              f"{type(exc).__name__}: {exc}", file=sys.stderr)
         return 0
     except Exception:
         return 0  # fail open, always

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Stage-C PreToolUse hook: harness payload -> custody gate -> exit 0/2.
+
+Fail-open by contract: ANY error (bad JSON, unknown harness, missing cwd,
+no mission, evaluator exception) exits 0. Denial travels only via the
+deliberate block path. Timeout is the harness's (configure <=10s); the inert
+fast path is one directory stat.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def _claude_kimi(payload: dict) -> dict | None:
+    tool_input = payload.get("tool_input") or {}
+    return {
+        "tool_name": payload.get("tool_name", ""),
+        "command": tool_input.get("command"),
+        "file_path": tool_input.get("file_path"),
+        "session_id": payload.get("session_id", ""),
+        "cwd": payload.get("cwd", ""),
+    }
+
+
+def _cursor(payload: dict) -> dict | None:
+    # beforeShellExecution: {"command", "cwd"}; preToolUse carries tool fields.
+    # beforeMCPExecution sends tool_input as a JSON STRING (verified against
+    # https://cursor.com/docs/agent/hooks 2026-08-12) -- parse it so command
+    # extraction still works; an unparseable string degrades to no match.
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, str):
+        try:
+            tool_input = json.loads(tool_input)
+        except ValueError:
+            tool_input = {}
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    return {
+        "tool_name": payload.get("tool_name", "Shell"),
+        "command": payload.get("command") or tool_input.get("command"),
+        "file_path": tool_input.get("file_path"),
+        "session_id": payload.get("session_id", ""),
+        "cwd": payload.get("cwd", ""),
+    }
+
+
+ADAPTERS = {
+    "claude": _claude_kimi,
+    "kimi": _claude_kimi,
+    "codex": _claude_kimi,   # same PreToolUse shape; Task 6 docs-verify
+    "cursor": _cursor,
+    "gemini": _claude_kimi,  # BeforeTool shape; Task 6 docs-verify (agy shares it)
+    "generic": _claude_kimi,
+}
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="custody_hook.py")
+    parser.add_argument("--harness", default="generic")
+    args = parser.parse_args(argv)
+    try:
+        adapter = ADAPTERS[args.harness]
+        raw = sys.stdin.read()
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return 0
+        call = adapter(payload)
+        if not call or not call.get("tool_name") and not call.get("command"):
+            return 0
+        cwd = call.get("cwd") or "."
+        workspace = Path(cwd)
+        if not (workspace / "missions").is_dir():
+            return 0  # inert fast path: no custody state here at all
+        from custody_gate import run_gate
+        verdict = run_gate(
+            workspace,
+            {"tool_name": call["tool_name"], "command": call.get("command"),
+             "file_path": call.get("file_path")},
+            actor="hook:custody-gate",
+            session_id=call.get("session_id", ""), harness=args.harness)
+        if verdict["decision"] == "block":
+            print(f"custody gate: BLOCKED -- {verdict['reason']}",
+                  file=sys.stderr)
+            return 2
+        return 0
+    except Exception:
+        return 0  # fail open, always
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -139,6 +139,19 @@ class Mission:
               guard_mode: str | None = None,
               actuator_guards: list | None = None) -> "Mission":
         workspace = Path(workspace)
+        # One ACTIVE mission per workspace, enforced at the door: every other
+        # command refuses multiple-active discovery, so open creating that
+        # state would be a decoy-disarm wedge (a second armed-or-unarmed
+        # mission bricks the gate's discovery). Checked BEFORE anything is
+        # written, so a refused open leaves no partial mission dir.
+        try:
+            cls.load(workspace, actor=actor)
+        except NoActiveMission:
+            pass  # the expected state: nothing active to conflict with
+        else:
+            raise CustodyError(
+                "an active mission already exists under this workspace; "
+                "complete or cancel it before opening another")
         store = MissionStore(workspace / "missions" / mission_id)
         created = now_utc()
         manifest = {
@@ -264,18 +277,28 @@ class Mission:
         origin_rest["authority"]["amendments"] = []
         latest_rest["authority"]["amendments"] = []
         # Guard fields are authority too: they may change only via amend, and
-        # amend always appends the operator's verbatim grant -- so a guard
-        # difference without any recorded amendment is tampering. (A forged
+        # amend always appends the operator's verbatim grant. The trustworthy
+        # baseline is the chain-protected PREVIOUS checkpoint (the same
+        # baseline the append-only check above uses), NOT the origin: an
+        # amended mission legitimately diverges from its origin, so a forged
+        # tail that reverts guards to the origin spelling -- or rides on an
+        # earlier unrelated amendment -- must still read as tampering. A
+        # guard difference from the baseline is sanctioned only when the
+        # amendments list GREW between baseline and latest. (A forged
         # amendment stays possible on the unsealed tail; that is the es#118
         # residue, disclosed in SECURITY.md, not something this check invents
         # coverage for.)
-        origin_guards = {k: origin_rest["authority"].pop(k, None)
-                         for k in _GUARD_AUTHORITY_KEYS}
+        baseline_rest = json.loads(json.dumps(baseline))
+        baseline_guards = {k: baseline_rest["authority"].pop(k, None)
+                           for k in _GUARD_AUTHORITY_KEYS}
         latest_guards = {k: latest_rest["authority"].pop(k, None)
                          for k in _GUARD_AUTHORITY_KEYS}
-        if origin_guards != latest_guards and not latest_amendments:
+        for k in _GUARD_AUTHORITY_KEYS:
+            origin_rest["authority"].pop(k, None)
+        if baseline_guards != latest_guards \
+                and len(latest_amendments) <= len(baseline_amendments):
             raise CustodyError(
-                "actuator guards changed with no authority amendment "
+                "actuator guards changed with no new authority amendment "
                 "recorded (tampered)")
         if origin_rest != latest_rest:
             differing = sorted(
@@ -542,9 +565,18 @@ class Mission:
         manifest["authority"]["amendments"].append(
             {"utc": now_utc(), "text": text})
         if actuator_guards is not _UNSET:
-            manifest["authority"]["actuator_guards"] = actuator_guards
+            # None clears the field (the key is removed, not nulled -- the
+            # schema has no nullable guard fields); a [] "clear" is refused
+            # by validation (minItems: 1), so clearing MUST go through None.
+            if actuator_guards is None:
+                manifest["authority"].pop("actuator_guards", None)
+            else:
+                manifest["authority"]["actuator_guards"] = actuator_guards
         if guard_mode is not _UNSET:
-            manifest["authority"]["guard_mode"] = guard_mode
+            if guard_mode is None:
+                manifest["authority"].pop("guard_mode", None)
+            else:
+                manifest["authority"]["guard_mode"] = guard_mode
         new = self._write_next(latest, path, status=latest["status"],
                                 manifest=manifest,
                                 note=f"authority amended: {text}")

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -18,6 +18,8 @@ from verify_mission_custody import TIERS, VERDICTS, validate_record
 _OPEN_STATES = {"draft", "active", "reopened", "verifying"}
 _EFFECT_STATES = {"draft", "active", "reopened"}
 _TIER_RANK = {"declared-role-separation": 1, "operator-accepted": 2}
+_UNSET = object()  # amend sentinel: distinguishes "leave alone" from "clear"
+_GUARD_AUTHORITY_KEYS = ("actuator_guards", "guard_mode")
 assert set(_TIER_RANK) == TIERS, "tier rank table out of sync with verify_mission_custody.TIERS"
 
 _ABS_DRIVE_RE = re.compile(r"^[A-Za-z]:")
@@ -133,7 +135,9 @@ class Mission:
               protected_state: list[str] | None = None,
               hold_if: list[str] | None = None, stop_if: list[str] | None = None,
               escalate_if: list[str] | None = None,
-              acceptable_costs: list[str] | None = None) -> "Mission":
+              acceptable_costs: list[str] | None = None,
+              guard_mode: str | None = None,
+              actuator_guards: list | None = None) -> "Mission":
         workspace = Path(workspace)
         store = MissionStore(workspace / "missions" / mission_id)
         created = now_utc()
@@ -148,6 +152,9 @@ class Mission:
                 "permissions": list(permissions or []),
                 "protected_state": list(protected_state or []),
                 "acceptable_costs": list(acceptable_costs or []),
+                **({"actuator_guards": actuator_guards}
+                   if actuator_guards is not None else {}),
+                **({"guard_mode": guard_mode} if guard_mode is not None else {}),
             },
             "scope": {"in": list(scope_in or []), "out": list(scope_out or [])},
             "acceptance": {"required_tier": required_tier, "acceptor_ref": None},
@@ -256,6 +263,20 @@ class Mission:
         latest_rest = json.loads(json.dumps(latest_manifest))
         origin_rest["authority"]["amendments"] = []
         latest_rest["authority"]["amendments"] = []
+        # Guard fields are authority too: they may change only via amend, and
+        # amend always appends the operator's verbatim grant -- so a guard
+        # difference without any recorded amendment is tampering. (A forged
+        # amendment stays possible on the unsealed tail; that is the es#118
+        # residue, disclosed in SECURITY.md, not something this check invents
+        # coverage for.)
+        origin_guards = {k: origin_rest["authority"].pop(k, None)
+                         for k in _GUARD_AUTHORITY_KEYS}
+        latest_guards = {k: latest_rest["authority"].pop(k, None)
+                         for k in _GUARD_AUTHORITY_KEYS}
+        if origin_guards != latest_guards and not latest_amendments:
+            raise CustodyError(
+                "actuator guards changed with no authority amendment "
+                "recorded (tampered)")
         if origin_rest != latest_rest:
             differing = sorted(
                 key for key in set(origin_rest) | set(latest_rest)
@@ -492,7 +513,8 @@ class Mission:
                           note=f"effect: {artifact_relpath}")
         return receipt
 
-    def amend_authority(self, text: str) -> int:
+    def amend_authority(self, text: str, *, guard_mode=_UNSET,
+                        actuator_guards=_UNSET) -> int:
         """Record a VERBATIM operator grant that changes the mission's
         authority, appended to authority.amendments.
 
@@ -519,6 +541,10 @@ class Mission:
         manifest = json.loads(json.dumps(latest["manifest"]))
         manifest["authority"]["amendments"].append(
             {"utc": now_utc(), "text": text})
+        if actuator_guards is not _UNSET:
+            manifest["authority"]["actuator_guards"] = actuator_guards
+        if guard_mode is not _UNSET:
+            manifest["authority"]["guard_mode"] = guard_mode
         new = self._write_next(latest, path, status=latest["status"],
                                 manifest=manifest,
                                 note=f"authority amended: {text}")

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-bad-mode.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-bad-mode.json
@@ -1,0 +1,73 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": [
+      "repo:media-library:read",
+      "repo:media-library:write-config"
+    ],
+    "protected_state": [
+      "download-clients:enabled-state"
+    ],
+    "acceptable_costs": [
+      "one working session per stage"
+    ],
+    "guard_mode": "block",
+    "actuator_guards": [
+      {
+        "name": "arr-api-mutations",
+        "tool_names": [
+          "Bash"
+        ],
+        "command_regexes": [
+          "https?://[^\\s]*:(7878|8989|8686|9696)/api/"
+        ],
+        "path_globs": []
+      },
+      {
+        "name": "media-fs-moves",
+        "tool_names": [
+          "Bash",
+          "Write",
+          "Edit"
+        ],
+        "command_regexes": [
+          "\\b(mv|robocopy|rsync|Move-Item)\\b[^\\n]*[Mm]edia"
+        ],
+        "path_globs": [
+          "M:/Media/**",
+          "//10.10.10.107/Media/**"
+        ]
+      }
+    ]
+  },
+  "scope": {
+    "in": [
+      "monitored-missing reconciliation"
+    ],
+    "out": [
+      "indexer changes",
+      "VPN configuration"
+    ]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": [
+      "any download client starts re-grabbing"
+    ],
+    "stop_if": [
+      "operator revokes"
+    ],
+    "escalate_if": [
+      "protected state would be touched"
+    ]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-bad-regex.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-bad-regex.json
@@ -1,0 +1,73 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": [
+      "repo:media-library:read",
+      "repo:media-library:write-config"
+    ],
+    "protected_state": [
+      "download-clients:enabled-state"
+    ],
+    "acceptable_costs": [
+      "one working session per stage"
+    ],
+    "guard_mode": "audit",
+    "actuator_guards": [
+      {
+        "name": "arr-api-mutations",
+        "tool_names": [
+          "Bash"
+        ],
+        "command_regexes": [
+          "([unclosed"
+        ],
+        "path_globs": []
+      },
+      {
+        "name": "media-fs-moves",
+        "tool_names": [
+          "Bash",
+          "Write",
+          "Edit"
+        ],
+        "command_regexes": [
+          "\\b(mv|robocopy|rsync|Move-Item)\\b[^\\n]*[Mm]edia"
+        ],
+        "path_globs": [
+          "M:/Media/**",
+          "//10.10.10.107/Media/**"
+        ]
+      }
+    ]
+  },
+  "scope": {
+    "in": [
+      "monitored-missing reconciliation"
+    ],
+    "out": [
+      "indexer changes",
+      "VPN configuration"
+    ]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": [
+      "any download client starts re-grabbing"
+    ],
+    "stop_if": [
+      "operator revokes"
+    ],
+    "escalate_if": [
+      "protected state would be touched"
+    ]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-empty-rule.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-empty-rule.json
@@ -1,0 +1,71 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": [
+      "repo:media-library:read",
+      "repo:media-library:write-config"
+    ],
+    "protected_state": [
+      "download-clients:enabled-state"
+    ],
+    "acceptable_costs": [
+      "one working session per stage"
+    ],
+    "guard_mode": "audit",
+    "actuator_guards": [
+      {
+        "name": "arr-api-mutations",
+        "tool_names": [
+          "Bash"
+        ],
+        "command_regexes": [],
+        "path_globs": []
+      },
+      {
+        "name": "media-fs-moves",
+        "tool_names": [
+          "Bash",
+          "Write",
+          "Edit"
+        ],
+        "command_regexes": [
+          "\\b(mv|robocopy|rsync|Move-Item)\\b[^\\n]*[Mm]edia"
+        ],
+        "path_globs": [
+          "M:/Media/**",
+          "//10.10.10.107/Media/**"
+        ]
+      }
+    ]
+  },
+  "scope": {
+    "in": [
+      "monitored-missing reconciliation"
+    ],
+    "out": [
+      "indexer changes",
+      "VPN configuration"
+    ]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": [
+      "any download client starts re-grabbing"
+    ],
+    "stop_if": [
+      "operator revokes"
+    ],
+    "escalate_if": [
+      "protected state would be touched"
+    ]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-mode-without-guards.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-mode-without-guards.json
@@ -1,0 +1,46 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": [
+      "repo:media-library:read",
+      "repo:media-library:write-config"
+    ],
+    "protected_state": [
+      "download-clients:enabled-state"
+    ],
+    "acceptable_costs": [
+      "one working session per stage"
+    ],
+    "guard_mode": "audit"
+  },
+  "scope": {
+    "in": [
+      "monitored-missing reconciliation"
+    ],
+    "out": [
+      "indexer changes",
+      "VPN configuration"
+    ]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": [
+      "any download client starts re-grabbing"
+    ],
+    "stop_if": [
+      "operator revokes"
+    ],
+    "escalate_if": [
+      "protected state would be touched"
+    ]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-shell-only-globs.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-shell-only-globs.json
@@ -1,0 +1,58 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": [
+      "repo:media-library:read",
+      "repo:media-library:write-config"
+    ],
+    "protected_state": [
+      "download-clients:enabled-state"
+    ],
+    "acceptable_costs": [
+      "one working session per stage"
+    ],
+    "guard_mode": "audit",
+    "actuator_guards": [
+      {
+        "name": "media-fs-moves",
+        "tool_names": [
+          "Bash"
+        ],
+        "command_regexes": [],
+        "path_globs": [
+          "M:/Media/**"
+        ]
+      }
+    ]
+  },
+  "scope": {
+    "in": [
+      "monitored-missing reconciliation"
+    ],
+    "out": [
+      "indexer changes",
+      "VPN configuration"
+    ]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": [
+      "any download client starts re-grabbing"
+    ],
+    "stop_if": [
+      "operator revokes"
+    ],
+    "escalate_if": [
+      "protected state would be touched"
+    ]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-unknown-field.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-unknown-field.json
@@ -1,0 +1,74 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": [
+      "repo:media-library:read",
+      "repo:media-library:write-config"
+    ],
+    "protected_state": [
+      "download-clients:enabled-state"
+    ],
+    "acceptable_costs": [
+      "one working session per stage"
+    ],
+    "guard_mode": "audit",
+    "actuator_guards": [
+      {
+        "name": "arr-api-mutations",
+        "tool_names": [
+          "Bash"
+        ],
+        "command_regexes": [
+          "https?://[^\\s]*:(7878|8989|8686|9696)/api/"
+        ],
+        "path_globs": [],
+        "action": "block"
+      },
+      {
+        "name": "media-fs-moves",
+        "tool_names": [
+          "Bash",
+          "Write",
+          "Edit"
+        ],
+        "command_regexes": [
+          "\\b(mv|robocopy|rsync|Move-Item)\\b[^\\n]*[Mm]edia"
+        ],
+        "path_globs": [
+          "M:/Media/**",
+          "//10.10.10.107/Media/**"
+        ]
+      }
+    ]
+  },
+  "scope": {
+    "in": [
+      "monitored-missing reconciliation"
+    ],
+    "out": [
+      "indexer changes",
+      "VPN configuration"
+    ]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": [
+      "any download client starts re-grabbing"
+    ],
+    "stop_if": [
+      "operator revokes"
+    ],
+    "escalate_if": [
+      "protected state would be touched"
+    ]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/examples/valid-manifest-guards.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/examples/valid-manifest-guards.json
@@ -1,0 +1,36 @@
+{
+  "record": "mission-manifest@1",
+  "mission_id": "tracer-media-missing",
+  "created_utc": "2026-08-11T00:00:00Z",
+  "authority": {
+    "operator_ref": "operator:zach-stern",
+    "instruction": "Reconcile the monitored-missing media backlog without re-grabbing over VPN.",
+    "amendments": [],
+    "permissions": ["repo:media-library:read", "repo:media-library:write-config"],
+    "protected_state": ["download-clients:enabled-state"],
+    "acceptable_costs": ["one working session per stage"],
+    "guard_mode": "audit",
+    "actuator_guards": [
+      {"name": "arr-api-mutations", "tool_names": ["Bash"],
+       "command_regexes": ["https?://[^\\s]*:(7878|8989|8686|9696)/api/"],
+       "path_globs": []},
+      {"name": "media-fs-moves", "tool_names": ["Bash", "Write", "Edit"],
+       "command_regexes": ["\\b(mv|robocopy|rsync|Move-Item)\\b[^\\n]*[Mm]edia"],
+       "path_globs": ["M:/Media/**", "//10.10.10.107/Media/**"]}
+    ]
+  },
+  "scope": {
+    "in": ["monitored-missing reconciliation"],
+    "out": ["indexer changes", "VPN configuration"]
+  },
+  "acceptance": {
+    "required_tier": "declared-role-separation",
+    "acceptor_ref": null
+  },
+  "stop_rules": {
+    "hold_if": ["any download client starts re-grabbing"],
+    "stop_if": ["operator revokes"],
+    "escalate_if": ["protected state would be touched"]
+  },
+  "steward_ref": "agent:claude-code-session"
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/mission-manifest.schema.json
+++ b/plugins/epistemic-skills/contracts/mission-custody/mission-manifest.schema.json
@@ -20,7 +20,17 @@
         "amendments": {"type": "array", "items": {"type": "object", "required": ["utc", "text"], "additionalProperties": false, "properties": {"utc": {"type": "string"}, "text": {"type": "string", "minLength": 1}}}},
         "permissions": {"type": "array", "items": {"type": "string"}},
         "protected_state": {"type": "array", "items": {"type": "string"}},
-        "acceptable_costs": {"type": "array", "items": {"type": "string"}}
+        "acceptable_costs": {"type": "array", "items": {"type": "string"}},
+        "guard_mode": {"enum": ["audit", "enforce"]},
+        "actuator_guards": {"type": "array", "minItems": 1, "items": {
+          "type": "object", "additionalProperties": false,
+          "required": ["name", "tool_names", "command_regexes", "path_globs"],
+          "properties": {
+            "name": {"type": "string", "minLength": 1},
+            "tool_names": {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1},
+            "command_regexes": {"type": "array", "items": {"type": "string"}},
+            "path_globs": {"type": "array", "items": {"type": "string"}}
+          }}}
       }
     },
     "scope": {"type": "object", "required": ["in", "out"], "additionalProperties": false, "properties": {"in": {"type": "array", "items": {"type": "string"}}, "out": {"type": "array", "items": {"type": "string"}}}},

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -399,6 +399,76 @@ def test_no_mission_flags_outside_open() -> None:
     check("open-declares-mission-id", saw_mission_id_in_open)
 
 
+def test_gate_verb() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        # open an enforced mission guarding 'rm -rf'
+        guards = [{"name": "no-rm", "tool_names": ["Bash"],
+                   "command_regexes": ["rm -rf"], "path_globs": []}]
+        gfile = tmp / "guards.json"
+        gfile.write_text(json.dumps(guards), encoding="utf-8")
+        run("open", "--workspace", str(tmp), "--actor", "agent:t",
+            "--mission-id", "gate-cli", "--instruction", "i",
+            "--operator", "operator:t", "--steward", "agent:t",
+            "--guards-file", str(gfile), "--guard-mode", "enforce")
+        run("approve", "--workspace", str(tmp), "--actor", "agent:t")
+        blocked = subprocess.run(
+            [sys.executable, str(CLI), "gate", "--workspace", str(tmp),
+             "--actor", "hook:custody-gate"],
+            input=json.dumps({"tool_name": "Bash", "command": "rm -rf x",
+                              "file_path": None}),
+            capture_output=True, text=True)
+        check("gate-blocks-enforced", blocked.returncode == 2)
+        verdict = json.loads(blocked.stdout)
+        check("gate-verdict-fields",
+              verdict["decision"] == "block" and verdict["rule"] == "no-rm")
+        allowed = subprocess.run(
+            [sys.executable, str(CLI), "gate", "--workspace", str(tmp),
+             "--actor", "hook:custody-gate"],
+            input=json.dumps({"tool_name": "Bash", "command": "ls",
+                              "file_path": None}),
+            capture_output=True, text=True)
+        check("gate-allows-unmatched", allowed.returncode == 0)
+
+
+def test_gate_no_mission_allows() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        res = subprocess.run(
+            [sys.executable, str(CLI), "gate", "--workspace", str(tmp),
+             "--actor", "hook:custody-gate"],
+            input=json.dumps({"tool_name": "Bash", "command": "rm -rf /"}),
+            capture_output=True, text=True)
+        check("gate-no-mission-exit-0", res.returncode == 0)
+
+
+def test_open_guard_mode_without_guards_refused() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        res = run("open", "--workspace", str(tmp), "--actor", "agent:t",
+                  "--mission-id", "bad-open", "--instruction", "i",
+                  "--operator", "operator:t", "--steward", "agent:t",
+                  "--guard-mode", "audit")
+        check("open-mode-without-guards-refused", res.returncode == 2)
+
+
+def test_amend_guard_mode_flag() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        run("open", "--workspace", str(tmp), "--actor", "agent:t",
+            "--mission-id", "amend-cli", "--instruction", "i",
+            "--operator", "operator:t", "--steward", "agent:t")
+        run("approve", "--workspace", str(tmp), "--actor", "agent:t")
+        guards = [{"name": "g", "tool_names": ["Bash"],
+                   "command_regexes": ["x"], "path_globs": []}]
+        gfile = tmp / "g.json"
+        gfile.write_text(json.dumps(guards), encoding="utf-8")
+        res = run("amend", "--workspace", str(tmp), "--actor", "agent:t",
+                  "--text", "operator: arm audit mode",
+                  "--guards-file", str(gfile), "--guard-mode", "audit")
+        check("amend-guards-accepted", res.returncode == 0)
+
+
 TESTS = [
     test_open_approve_effect_status_roundtrip,
     test_resume_detects_drift_exit_3,
@@ -411,6 +481,10 @@ TESTS = [
     test_resume_vacuous_clean_is_labelled,
     test_resume_missing_receipt_via_cli,
     test_no_mission_flags_outside_open,
+    test_gate_verb,
+    test_gate_no_mission_allows,
+    test_open_guard_mode_without_guards_refused,
+    test_amend_guard_mode_flag,
 ]
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Unit + integration tests for custody_gate.py."""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+from custody_gate import evaluate, run_gate  # noqa: E402
+from custody_mission import Mission  # noqa: E402
+from custody_store import sha256_file  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+GUARDS = [
+    {"name": "arr-api", "tool_names": ["Bash"],
+     "command_regexes": [r":7878/api"], "path_globs": []},
+    {"name": "media-moves", "tool_names": ["Bash", "Write", "Edit"],
+     "command_regexes": [r"\b(mv|robocopy)\b[^\n]*[Mm]edia"],
+     "path_globs": ["M:/Media/**"]},
+]
+
+
+def auth(mode: str | None, guards=None) -> dict:
+    out: dict = {}
+    if mode is not None:
+        out["guard_mode"] = mode
+    if guards is not None:
+        out["actuator_guards"] = guards
+    return out
+
+
+def test_evaluate_inert() -> None:
+    call = {"tool_name": "Bash", "command": "curl :7878/api", "file_path": None}
+    check("eval-inert-no-fields", evaluate(auth(None), call)["decision"] == "allow")
+    check("eval-inert-guards-no-mode",
+          evaluate(auth(None, GUARDS), call)["decision"] == "allow")
+
+
+def test_evaluate_modes() -> None:
+    call = {"tool_name": "Bash", "command": "curl :7878/api", "file_path": None}
+    v = evaluate(auth("audit", GUARDS), call)
+    check("eval-audit-allows-matched",
+          v["decision"] == "allow" and v["matched"] and v["rule"] == "arr-api")
+    v = evaluate(auth("enforce", GUARDS), call)
+    check("eval-enforce-blocks",
+          v["decision"] == "block" and v["rule"] == "arr-api")
+
+
+def test_evaluate_tool_gate() -> None:
+    call = {"tool_name": "Read", "command": None, "file_path": "M:/Media/x.mkv"}
+    v = evaluate(auth("enforce", GUARDS), call)
+    check("eval-tool-not-in-rule", not v["matched"] and v["decision"] == "allow")
+    call = {"tool_name": "Write", "command": None, "file_path": "M:/Media/x.mkv"}
+    v = evaluate(auth("enforce", GUARDS), call)
+    check("eval-glob-match", v["matched"] and v["rule"] == "media-moves")
+    call = {"tool_name": "Write", "command": None, "file_path": "M:/Other/x.mkv"}
+    check("eval-glob-no-match", not evaluate(auth("enforce", GUARDS), call)["matched"])
+
+
+def test_evaluate_case_fold_is_ascii_only() -> None:
+    guards = [{"name": "g", "tool_names": ["Write"], "command_regexes": [],
+               "path_globs": ["M:/Media/STRASSE/**"]}]
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "M:/Media/strasse/x"}  # ß-folded spelling
+    # NTFS folds A-Z only: 'strasse' (with eszett in the glob) must NOT match
+    # a different codepoint sequence. Build both spellings explicitly:
+    glob_eszett = ["M:/Media/stra\u00dfe/**"]
+    guards[0]["path_globs"] = glob_eszett
+    check("eval-no-eszett-fold",
+          not evaluate(auth("enforce", guards), call)["matched"])
+    call_ascii = {"tool_name": "Write", "command": None,
+                  "file_path": "m:/media/stra\u00dfe/x"}
+    if sys.platform.startswith("win"):
+        check("eval-ascii-fold-nt",
+              evaluate(auth("enforce", guards), call_ascii)["matched"])
+
+
+def test_run_gate_chain_untouched_and_log() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "gate-it", "i", "operator:test", "agent:test",
+                         actor="agent:test", guard_mode="audit",
+                         actuator_guards=GUARDS)
+        m.approve()
+        before = {p.name: sha256_file(p)
+                  for p in sorted((ws / "missions" / "gate-it").rglob("*.json"))}
+        call = {"tool_name": "Bash", "command": "curl :7878/api", "file_path": None}
+        v = run_gate(ws, call, actor="hook:custody-gate", session_id="s1",
+                     harness="test")
+        after = {p.name: sha256_file(p)
+                 for p in sorted((ws / "missions" / "gate-it").rglob("*.json"))}
+        check("run-gate-allows-audit", v["decision"] == "allow" and v["matched"])
+        check("run-gate-chain-byte-identical", before == after)
+        log = ws / "missions" / "gate-it" / "guard-log.jsonl"
+        check("run-gate-log-written", log.is_file())
+        entry = json.loads(log.read_text(encoding="utf-8").splitlines()[-1])
+        check("run-gate-log-fields",
+              entry["rule"] == "arr-api" and entry["session_id"] == "s1"
+              and entry["mode"] == "audit")
+        # No match -> no log line
+        n_lines = len(log.read_text(encoding="utf-8").splitlines())
+        run_gate(ws, {"tool_name": "Read", "command": None, "file_path": "x"},
+                 actor="hook:custody-gate")
+        check("run-gate-no-match-no-log",
+              len(log.read_text(encoding="utf-8").splitlines()) == n_lines)
+
+
+def test_run_gate_no_mission_allows() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        v = run_gate(Path(tmp), {"tool_name": "Bash", "command": "rm -rf /",
+                                 "file_path": None}, actor="hook:custody-gate")
+        check("run-gate-no-mission-allow",
+              v["decision"] == "allow" and not v["matched"])
+
+
+if __name__ == "__main__":
+    for fn in list(globals().values()):
+        if callable(fn) and getattr(fn, "__name__", "").startswith("test_"):
+            fn()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILURES")
+        sys.exit(1)
+    print("all green")

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
@@ -2,7 +2,10 @@
 """Unit + integration tests for custody_gate.py."""
 from __future__ import annotations
 
+import contextlib
+import io
 import json
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -89,6 +92,79 @@ def test_evaluate_case_fold_is_ascii_only() -> None:
               evaluate(auth("enforce", guards), call_ascii)["matched"])
 
 
+def test_glob_doublestar_zero_segments() -> None:
+    guards = [{"name": "g", "tool_names": ["Write"], "command_regexes": [],
+               "path_globs": ["src/**/secret*"]}]
+    # '**/' must match ZERO or more segments, not one-or-more
+    call = {"tool_name": "Write", "command": None, "file_path": "src/secret.txt"}
+    check("glob-doublestar-zero-segments",
+          evaluate(auth("enforce", guards), call)["matched"])
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "src/a/b/secret.txt"}
+    check("glob-doublestar-many-segments",
+          evaluate(auth("enforce", guards), call)["matched"])
+    # trailing '/**' must match the base path itself
+    guards[0]["path_globs"] = ["M:/Media/**"]
+    call = {"tool_name": "Write", "command": None, "file_path": "M:/Media"}
+    check("glob-trailing-doublestar-base",
+          evaluate(auth("enforce", guards), call)["matched"])
+
+
+def test_glob_overmatch_still_held() -> None:
+    guards = [{"name": "g", "tool_names": ["Write"], "command_regexes": [],
+               "path_globs": ["M:/Media/**"]}]
+    call = {"tool_name": "Write", "command": None, "file_path": "M:/Mediaevil/x"}
+    check("glob-mediaevil-rejected",
+          not evaluate(auth("enforce", guards), call)["matched"])
+    call = {"tool_name": "Write", "command": None, "file_path": "M:/Media/a/b/c.mkv"}
+    check("glob-deep-still-matches",
+          evaluate(auth("enforce", guards), call)["matched"])
+    # '..' is not collapsed by normalization, so it over-matches -- the safe
+    # direction (a false block names its rule; a false allow retires custody)
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "M:/Media/../etc/passwd"}
+    check("glob-dotdot-overmatches",
+          evaluate(auth("enforce", guards), call)["matched"])
+
+
+def test_mcp_tool_input_serialized_match() -> None:
+    guards = [{"name": "arr-mcp", "tool_names": ["mcp__sonarr__post"],
+               "command_regexes": ["7878"], "path_globs": []}]
+    call = {"tool_name": "mcp__sonarr__post", "command": None,
+            "file_path": None,
+            "tool_input": {"url": "http://10.10.10.50:7878/api/v3/series",
+                           "method": "POST"}}
+    v = evaluate(auth("enforce", guards), call)
+    check("eval-mcp-serialized-args-block",
+          v["decision"] == "block" and v["rule"] == "arr-mcp")
+    safe = {"tool_name": "mcp__sonarr__post", "command": None,
+            "file_path": None,
+            "tool_input": {"url": "http://10.10.10.50:8989/api/v3/series"}}
+    check("eval-mcp-no-match-allows",
+          not evaluate(auth("enforce", guards), safe)["matched"])
+
+
+def test_run_gate_mcp_end_to_end() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "gate-mcp", "i", "operator:test", "agent:test",
+                         actor="agent:test", guard_mode="enforce",
+                         actuator_guards=[{
+                             "name": "arr-mcp",
+                             "tool_names": ["mcp__sonarr__post"],
+                             "command_regexes": ["7878"], "path_globs": []}])
+        m.approve()
+        v = run_gate(ws, {"tool_name": "mcp__sonarr__post", "command": None,
+                          "file_path": None,
+                          "tool_input": {"url": "http://h:7878/api"}},
+                     actor="hook:custody-gate")
+        check("run-gate-mcp-blocks", v["decision"] == "block")
+        entry = json.loads(
+            (ws / "missions" / "gate-mcp" / "guard-log.jsonl")
+            .read_text(encoding="utf-8").splitlines()[-1])
+        check("run-gate-mcp-logged", entry["rule"] == "arr-mcp")
+
+
 def test_run_gate_chain_untouched_and_log() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         ws = Path(tmp)
@@ -125,6 +201,44 @@ def test_run_gate_no_mission_allows() -> None:
                                  "file_path": None}, actor="hook:custody-gate")
         check("run-gate-no-mission-allow",
               v["decision"] == "allow" and not v["matched"])
+
+
+def test_run_gate_log_failure_keeps_verdict() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "gate-logfail", "i", "operator:test", "agent:test",
+                         actor="agent:test", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        # guard-log.jsonl occupied by a directory: the append must fail
+        (ws / "missions" / "gate-logfail" / "guard-log.jsonl").mkdir()
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            v = run_gate(ws, {"tool_name": "Bash", "command": "curl :7878/api",
+                              "file_path": None}, actor="hook:custody-gate")
+        check("run-gate-log-failure-keeps-block",
+              v["decision"] == "block" and v["matched"])
+        check("run-gate-log-failure-notes-loss",
+              "guard-log" in buf.getvalue())
+
+
+def test_run_gate_multiple_active_allows_loudly() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "gate-multi", "i", "operator:test", "agent:test",
+                         actor="agent:test", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        # a duplicated mission dir arriving out-of-band (sync, copy) -- the
+        # decoy shape open() now refuses to create itself
+        shutil.copytree(m.store.mission_dir, ws / "missions" / "gate-multi-2")
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            v = run_gate(ws, {"tool_name": "Bash", "command": "curl :7878/api",
+                              "file_path": None}, actor="hook:custody-gate")
+        check("run-gate-multi-active-allows", v["decision"] == "allow")
+        check("run-gate-multi-active-warns",
+              "multiple active" in buf.getvalue().lower())
 
 
 if __name__ == "__main__":

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""End-to-end tests for custody_hook.py: stdin payload -> exit code."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+HOOK = ROOT / "custody_hook.py"
+sys.path.insert(0, str(ROOT))
+from custody_mission import Mission  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+    else:
+        print(f"ok   {name}")
+
+
+GUARDS = [{"name": "no-rm", "tool_names": ["Bash", "shell", "Shell"],
+           "command_regexes": ["rm -rf"], "path_globs": []}]
+
+
+def run_hook(harness: str, payload: dict | str) -> subprocess.CompletedProcess:
+    raw = payload if isinstance(payload, str) else json.dumps(payload)
+    return subprocess.run(
+        [sys.executable, str(HOOK), "--harness", harness],
+        input=raw, capture_output=True, text=True)
+
+
+def payloads(cwd: str) -> dict:
+    return {
+        "claude": {"hook_event_name": "PreToolUse", "session_id": "s1",
+                   "cwd": cwd,
+                   "tool_name": "Bash", "tool_input": {"command": "rm -rf x"}},
+        "kimi": {"hook_event_name": "PreToolUse", "session_id": "s2",
+                 "cwd": cwd,
+                 "tool_name": "Bash", "tool_input": {"command": "rm -rf x"}},
+        "codex": {"session_id": "s3", "cwd": cwd,
+                  "tool_name": "Bash", "tool_input": {"command": "rm -rf x"}},
+        "cursor": {"command": "rm -rf x", "cwd": cwd},  # beforeShellExecution
+        "gemini": {"tool_name": "Bash",
+                   "tool_input": {"command": "rm -rf x"}, "cwd": cwd},
+        "generic": {"tool_name": "Bash",
+                    "tool_input": {"command": "rm -rf x"}, "cwd": cwd},
+    }
+
+
+def test_block_per_harness() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-e2e", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        for harness, payload in payloads(tmp).items():
+            res = run_hook(harness, payload)
+            check(f"hook-{harness}-blocks", res.returncode == 2)
+            check(f"hook-{harness}-reason-names-rule",
+                  "no-rm" in (res.stderr + res.stdout))
+
+
+def test_allow_paths() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-allow", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        ok = payloads(tmp)["claude"]
+        ok["tool_input"] = {"command": "ls"}
+        check("hook-unmatched-allows", run_hook("claude", ok).returncode == 0)
+    with tempfile.TemporaryDirectory() as tmp:
+        # no missions dir at all -> inert fast path
+        p = payloads(tmp)["claude"]
+        check("hook-no-missions-dir-allows",
+              run_hook("claude", p).returncode == 0)
+
+
+def test_fail_open() -> None:
+    check("hook-garbage-stdin-allows", run_hook("claude", "not json{{").returncode == 0)
+    check("hook-empty-stdin-allows", run_hook("claude", "").returncode == 0)
+    check("hook-unknown-harness-allows",
+          subprocess.run([sys.executable, str(HOOK), "--harness", "nope"],
+                         input="{}", capture_output=True,
+                         text=True).returncode == 0)
+
+
+if __name__ == "__main__":
+    for fn in list(globals().values()):
+        if callable(fn) and getattr(fn, "__name__", "").startswith("test_"):
+            fn()
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILURES")
+        sys.exit(1)
+    print("all green")

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -12,6 +13,7 @@ ROOT = Path(__file__).resolve().parent
 HOOK = ROOT / "custody_hook.py"
 sys.path.insert(0, str(ROOT))
 from custody_mission import Mission  # noqa: E402
+from custody_store import sha256_file  # noqa: E402
 
 FAILURES: list[str] = []
 
@@ -82,6 +84,95 @@ def test_allow_paths() -> None:
         p = payloads(tmp)["claude"]
         check("hook-no-missions-dir-allows",
               run_hook("claude", p).returncode == 0)
+
+
+def test_log_write_failure_still_blocks() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-logfail", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        (ws / "missions" / "hook-logfail" / "guard-log.jsonl").mkdir()
+        res = run_hook("claude", payloads(tmp)["claude"])
+        check("hook-log-failure-still-blocks", res.returncode == 2)
+
+
+def test_subdirectory_cwd_still_gates() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-subdir", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        sub = ws / "deep" / "nest"
+        sub.mkdir(parents=True)
+        p = payloads(str(sub))["claude"]
+        check("hook-subdir-cwd-blocks", run_hook("claude", p).returncode == 2)
+
+
+def test_tampered_mission_fails_open_loudly() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-tamper", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        # forge a tail checkpoint rewriting the instruction
+        latest, path = m.store.load_latest()
+        forged = json.loads(json.dumps(latest))
+        forged["revision"] = latest["revision"] + 1
+        forged["prev_checkpoint_sha256"] = sha256_file(path)
+        forged["manifest"]["authority"]["instruction"] = "rewritten"
+        m.store.write_checkpoint(forged)
+        res = run_hook("claude", payloads(tmp)["claude"])
+        check("hook-tamper-fails-open", res.returncode == 0)
+        check("hook-tamper-stderr-loud",
+              "CustodyError" in res.stderr and "TAMPER" in res.stderr)
+
+
+def test_completed_mission_allows() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-done", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        m.cancel("done")  # completed/cancelled missions are out of scope
+        check("hook-completed-mission-allows",
+              run_hook("claude", payloads(tmp)["claude"]).returncode == 0)
+
+
+def test_cursor_string_tool_input_mcp() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        guards = [{"name": "no-rm-mcp", "tool_names": ["mcp__arr__mutate"],
+                   "command_regexes": ["rm -rf"], "path_globs": []}]
+        m = Mission.open(ws, "hook-mcp-str", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=guards)
+        m.approve()
+        # beforeMCPExecution sends tool_input as a JSON STRING
+        payload = {"tool_name": "mcp__arr__mutate",
+                   "tool_input": json.dumps({"command": "rm -rf x"}),
+                   "cwd": tmp}
+        check("hook-cursor-string-tool-input-blocks",
+              run_hook("cursor", payload).returncode == 2)
+
+
+def test_multiple_active_allows_with_warning() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        m = Mission.open(ws, "hook-multi", "i", "operator:t", "agent:t",
+                         actor="agent:t", guard_mode="enforce",
+                         actuator_guards=GUARDS)
+        m.approve()
+        shutil.copytree(ws / "missions" / "hook-multi",
+                        ws / "missions" / "hook-multi-2")
+        res = run_hook("claude", payloads(tmp)["claude"])
+        check("hook-multi-active-allows", res.returncode == 0)
+        check("hook-multi-active-warns",
+              "multiple active" in res.stderr.lower())
 
 
 def test_fail_open() -> None:

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
@@ -66,8 +67,12 @@ def test_load_refuses_zero_and_multiple(workspace: Path) -> None:
     except NoActiveMission:
         check("load-zero-raises", True)
 
-    open_mission(workspace, "m-one", "A.")
-    open_mission(workspace, "m-two", "B.")
+    m1 = open_mission(workspace, "m-one", "A.")
+    # open() refuses to CREATE a second active mission in one workspace
+    # (decoy-disarm wedge, es#117 review fix 4); a duplicated mission dir
+    # arriving out-of-band (sync, copy) is exactly the multiple-active state
+    # load() must still refuse, so build it that way.
+    shutil.copytree(m1.store.mission_dir, workspace / "missions" / "m-two")
     try:
         Mission.load(workspace, actor="agent:x")
         check("load-multiple-raises", False)
@@ -611,7 +616,9 @@ def test_continuity_surfaces_unreceipted_mutation(workspace: Path) -> None:
           and m.status()["status"] == "active")
 
     # honest legitimate history stays clean: reconcile after real drift is a
-    # receipted event and must NOT read as a break
+    # receipted event and must NOT read as a break. (The first scenario is
+    # cancelled first: open() refuses a second ACTIVE mission per workspace.)
+    m.cancel("first scenario done")
     m2 = open_mission(workspace, "m-continuity-ok", "Legitimate history.")
     m2.approve()
     m2.record_effect("notes/b.md", "v1", "r1")
@@ -650,7 +657,9 @@ def test_continuity_is_silent_on_sanctioned_recovery(workspace: Path) -> None:
           st["state"]["unresolved_verdicts"] == [] and st["status"] == "active")
     check("sanctioned-recovery-no-phantom-break", m.continuity_breaks() == [])
 
-    # deeper: three receipts, the LAST retired, then recovered
+    # deeper: three receipts, the LAST retired, then recovered. (The first
+    # scenario is cancelled first: open() refuses a second ACTIVE mission.)
+    m.cancel("first scenario done")
     m2 = open_mission(workspace, "m-deep-retire", "Deeper chain.")
     m2.approve()
     for content, rid in (("v1", "A"), ("v2", "B"), ("v3", "C")):
@@ -918,6 +927,111 @@ def test_tail_guard_tamper_without_amendment_detected(workspace: Path) -> None:
         check("tail-guard-tamper-detected", True)
 
 
+def test_open_refuses_second_active_mission(workspace: Path) -> None:
+    # A second ACTIVE mission under one workspace makes every other command
+    # refuse (MultipleActiveMissions) -- including the gate's discovery -- so
+    # open creating one is a decoy-disarm wedge, not a feature.
+    open_mission(workspace, "m-first", "First.")
+    try:
+        open_mission(workspace, "m-second", "Decoy.")
+        check("open-refuses-second-active", False)
+    except CustodyError:
+        check("open-refuses-second-active", True)
+    # the refused open must not leave a partial mission dir behind
+    check("open-refused-left-no-dir",
+          not (workspace / "missions" / "m-second").exists())
+
+
+def test_amend_none_clears_guard_keys(workspace: Path) -> None:
+    m = open_mission(workspace, "guard-clear", "i",
+                     guard_mode="audit",
+                     actuator_guards=[{"name": "g", "tool_names": ["Bash"],
+                                       "command_regexes": ["rm"],
+                                       "path_globs": []}])
+    m.approve()
+    m.amend_authority("operator: disarm the hook",
+                      guard_mode=None, actuator_guards=None)
+    auth = m.status()["manifest"]["authority"]
+    check("amend-none-clears-guards",
+          "guard_mode" not in auth and "actuator_guards" not in auth)
+
+
+def test_amend_empty_guards_list_refused(workspace: Path) -> None:
+    m = open_mission(workspace, "guard-empty-list", "i")
+    m.approve()
+    try:
+        m.amend_authority("operator: empty guards", actuator_guards=[])
+        check("amend-empty-guards-refused", False)
+    except (CustodyError, StoreError):
+        check("amend-empty-guards-refused", True)
+
+
+def test_amend_arms_guards_legitimately(workspace: Path) -> None:
+    # (a) a legitimate amend arming guards must verify clean afterwards,
+    # including on the NEXT ordinary operation (baseline moves forward).
+    guards = [{"name": "g", "tool_names": ["Bash"],
+               "command_regexes": ["rm"], "path_globs": []}]
+    m = open_mission(workspace, "guard-amend-legit", "i")
+    m.approve()
+    m.amend_authority("operator: arm audit mode",
+                      guard_mode="audit", actuator_guards=guards)
+    m.note("still fine")
+    auth = m.status()["manifest"]["authority"]
+    check("amend-armed-guards-persist",
+          auth["actuator_guards"] == guards and auth["guard_mode"] == "audit")
+
+
+def test_amend_then_tail_guard_strip_detected(workspace: Path) -> None:
+    # (b) guards armed via amend, then a forged tail strips them without a
+    # new amendment: comparing against ORIGIN is blind here (origin had no
+    # guards either) -- the chain-protected BASELINE catches it.
+    m = open_mission(workspace, "guard-strip", "i")
+    m.approve()
+    m.amend_authority("operator: arm audit mode",
+                      guard_mode="audit",
+                      actuator_guards=[{"name": "g", "tool_names": ["Bash"],
+                                        "command_regexes": ["rm"],
+                                        "path_globs": []}])
+    latest, path = m.store.load_latest()
+    forged = json.loads(json.dumps(latest))
+    forged["revision"] = latest["revision"] + 1
+    forged["prev_checkpoint_sha256"] = sha256_file(path)
+    del forged["manifest"]["authority"]["actuator_guards"]
+    del forged["manifest"]["authority"]["guard_mode"]
+    m.store.write_checkpoint(forged)
+    try:
+        m.note("probe")
+        check("tail-guard-strip-after-amend-detected", False)
+    except CustodyError:
+        check("tail-guard-strip-after-amend-detected", True)
+
+
+def test_unrelated_amend_then_tail_regex_narrow_detected(workspace: Path) -> None:
+    # (c) guards armed at open; a text-only (unrelated) amend grows the
+    # amendments list; then a forged tail narrows the regex. The old rule
+    # (fires only when amendments empty) was blessed by the prior unrelated
+    # amendment -- the baseline rule catches it.
+    m = open_mission(workspace, "guard-narrow", "i",
+                     guard_mode="enforce",
+                     actuator_guards=[{"name": "g", "tool_names": ["Bash"],
+                                       "command_regexes": ["rm -rf"],
+                                       "path_globs": []}])
+    m.approve()
+    m.amend_authority("operator: unrelated scope note")
+    latest, path = m.store.load_latest()
+    forged = json.loads(json.dumps(latest))
+    forged["revision"] = latest["revision"] + 1
+    forged["prev_checkpoint_sha256"] = sha256_file(path)
+    forged["manifest"]["authority"]["actuator_guards"][0][
+        "command_regexes"] = ["rm -rf /very/specific"]
+    m.store.write_checkpoint(forged)
+    try:
+        m.note("probe")
+        check("tail-regex-narrow-after-unrelated-amend-detected", False)
+    except CustodyError:
+        check("tail-regex-narrow-after-unrelated-amend-detected", True)
+
+
 TESTS = [
     test_open_creates_draft_r1,
     test_pathless_load_single_active,
@@ -952,6 +1066,12 @@ TESTS = [
     test_open_without_guards_omits_fields,
     test_amend_changes_guards,
     test_tail_guard_tamper_without_amendment_detected,
+    test_amend_arms_guards_legitimately,
+    test_amend_none_clears_guard_keys,
+    test_open_refuses_second_active_mission,
+    test_amend_empty_guards_list_refused,
+    test_amend_then_tail_guard_strip_detected,
+    test_unrelated_amend_then_tail_regex_narrow_detected,
 ]
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -10,7 +10,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT))
 
-from custody_store import StoreError, sha256_bytes  # noqa: E402
+from custody_store import StoreError, sha256_bytes, sha256_file  # noqa: E402
 from verify_mission_custody import is_iso_utc  # noqa: E402
 from custody_mission import (  # noqa: E402
     _same_artifact,
@@ -35,11 +35,11 @@ def check(name: str, cond: bool) -> None:
 
 def open_mission(workspace: Path, mission_id: str, instruction: str,
                   required_tier: str = "declared-role-separation",
-                  actor: str = "agent:worker") -> Mission:
+                  actor: str = "agent:worker", **kwargs) -> Mission:
     return Mission.open(
         workspace, mission_id=mission_id, instruction=instruction,
         operator_ref="operator:zach", steward_ref="agent:worker",
-        required_tier=required_tier, actor=actor)
+        required_tier=required_tier, actor=actor, **kwargs)
 
 
 def test_open_creates_draft_r1(workspace: Path) -> None:
@@ -866,6 +866,58 @@ def test_operator_tier(workspace: Path) -> None:
     check("tier-operator-accept-completes", st["status"] == "completed")
 
 
+def test_open_with_guards_roundtrip(workspace: Path) -> None:
+    # open a mission with guards + mode; checkpoint r1 must validate and carry them
+    guards = [{"name": "g", "tool_names": ["Bash"],
+               "command_regexes": ["rm"], "path_globs": []}]
+    m = open_mission(workspace, "guard-open", "do the thing",
+                     guard_mode="audit", actuator_guards=guards)
+    auth = m.status()["manifest"]["authority"]
+    check("open-guards-roundtrip",
+          auth["guard_mode"] == "audit" and auth["actuator_guards"] == guards)
+
+
+def test_open_without_guards_omits_fields(workspace: Path) -> None:
+    m = open_mission(workspace, "guard-less", "do the thing")
+    auth = m.status()["manifest"]["authority"]
+    check("open-guardless-omits-fields",
+          "guard_mode" not in auth and "actuator_guards" not in auth)
+
+
+def test_amend_changes_guards(workspace: Path) -> None:
+    m = open_mission(workspace, "guard-amend", "i")
+    m.approve()
+    rev = m.amend_authority(
+        "operator: arm the hook in audit mode",
+        guard_mode="audit",
+        actuator_guards=[{"name": "g", "tool_names": ["Bash"],
+                          "command_regexes": ["rm"], "path_globs": []}])
+    latest = m.status()
+    check("amend-guards-landed",
+          latest["manifest"]["authority"]["guard_mode"] == "audit"
+          and latest["revision"] == rev)
+
+
+def test_tail_guard_tamper_without_amendment_detected(workspace: Path) -> None:
+    m = open_mission(workspace, "guard-tamper", "i")
+    m.approve()
+    # Forge a tail checkpoint: same chain, guards added by hand, no amendment.
+    latest, path = m.store.load_latest()
+    forged = json.loads(json.dumps(latest))
+    forged["revision"] = latest["revision"] + 1
+    forged["prev_checkpoint_sha256"] = sha256_file(path)
+    forged["manifest"]["authority"]["actuator_guards"] = [
+        {"name": "x", "tool_names": ["Bash"], "command_regexes": ["a"],
+         "path_globs": []}]
+    forged["manifest"]["authority"]["guard_mode"] = "audit"
+    m.store.write_checkpoint(forged)
+    try:
+        m.note("probe")
+        check("tail-guard-tamper-detected", False)
+    except CustodyError:
+        check("tail-guard-tamper-detected", True)
+
+
 TESTS = [
     test_open_creates_draft_r1,
     test_pathless_load_single_active,
@@ -896,6 +948,10 @@ TESTS = [
     test_accept_requires_verifying_and_separation,
     test_fail_is_clearable,
     test_operator_tier,
+    test_open_with_guards_roundtrip,
+    test_open_without_guards_omits_fields,
+    test_amend_changes_guards,
+    test_tail_guard_tamper_without_amendment_detected,
 ]
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -186,6 +186,14 @@ def test_manifest_guard_rules_shape() -> None:
     check("manifest-guard-empty-tool-names", validate_record(bad) != [])
 
 
+def test_manifest_guard_empty_guards_list_invalid() -> None:
+    # [] is not "clear the guards" (that is amend(..., actuator_guards=None));
+    # the schema's minItems: 1 forbids it and the hand validator must agree.
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["actuator_guards"] = []
+    check("manifest-guards-empty-list", validate_record(rec) != [])
+
+
 def test_examples_corpus() -> None:
     ex = ROOT / "examples"
     for path in sorted(ex.glob("valid-*.json")):
@@ -219,6 +227,7 @@ def main() -> int:
     test_manifest_guard_examples_invalid()
     test_manifest_guards_optional_absent()
     test_manifest_guard_rules_shape()
+    test_manifest_guard_empty_guards_list_invalid()
     test_examples_corpus()
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -152,6 +152,40 @@ def test_receipt_and_verdict_mission_id_kebab_required() -> None:
     check("verdict-mission-id-kebab", validate_record(rec) != [])
 
 
+def test_manifest_guards_valid_example() -> None:
+    check("manifest-guards-valid-example",
+          validate_record(load("valid-manifest-guards.json")) == [])
+
+
+def test_manifest_guard_examples_invalid() -> None:
+    for name in (
+        "invalid-manifest-guard-bad-mode.json",
+        "invalid-manifest-guard-empty-rule.json",
+        "invalid-manifest-guard-bad-regex.json",
+        "invalid-manifest-guard-mode-without-guards.json",
+        "invalid-manifest-guard-unknown-field.json",
+    ):
+        check(f"manifest-{name}", validate_record(load(name)) != [])
+
+
+def test_manifest_guards_optional_absent() -> None:
+    # The pre-change minimal manifest must still validate: fields are additive.
+    check("manifest-guards-optional-absent",
+          validate_record(valid_manifest()) == [])
+
+
+def test_manifest_guard_rules_shape() -> None:
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["guard_mode"] = "audit"
+    rec["authority"]["actuator_guards"] = [{
+        "name": "arr", "tool_names": ["Bash"],
+        "command_regexes": ["7878"], "path_globs": []}]
+    check("manifest-guard-rules-inline-valid", validate_record(rec) == [])
+    bad = copy.deepcopy(rec)
+    bad["authority"]["actuator_guards"][0]["tool_names"] = []
+    check("manifest-guard-empty-tool-names", validate_record(bad) != [])
+
+
 def test_examples_corpus() -> None:
     ex = ROOT / "examples"
     for path in sorted(ex.glob("valid-*.json")):
@@ -181,6 +215,10 @@ def main() -> int:
     test_verdict_self_certification_refused()
     test_verdict_operator_tier_binds_acceptor()
     test_receipt_and_verdict_mission_id_kebab_required()
+    test_manifest_guards_valid_example()
+    test_manifest_guard_examples_invalid()
+    test_manifest_guards_optional_absent()
+    test_manifest_guard_rules_shape()
     test_examples_corpus()
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -164,6 +164,7 @@ def test_manifest_guard_examples_invalid() -> None:
         "invalid-manifest-guard-bad-regex.json",
         "invalid-manifest-guard-mode-without-guards.json",
         "invalid-manifest-guard-unknown-field.json",
+        "invalid-manifest-guard-shell-only-globs.json",
     ):
         check(f"manifest-{name}", validate_record(load(name)) != [])
 
@@ -192,6 +193,41 @@ def test_manifest_guard_empty_guards_list_invalid() -> None:
     rec = copy.deepcopy(valid_manifest())
     rec["authority"]["actuator_guards"] = []
     check("manifest-guards-empty-list", validate_record(rec) != [])
+
+
+def test_manifest_guard_inert_shapes_rejected() -> None:
+    # A rule whose patterns can never fire for its tools arms nothing while
+    # reading as armed -- refuse those shapes at validation.
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["actuator_guards"] = [{
+        "name": "g", "tool_names": ["Bash"],
+        "command_regexes": [], "path_globs": ["M:/Media/**"]}]
+    check("guard-shell-only-globs-inert", validate_record(rec) != [])
+
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["actuator_guards"] = [{
+        "name": "g", "tool_names": ["Write"],
+        "command_regexes": ["secret"], "path_globs": []}]
+    check("guard-write-only-regexes-inert", validate_record(rec) != [])
+
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["actuator_guards"] = [{
+        "name": "g", "tool_names": ["mcp__sonarr__post"],
+        "command_regexes": [], "path_globs": ["M:/Media/**"]}]
+    check("guard-mcp-only-globs-inert", validate_record(rec) != [])
+
+    # mixed or unknown tool names pass: one arm can still fire (mixed), and
+    # unknown tools are the operator's responsibility
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["actuator_guards"] = [{
+        "name": "g", "tool_names": ["Bash", "Write"],
+        "command_regexes": [], "path_globs": ["M:/Media/**"]}]
+    check("guard-mixed-tools-pass", validate_record(rec) == [])
+    rec = copy.deepcopy(valid_manifest())
+    rec["authority"]["actuator_guards"] = [{
+        "name": "g", "tool_names": ["FutureTool"],
+        "command_regexes": [], "path_globs": ["M:/Media/**"]}]
+    check("guard-unknown-tools-pass", validate_record(rec) == [])
 
 
 def test_examples_corpus() -> None:
@@ -228,6 +264,7 @@ def main() -> int:
     test_manifest_guards_optional_absent()
     test_manifest_guard_rules_shape()
     test_manifest_guard_empty_guards_list_invalid()
+    test_manifest_guard_inert_shapes_rejected()
     test_examples_corpus()
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -130,7 +130,7 @@ def validate_manifest(rec: dict) -> list[str]:
                      "authority.guard_mode",
                      "guard_mode requires a non-empty actuator_guards list")
         if guards is not None:
-            ok = isinstance(guards, list)
+            ok = isinstance(guards, list) and bool(guards)
             if ok:
                 for rule in guards:
                     if not isinstance(rule, dict) or set(rule) != GUARD_RULE_FIELDS:

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -35,6 +35,10 @@ AUTHORITY_FIELDS = {
     "operator_ref", "instruction", "amendments", "permissions",
     "protected_state", "acceptable_costs",
 }
+AUTHORITY_OPTIONAL_FIELDS = {"guard_mode", "actuator_guards"}
+GUARD_MODES = {"audit", "enforce"}
+GUARD_RULE_FIELDS = {"name", "tool_names", "command_regexes", "path_globs"}
+GUARD_RULE_REQUIRED = {"name", "tool_names", "command_regexes", "path_globs"}
 CHECKPOINT_FIELDS = {
     "record", "mission_id", "revision", "status", "prev_checkpoint_sha256",
     "manifest", "state", "receipt_ids", "written_utc", "written_by",
@@ -94,7 +98,12 @@ def validate_manifest(rec: dict) -> list[str]:
     if not isinstance(auth, dict):
         errors.append("authority: object required")
         return errors
-    _check_exact_fields(errors, auth, AUTHORITY_FIELDS, "authority")
+    for key in auth:
+        if key not in AUTHORITY_FIELDS | AUTHORITY_OPTIONAL_FIELDS:
+            errors.append(f"authority.{key}: unknown field")
+    for key in AUTHORITY_FIELDS:
+        if key not in auth:
+            errors.append(f"authority.{key}: missing")
     if not errors:
         _require(errors, isinstance(auth["operator_ref"], str)
                  and auth["operator_ref"],
@@ -112,6 +121,51 @@ def validate_manifest(rec: dict) -> list[str]:
         for name in ("permissions", "protected_state", "acceptable_costs"):
             _require(errors, _str_list(auth[name]),
                      f"authority.{name}", "list of strings required")
+        mode = auth.get("guard_mode")
+        guards = auth.get("actuator_guards")
+        if mode is not None:
+            _require(errors, mode in GUARD_MODES,
+                     "authority.guard_mode", "must be 'audit' or 'enforce'")
+            _require(errors, isinstance(guards, list) and bool(guards),
+                     "authority.guard_mode",
+                     "guard_mode requires a non-empty actuator_guards list")
+        if guards is not None:
+            ok = isinstance(guards, list)
+            if ok:
+                for rule in guards:
+                    if not isinstance(rule, dict) or set(rule) != GUARD_RULE_FIELDS:
+                        ok = False
+                        break
+                    if not (isinstance(rule["name"], str) and rule["name"]):
+                        ok = False
+                        break
+                    if not rule["tool_names"] or not _str_list(rule["tool_names"]):
+                        ok = False
+                        break
+                    patterns = []
+                    for field in ("command_regexes", "path_globs"):
+                        value = rule[field]
+                        if not isinstance(value, list) or not all(
+                                isinstance(p, str) for p in value):
+                            ok = False
+                            break
+                        patterns.extend(value)
+                    if not ok:
+                        break
+                    if not patterns:
+                        ok = False  # a patternless rule matches nothing -> inert by accident
+                        break
+                    for pattern in rule["command_regexes"]:
+                        try:
+                            re.compile(pattern)
+                        except re.error:
+                            ok = False
+                            break
+                    if not ok:
+                        break
+            _require(errors, ok, "authority.actuator_guards",
+                     "list of {name, tool_names, command_regexes, path_globs} "
+                     "rules; tool_names non-empty; >=1 pattern; regexes must compile")
 
     scope = rec["scope"]
     ok = isinstance(scope, dict) and set(scope) == {"in", "out"} \

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -39,6 +39,16 @@ AUTHORITY_OPTIONAL_FIELDS = {"guard_mode", "actuator_guards"}
 GUARD_MODES = {"audit", "enforce"}
 GUARD_RULE_FIELDS = {"name", "tool_names", "command_regexes", "path_globs"}
 GUARD_RULE_REQUIRED = {"name", "tool_names", "command_regexes", "path_globs"}
+# Tool-name classes for inert-shape detection: a rule whose pattern lists can
+# never fire for its tools arms nothing while reading as armed.
+GUARD_SHELL_TOOLS = {
+    "Bash", "bash", "shell", "Shell",
+    "run_command", "local_shell", "run_shell_command",
+}
+GUARD_FS_WRITE_TOOLS = {
+    "Write", "Edit", "MultiEdit", "write_file", "replace",
+    "apply_patch", "str_replace_editor",
+}
 CHECKPOINT_FIELDS = {
     "record", "mission_id", "revision", "status", "prev_checkpoint_sha256",
     "manifest", "state", "receipt_ids", "written_utc", "written_by",
@@ -130,42 +140,79 @@ def validate_manifest(rec: dict) -> list[str]:
                      "authority.guard_mode",
                      "guard_mode requires a non-empty actuator_guards list")
         if guards is not None:
-            ok = isinstance(guards, list) and bool(guards)
-            if ok:
-                for rule in guards:
+            if not isinstance(guards, list) or not guards:
+                errors.append(
+                    "authority.actuator_guards: non-empty list of guard rules "
+                    "required (to disarm, amend with actuator_guards=None)")
+            else:
+                for i, rule in enumerate(guards):
+                    where = f"authority.actuator_guards[{i}]"
                     if not isinstance(rule, dict) or set(rule) != GUARD_RULE_FIELDS:
-                        ok = False
-                        break
+                        errors.append(
+                            f"{where}: rule must carry exactly "
+                            "{name, tool_names, command_regexes, path_globs}")
+                        continue
                     if not (isinstance(rule["name"], str) and rule["name"]):
-                        ok = False
-                        break
+                        errors.append(f"{where}.name: non-empty string required")
+                        continue
                     if not rule["tool_names"] or not _str_list(rule["tool_names"]):
-                        ok = False
-                        break
+                        errors.append(
+                            f"{where}.tool_names: non-empty list of non-empty "
+                            "strings required")
+                        continue
                     patterns = []
+                    shape_bad = False
                     for field in ("command_regexes", "path_globs"):
                         value = rule[field]
                         if not isinstance(value, list) or not all(
                                 isinstance(p, str) for p in value):
-                            ok = False
+                            errors.append(
+                                f"{where}.{field}: list of strings required")
+                            shape_bad = True
                             break
                         patterns.extend(value)
-                    if not ok:
-                        break
+                    if shape_bad:
+                        continue
                     if not patterns:
-                        ok = False  # a patternless rule matches nothing -> inert by accident
-                        break
+                        # a patternless rule matches nothing -> inert by accident
+                        errors.append(
+                            f"{where}: >=1 pattern across command_regexes and "
+                            "path_globs required (patternless rule is inert)")
+                        continue
+                    regex_bad = False
                     for pattern in rule["command_regexes"]:
                         try:
                             re.compile(pattern)
                         except re.error:
-                            ok = False
+                            errors.append(
+                                f"{where}.command_regexes: does not compile: "
+                                f"{pattern!r}")
+                            regex_bad = True
                             break
-                    if not ok:
-                        break
-            _require(errors, ok, "authority.actuator_guards",
-                     "list of {name, tool_names, command_regexes, path_globs} "
-                     "rules; tool_names non-empty; >=1 pattern; regexes must compile")
+                    if regex_bad:
+                        continue
+                    # Inert-shape refusal: the pattern lists a rule carries
+                    # must be ones its tools can actually fire. Mixed or
+                    # unknown tool names pass -- unknown tools are the
+                    # operator's responsibility.
+                    names = rule["tool_names"]
+                    if all(n in GUARD_SHELL_TOOLS for n in names) \
+                            and not rule["command_regexes"]:
+                        errors.append(
+                            f"{where}: shell tools carry no file_path, so "
+                            "path_globs never fire; command_regexes required")
+                    elif all(n in GUARD_FS_WRITE_TOOLS for n in names) \
+                            and not rule["path_globs"]:
+                        errors.append(
+                            f"{where}: fs-write tools carry no command "
+                            "string, so command_regexes never fire; "
+                            "path_globs required")
+                    elif all(n.startswith("mcp__") for n in names) \
+                            and not rule["command_regexes"]:
+                        errors.append(
+                            f"{where}: MCP arguments match command_regexes "
+                            "(serialized tool_input) only, so path_globs "
+                            "never fire; command_regexes required")
 
     scope = rec["scope"]
     ok = isinstance(scope, dict) and set(scope) == {"in", "out"} \

--- a/plugins/epistemic-skills/hooks/codex-hooks.json
+++ b/plugins/epistemic-skills/hooks/codex-hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Stage-C mission-custody PreToolUse gate (es#117) -- INSTALL SNIPPET, not a live config. Codex reads hooks from ~/.codex/hooks.json or <repo>/.codex/hooks.json (verified against https://developers.openai.com/codex/hooks, 2026-08-12). Copy the PreToolUse entry into one of those files, replacing <plugin-root> with the absolute path to this plugin directory. Payload carries session_id/cwd/tool_name/tool_input (Bash and apply_patch use tool_input.command); exit 2 + stderr blocks. Caveats from the same docs: hosted tools (e.g. WebSearch) do not fire hooks; repo-local hooks load only in trusted projects; new hooks must be trusted via /hooks before they run.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|apply_patch|Edit|Write|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"<plugin-root>/contracts/mission-custody/custody_hook.py\" --harness codex",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/epistemic-skills/hooks/cursor-hooks.json
+++ b/plugins/epistemic-skills/hooks/cursor-hooks.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "python ./contracts/mission-custody/custody_hook.py --harness cursor",
+        "timeout": 10
+      }
+    ],
+    "preToolUse": [
+      {
+        "command": "python ./contracts/mission-custody/custody_hook.py --harness cursor",
+        "timeout": 10,
+        "matcher": "Shell|Write|Delete"
+      }
+    ],
+    "beforeMCPExecution": [
+      {
+        "command": "python ./contracts/mission-custody/custody_hook.py --harness cursor",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/plugins/epistemic-skills/hooks/gemini-settings-snippet.json
+++ b/plugins/epistemic-skills/hooks/gemini-settings-snippet.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Stage-C mission-custody BeforeTool gate (es#117) -- INSTALL SNIPPET, not a live config. Gemini CLI reads hooks from ~/.gemini/settings.json (user) or .gemini/settings.json (project); the Antigravity CLI (agy) shares the ~/.gemini/settings.json surface. Verified against https://geminicli.com/docs/hooks/reference/ (2026-08-12): BeforeTool input carries session_id/cwd/tool_name/tool_input; exit 2 + stderr blocks the tool and the turn continues; timeout is in MILLISECONDS. Merge the hooks object below into your settings.json, replacing <plugin-root> with the absolute path to this plugin directory. NOTE: Gemini built-in tool names differ from Claude's -- guards in a mission manifest must name run_shell_command / write_file / replace / mcp_<server>_<tool> to match.",
+  "hooks": {
+    "BeforeTool": [
+      {
+        "matcher": "run_shell_command|write_file|replace|mcp_.*",
+        "hooks": [
+          {
+            "name": "mission-custody-gate",
+            "type": "command",
+            "command": "python \"<plugin-root>/contracts/mission-custody/custody_hook.py\" --harness gemini",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/epistemic-skills/hooks/hooks.json
+++ b/plugins/epistemic-skills/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Write|Edit|mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PLUGIN_ROOT}/contracts/mission-custody/custody_hook.py\" --harness claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -63,10 +63,11 @@ else.
   load-bearing condition blocks progress (an unverified claim, an unmapped
   territory, an irreversible fork), STATE THE CONDITION and the return point
   (mission id + frontier) and let the surrounding stack answer it.
-- Custody here is convention-held, not mechanically enforced — the tracer
-  retro (2026-08-11) ruled Stage C teeth IN, tracked as epistemic-skills#117;
-  until that PreToolUse hook ships, honestly label enforcement as
-  convention-held if asked.
+- Custody enforcement is opt-in per mission: if the operator armed
+  `actuator_guards` + `guard_mode` (the es#117 Stage-C hook), guarded
+  actuators are mechanically gated -- a block names the rule and is
+  discharged only by an operator-granted `amend`. If the mission carries no
+  guards, custody remains convention-held; say so honestly if asked.
 - Degraded modes: core unavailable -> author a markdown mission manifest,
   label it session-bounded; store unwritable -> surface immediately; operator
   revocation -> stop consequential work, surface AUTHORITY_REVOKED.


### PR DESCRIPTION
## Stage C: PreToolUse custody enforcement hook

Closes #117.

The tracer retro (vanta `mission/tracer-media-missing-record` @ `4540ddb`) ruled teeth IN, scoped to the successor mission's real actuators — arr API mutations and filesystem moves — not built speculatively. This PR ships that enforcement, **inert by default**: a mission opts in by adding operator-approved `actuator_guards` + `guard_mode` to its manifest authority (`open --guards-file` / `amend --guard-mode`); every other mission's custody is untouched and stays convention-held.

### What lands

- **Schema (additive within `mission-manifest@1`, no epoch bump):** optional `authority.guard_mode` (`audit`|`enforce`) + `authority.actuator_guards` (rules: `name`, `tool_names`, `command_regexes`, `path_globs`). Hand validator + JSON schema + 6 new invalid-corpus examples.
- **`custody_gate.py`:** pure evaluator + `run_gate` — chain-verified read via `MissionStore.load_latest`, never mutates chain state; matches append one JSONL line to `missions/<id>/guard-log.jsonl`.
- **`gate` CLI verb** + `open`/`amend` guard flags. Guard changes ride `amend` (verbatim operator grant) — guard relaxation is authority change with the same paper trail.
- **Tamper rule:** guards may differ from the chain-protected previous checkpoint only when a new amendment was recorded with the change; otherwise `_verify_manifest` reads it as tampering.
- **`custody_hook.py`:** stdlib, fail-open, in-process gate evaluation (no subprocess layer), per-harness payload adapters: claude, kimi, codex, cursor, gemini (covers agy via the shared `~/.gemini/settings.json` surface), generic.
- **Wiring:** Claude plugin `hooks/hooks.json`; Kimi plugin.json `hooks` arrays (inner + root manifests); Codex/Cursor/Gemini hook config files with docs citations. Codex and Gemini payload contracts verified against official docs; Cursor mostly verified (plugin-hook CWD undocumented; Cursor CLI reportedly ignores plugin hooks — both marked unverified in the README table).
- **Retro-consumption (the issue's second deliverable):** mission-custody README records the ruling as consumed; `skills/manifest/SKILL.md` boundary bullet updated; SECURITY.md gains the fail-open disclosure, guard-tamper residue, forward-compat hazard (arming guards makes checkpoints unreadable to pre-#117 caches — mixed-fleet note), and guard-log secrecy note.

Design: `docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md`. Plan: `docs/superpowers/plans/2026-08-12-stage-c-custody-hook.md`.

### Evidence

- **Tests:** all 7 custody suites green (script runner, exit 0); 13-file invalid corpus all rejected; valid manifests validate. Chain byte-identity across gate evaluations is a test (`run-gate-chain-byte-identical`).
- **Independent review:** one code review + one adversarial review (fresh agents, PoC-driven). Found **1 Critical + 6 Important** — including a plan-level flaw: the tamper tripwire as first specified was blind on any mission with a prior amendment (i.e. every mission that reaches enforce via `amend`). All findings fixed in two TDD rounds; adversarial re-review verified each fix closed with live repros, probed the fixes for new holes (false-positive sweep across all legitimate mutations, encoding attacks, nested-workspace discovery, glob boundaries), and returned **"mergeable pending operator GO"**.
- **Live scratch-mission UAT** (real hook entrypoint, canonical payloads): audit mode — Kimi and Claude guarded calls allowed + logged with correct rule/session/harness attribution; `amend --guard-mode enforce`; enforce mode — guarded arr-API call **blocked, exit 2, stderr names the rule**, block logged; unguarded call allowed; chain byte-identical (resume exit 0, exactly the 3 sanctioned checkpoints).

### Deliberate postures (disclosed, not hidden)

- Hooks fail open on error/timeout/crash on every platform — enforcement layer over convention, not a sole barrier. Detected tamper fails open but **loud** (stderr notice).
- Over-matching bias: a false block names its rule and is amend-dischargeable; a false allow silently retires custody. MCP/serialized-args matching is intentionally broad.
- Out of scope per the issue: es#118 (contract@2 tail anchor — the forged-amendment-on-tail residue class), es#124, arming any live mission.

### Merge discipline

ES main has no branch protection; merge only after checks are green **and** the head SHA matches the reviewed head (`1a7965e`).
