### PR TITLE
feat(mission-custody): --*-file input for verbatim text; argv is a lossy channel

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
@@ -69,3 +69,21 @@ fields: their stores will read the armed mission's checkpoints as
 ChainBroken (or skip the mission as unreadable). On a mixed fleet, update
 ALL custody consumers to the #117-or-later plugin before arming guards on
 any shared mission.
+
+## Verbatim text and the argv channel
+
+`amend` records the operator's VERBATIM grant, and `open --instruction` records
+the mission's founding instruction. Both, plus `note`/`frontier`/`--reason`,
+accept text inline on the command line -- where a shell can rewrite the string
+BEFORE the contract ever sees it. Backticks and `$(...)` are command
+substitution, `$VAR` expands, and argv caps near 32K chars on Windows.
+
+That corruption is invisible to every guarantee this contract provides: the
+mangled string is validated, hashed, chained, and (under contract@2) anchored,
+all faithfully -- the record is intact and wrong. Observed live: backticks in a
+double-quoted shell string silently rewrote a recorded note while the CLI
+exited 0.
+
+Use the `--*-file` variants for anything whose exactness matters, and always
+for `amend`. They read the bytes directly (`newline=''`, trailing newline
+stripped), so the recorded text is the supplied text.

--- a/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
+++ b/plugins/epistemic-skills/contracts/mission-custody/SECURITY.md
@@ -85,5 +85,10 @@ double-quoted shell string silently rewrote a recorded note while the CLI
 exited 0.
 
 Use the `--*-file` variants for anything whose exactness matters, and always
-for `amend`. They read the bytes directly (`newline=''`, trailing newline
-stripped), so the recorded text is the supplied text.
+for `amend`. They remove exactly two editor artifacts and nothing else: a
+leading UTF-8 BOM (PowerShell writes one by default, and U+FEFF is not
+whitespace, so it otherwise lands as the first character of a "verbatim"
+grant) and ONE trailing line terminator. Interior bytes -- including CRLF and
+deliberate blank lines -- are preserved exactly. A file that is not valid
+UTF-8 is refused with exit 2 rather than crashing, since PowerShell's bare
+`Out-File` writes UTF-16LE.

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -90,15 +90,41 @@ def _add_text_flags(parser: argparse.ArgumentParser, name: str) -> None:
 def _read_text(args: argparse.Namespace, name: str) -> str:
     """Read a text argument from its inline flag or its file.
 
-    newline='' for the same reason _read_content uses it: the bytes recorded
-    are the bytes supplied. A trailing newline is stripped because a file
-    almost always ends with one and it is not part of what the operator said;
-    interior bytes are untouched."""
+    Exactly two editor/shell artifacts are removed, and nothing else:
+
+    - a leading UTF-8 BOM (`utf-8-sig`). PowerShell 5.1's `Out-File` and
+      `Set-Content -Encoding utf8` write one by default on this fleet, and
+      plain `utf-8` decoding keeps it as U+FEFF -- which is NOT whitespace, so
+      it survives the empty-text checks and lands as the first character of a
+      "verbatim" operator grant.
+    - ONE trailing line terminator (\\r\\n, \\n, or \\r), because a file
+      practically always ends with one and it is not part of what the operator
+      said. Deliberately not `rstrip("\\r\\n")`: that eats an entire trailing
+      RUN, silently deleting a blank line the operator meant to keep.
+
+    Interior bytes are untouched -- newline='' keeps CRLF exactly as supplied.
+
+    A file that is not valid UTF-8 is a REFUSAL, not a crash: PowerShell's
+    bare `Out-File` writes UTF-16LE, and letting UnicodeDecodeError escape
+    exits 1 with a traceback, violating this module's documented 0/2/3
+    contract."""
     path = getattr(args, f"{name}_file", None)
-    if path is not None:
-        with open(path, encoding="utf-8", newline="") as handle:
-            return handle.read().rstrip("\r\n")
-    return getattr(args, name)
+    if path is None:
+        return getattr(args, name)
+    try:
+        with open(path, encoding="utf-8-sig", newline="") as handle:
+            text = handle.read()
+    except UnicodeDecodeError as exc:
+        raise CustodyError(
+            f"{name} file is not valid UTF-8 ({exc.reason}); custody records "
+            "text, and a file this cannot decode would be recorded wrong or "
+            "not at all -- re-save it as UTF-8") from None
+    except OSError as exc:
+        raise CustodyError(f"cannot read {name} file: {exc}") from None
+    for terminator in ("\r\n", "\n", "\r"):
+        if text.endswith(terminator):
+            return text[:-len(terminator)]
+    return text
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -69,6 +69,38 @@ def _add_content_flags(parser: argparse.ArgumentParser) -> None:
     group.add_argument("--content-file", dest="content_file")
 
 
+def _add_text_flags(parser: argparse.ArgumentParser, name: str) -> None:
+    """A `--<name>` / `--<name>-file` pair, for the SAME reason artifact
+    bodies got one: argv caps near 32K chars on Windows and every shell
+    metacharacter must survive quoting.
+
+    The reason is strictest for `amend`, whose text is the operator's
+    VERBATIM grant -- the one string in the contract whose exactness is the
+    whole point. Corruption here happens BEFORE the contract sees the string,
+    so every downstream guarantee (validation, hash chain, drift detection,
+    tail anchor) is intact and irrelevant: the mangled text is sealed as
+    authoritative. Observed live -- backticks in a double-quoted shell string
+    were executed as command substitution and silently deleted a word from a
+    recorded note, exit 0 (es#133)."""
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(f"--{name}")
+    group.add_argument(f"--{name}-file", dest=f"{name}_file")
+
+
+def _read_text(args: argparse.Namespace, name: str) -> str:
+    """Read a text argument from its inline flag or its file.
+
+    newline='' for the same reason _read_content uses it: the bytes recorded
+    are the bytes supplied. A trailing newline is stripped because a file
+    almost always ends with one and it is not part of what the operator said;
+    interior bytes are untouched."""
+    path = getattr(args, f"{name}_file", None)
+    if path is not None:
+        with open(path, encoding="utf-8", newline="") as handle:
+            return handle.read().rstrip("\r\n")
+    return getattr(args, name)
+
+
 def build_parser() -> argparse.ArgumentParser:
     common = _common_parser()
     parser = argparse.ArgumentParser(prog="custody_cli.py")
@@ -76,7 +108,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_open = sub.add_parser("open", parents=[common])
     p_open.add_argument("--mission-id", required=True)
-    p_open.add_argument("--instruction", required=True)
+    _add_text_flags(p_open, "instruction")
     p_open.add_argument("--operator", required=True)
     p_open.add_argument("--steward", required=True)
     p_open.add_argument("--tier", default="declared-role-separation")
@@ -100,7 +132,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("audit", parents=[common])
 
     p_amend = sub.add_parser("amend", parents=[common])
-    p_amend.add_argument("--text", required=True)
+    _add_text_flags(p_amend, "text")
     p_amend.add_argument("--guards-file", dest="guards_file")
     p_amend.add_argument("--guard-mode", dest="guard_mode",
                          choices=["audit", "enforce"])
@@ -109,10 +141,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_gate.add_argument("--input-file", dest="input_file")
 
     p_note = sub.add_parser("note", parents=[common])
-    p_note.add_argument("--text", required=True)
+    _add_text_flags(p_note, "text")
 
     p_frontier = sub.add_parser("frontier", parents=[common])
-    p_frontier.add_argument("--text", required=True)
+    _add_text_flags(p_frontier, "text")
 
     p_effect = sub.add_parser("effect", parents=[common])
     p_effect.add_argument("--path", required=True)
@@ -135,14 +167,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_accept.add_argument("--verdict", required=True)
     p_accept.add_argument("--acceptor", required=True)
     p_accept.add_argument("--tier", required=True)
-    p_accept.add_argument("--reason", required=True)
+    _add_text_flags(p_accept, "reason")
 
     p_clear = sub.add_parser("clear-fail", parents=[common])
     p_clear.add_argument("--match", required=True)
     p_clear.add_argument("--request-id", required=True)
 
     p_cancel = sub.add_parser("cancel", parents=[common])
-    p_cancel.add_argument("--reason", required=True)
+    _add_text_flags(p_cancel, "reason")
 
     return parser
 
@@ -197,7 +229,8 @@ def dispatch(args: argparse.Namespace) -> int:
         guards = (_read_guards_file(args.guards_file)
                   if args.guards_file else None)
         Mission.open(
-            workspace, mission_id=args.mission_id, instruction=args.instruction,
+            workspace, mission_id=args.mission_id,
+            instruction=_read_text(args, "instruction"),
             operator_ref=args.operator, steward_ref=args.steward,
             required_tier=args.tier, actor=args.actor,
             scope_in=args.scope_in, scope_out=args.scope_out,
@@ -233,11 +266,11 @@ def dispatch(args: argparse.Namespace) -> int:
             kwargs["actuator_guards"] = _read_guards_file(args.guards_file)
         if args.guard_mode:
             kwargs["guard_mode"] = args.guard_mode
-        print(mission.amend_authority(args.text, **kwargs))
+        print(mission.amend_authority(_read_text(args, "text"), **kwargs))
     elif args.command == "note":
-        print(mission.note(args.text))
+        print(mission.note(_read_text(args, "text")))
     elif args.command == "frontier":
-        print(mission.set_frontier(args.text))
+        print(mission.set_frontier(_read_text(args, "text")))
     elif args.command == "effect":
         receipt = mission.record_effect(args.path, _read_content(args),
                                          args.request_id)
@@ -273,11 +306,12 @@ def dispatch(args: argparse.Namespace) -> int:
         print(mission.begin_verification())
     elif args.command == "accept":
         print(mission.record_verdict(args.verdict, acceptor_id=args.acceptor,
-                                      assurance_tier=args.tier, reason=args.reason))
+                                      assurance_tier=args.tier,
+                                      reason=_read_text(args, "reason")))
     elif args.command == "clear-fail":
         print(mission.clear_fail(args.match, args.request_id))
     elif args.command == "cancel":
-        print(mission.cancel(args.reason))
+        print(mission.cancel(_read_text(args, "reason")))
     else:
         raise AssertionError(f"unhandled command {args.command!r}")
     return 0

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -469,6 +469,69 @@ def test_amend_guard_mode_flag() -> None:
         check("amend-guards-accepted", res.returncode == 0)
 
 
+def test_text_file_preserves_bytes_exactly() -> None:
+    """A verbatim grant must survive the CLI byte-for-byte.
+
+    The inline flags travel argv, where a shell can rewrite the string before
+    the contract ever sees it -- and the corruption is then hashed, chained and
+    sealed as authoritative, so no downstream guarantee can catch it (es#133).
+    The file path is the one that must be exact."""
+    hostile = ('operator grants: run `amend` and $HOME cleanup; '
+               '"quoted" \'single\' and $(date) stay literal; 100% & <>|;')
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        grant = Path(tmp) / "grant.txt"
+        # a trailing newline is what a heredoc or editor leaves behind; it must
+        # be stripped, not recorded as part of what the operator said
+        grant.write_text(hostile + "\n", encoding="utf-8", newline="")
+
+        r = run("open", "--workspace", str(ws), "--actor", "agent:w",
+                "--mission-id", "textfile", "--instruction-file", str(grant),
+                "--operator", "operator:zach", "--steward", "agent:w")
+        check("open-instruction-file-exit-0", r.returncode == 0)
+        run("approve", "--workspace", str(ws), "--actor", "agent:w")
+
+        r = run("amend", "--workspace", str(ws), "--actor", "agent:w",
+                "--text-file", str(grant))
+        check("amend-text-file-exit-0", r.returncode == 0)
+
+        auth = json.loads(run("status", "--workspace", str(ws),
+                               "--actor", "agent:w").stdout)["manifest"]["authority"]
+        check("instruction-byte-identical", auth["instruction"] == hostile)
+        check("amendment-byte-identical", auth["amendments"][0]["text"] == hostile)
+
+        check("note-text-file-exit-0",
+              run("note", "--workspace", str(ws), "--actor", "agent:w",
+                  "--text-file", str(grant)).returncode == 0)
+        check("frontier-text-file-exit-0",
+              run("frontier", "--workspace", str(ws), "--actor", "agent:w",
+                  "--text-file", str(grant)).returncode == 0)
+        st = json.loads(run("status", "--workspace", str(ws),
+                             "--actor", "agent:w").stdout)
+        check("note-byte-identical", st["state"]["notes"][-1] == hostile)
+        check("frontier-byte-identical", st["state"]["frontier"] == hostile)
+
+
+def test_text_and_text_file_are_mutually_exclusive() -> None:
+    """Both flags is ambiguous about which is the record of truth; neither
+    leaves the verb with nothing to record. Both refuse."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        grant = Path(tmp) / "g.txt"
+        grant.write_text("hello", encoding="utf-8")
+        open_cli(ws, "excl", "instruction")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+
+        check("note-both-flags-refused",
+              run("note", "--workspace", str(ws), "--actor", "agent:worker",
+                  "--text", "a", "--text-file", str(grant)).returncode == 2)
+        check("note-neither-flag-refused",
+              run("note", "--workspace", str(ws),
+                  "--actor", "agent:worker").returncode == 2)
+
+
 TESTS = [
     test_open_approve_effect_status_roundtrip,
     test_resume_detects_drift_exit_3,
@@ -485,6 +548,8 @@ TESTS = [
     test_gate_no_mission_allows,
     test_open_guard_mode_without_guards_refused,
     test_amend_guard_mode_flag,
+    test_text_file_preserves_bytes_exactly,
+    test_text_and_text_file_are_mutually_exclusive,
 ]
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -513,6 +513,114 @@ def test_text_file_preserves_bytes_exactly() -> None:
         check("frontier-byte-identical", st["state"]["frontier"] == hostile)
 
 
+def test_text_file_artifact_stripping_is_exact() -> None:
+    """Exactly two editor artifacts are removed, and nothing else.
+
+    A greedy rstrip("\r\n") ate an operator's deliberate trailing blank line,
+    and plain utf-8 decoding let a PowerShell-written BOM become the first
+    character of a "verbatim" grant -- both silently, both producing a record
+    that is intact and wrong."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        multi = Path(tmp) / "multi.txt"
+        # deliberate blank line at the end, CRLF throughout: only the LAST
+        # terminator is an artifact, the blank line is content
+        multi.write_bytes(b"Line one.\r\nLine two.\r\n\r\n")
+        r = run("open", "--workspace", str(ws), "--actor", "agent:w",
+                "--mission-id", "artifacts", "--instruction-file", str(multi),
+                "--operator", "operator:zach", "--steward", "agent:w")
+        check("multiline-open-exit-0", r.returncode == 0)
+        st = json.loads(run("status", "--workspace", str(ws),
+                             "--actor", "agent:w").stdout)
+        check("multiline-blank-line-preserved",
+              st["manifest"]["authority"]["instruction"]
+              == "Line one.\r\nLine two.\r\n")
+
+        run("approve", "--workspace", str(ws), "--actor", "agent:w")
+        bom = Path(tmp) / "bom.txt"
+        bom.write_bytes(b"\xef\xbb\xbf" + b"operator grants: proceed\n")
+        r = run("amend", "--workspace", str(ws), "--actor", "agent:w",
+                "--text-file", str(bom))
+        check("bom-amend-exit-0", r.returncode == 0)
+        st = json.loads(run("status", "--workspace", str(ws),
+                             "--actor", "agent:w").stdout)
+        check("bom-stripped-from-verbatim-grant",
+              st["manifest"]["authority"]["amendments"][0]["text"]
+              == "operator grants: proceed")
+
+
+def test_text_file_invalid_utf8_refuses_not_crashes() -> None:
+    """PowerShell's bare Out-File writes UTF-16LE. Letting UnicodeDecodeError
+    escape exits 1 with a traceback, breaking the documented 0/2/3 contract."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        bad = Path(tmp) / "utf16.txt"
+        bad.write_bytes(b"\xff\xfeo\x00p\x00")
+        r = run("open", "--workspace", str(ws), "--actor", "agent:w",
+                "--mission-id", "badenc", "--instruction-file", str(bad),
+                "--operator", "operator:zach", "--steward", "agent:w")
+        check("invalid-utf8-exit-2", r.returncode == 2)
+        check("invalid-utf8-names-custody-error", "CustodyError" in r.stderr)
+        check("invalid-utf8-no-traceback", "Traceback" not in r.stderr)
+
+
+def test_reason_file_on_accept_and_cancel() -> None:
+    """accept's reason is hash-chained into the acceptance-verdict record --
+    the same exactness stakes as an amendment, and previously untested."""
+    reason = "accepted: `verified` end-to-end; $SCOPE unchanged; 100% green"
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        rf = Path(tmp) / "reason.txt"
+        rf.write_text(reason + "\n", encoding="utf-8", newline="")
+        open_cli(ws, "reasonfile", "instruction")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        run("verify", "--workspace", str(ws), "--actor", "agent:worker")
+        r = run("accept", "--workspace", str(ws), "--actor", "agent:acceptor",
+                "--verdict", "PASS", "--acceptor", "agent:acceptor",
+                "--tier", "declared-role-separation", "--reason-file", str(rf))
+        check("accept-reason-file-exit-0", r.returncode == 0)
+        verdicts = list((ws / "missions" / "reasonfile" / "verdicts").glob("*.json"))
+        check("accept-reason-byte-identical",
+              bool(verdicts) and json.loads(
+                  verdicts[0].read_text(encoding="utf-8"))["reason"] == reason)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        rf = Path(tmp) / "reason.txt"
+        rf.write_text(reason + "\n", encoding="utf-8", newline="")
+        open_cli(ws, "cancelfile", "instruction")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        r = run("cancel", "--workspace", str(ws), "--actor", "agent:worker",
+                "--reason-file", str(rf))
+        check("cancel-reason-file-exit-0", r.returncode == 0)
+
+
+def test_text_file_mutual_exclusion_across_subcommands() -> None:
+    """Mutual exclusion must hold on every verb that takes text, not only the
+    one that happened to get a test."""
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        f = Path(tmp) / "t.txt"
+        f.write_text("x", encoding="utf-8")
+        r = run("open", "--workspace", str(ws), "--actor", "agent:w",
+                "--mission-id", "excl2", "--instruction", "a",
+                "--instruction-file", str(f),
+                "--operator", "op", "--steward", "agent:w")
+        check("open-both-instruction-flags-refused", r.returncode == 2)
+
+        open_cli(ws, "excl2", "instruction")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        for verb in ("amend", "frontier"):
+            r = run(verb, "--workspace", str(ws), "--actor", "agent:worker",
+                    "--text", "a", "--text-file", str(f))
+            check(f"{verb}-both-text-flags-refused", r.returncode == 2)
+
+
 def test_text_and_text_file_are_mutually_exclusive() -> None:
     """Both flags is ambiguous about which is the record of truth; neither
     leaves the verb with nothing to record. Both refuse."""
@@ -550,6 +658,10 @@ TESTS = [
     test_amend_guard_mode_flag,
     test_text_file_preserves_bytes_exactly,
     test_text_and_text_file_are_mutually_exclusive,
+    test_text_file_artifact_stripping_is_exact,
+    test_text_file_invalid_utf8_refuses_not_crashes,
+    test_reason_file_on_accept_and_cancel,
+    test_text_file_mutual_exclusion_across_subcommands,
 ]
 
 

--- a/plugins/epistemic-skills/skills/manifest/SKILL.md
+++ b/plugins/epistemic-skills/skills/manifest/SKILL.md
@@ -20,7 +20,7 @@ else.
 ## Modes
 
 1. **Open** — capture the operator instruction VERBATIM: `open --mission-id
-   <kebab> --instruction <verbatim> --operator <ref> --steward <your actor>
+   <kebab> --instruction-file <file> --operator <ref> --steward <your actor>
    --scope-in ... --scope-out ... --permission ... --protected ...
    [--tier declared-role-separation] [--hold-if RULE ...] [--stop-if RULE ...]
    [--escalate-if RULE ...] [--cost COST ...]`. An empty authority field is
@@ -47,10 +47,18 @@ else.
    Update `frontier` whenever the true next action changes and before session
    end — it is the next resume's anchor.
 4. **Amend** — when the operator grants authority the manifest does not carry,
-   record it VERBATIM with `amend --text <operator's words>` before acting on
-   it, then continue. Amendments are append-only and never self-authored:
-   this records a grant, it does not create one. Authority you cannot record
-   is authority you do not have — escalate instead.
+   record it VERBATIM with `amend --text-file <file>` before acting on it, then
+   continue. Amendments are append-only and never self-authored: this records a
+   grant, it does not create one. Authority you cannot record is authority you
+   do not have — escalate instead.
+   **Write the grant to a file and use `--text-file`, never `--text`** (same
+   for `--instruction-file` at open). Text passed inline travels argv, where a
+   shell rewrites it BEFORE custody sees it: backticks and `$(...)` execute,
+   `$VAR` expands, and argv truncates near 32K on Windows. The mangled text is
+   then validated, hashed, chained and anchored perfectly faithfully — the
+   record ends up intact and WRONG, and no downstream guarantee can catch it
+   because the corruption happened upstream of every one of them. Observed
+   live: a word was silently deleted from a recorded note, exit 0.
 5. **Verify / Close** — `verify`, then acceptance by a DIFFERENT actor: a
    distinct session runs `accept` as itself (`--actor` must equal
    `--acceptor`). Never accept work you performed; the core refuses it


### PR DESCRIPTION
Closes #133.

## The defect

`amend --text` carries the operator's **verbatim grant** — the one string in the contract whose exactness is the entire point — and it travelled argv, where a shell can rewrite it *before the contract ever sees it*. The corruption then passes every downstream guarantee faithfully: validated, hashed, chained, and (under the incoming contract@2) anchored. **The record ends up intact and wrong.**

Observed live rather than theorized: backticks in a double-quoted shell string were executed as command substitution and silently rewrote a recorded custody note, **exit 0**.

The codebase had already learned this lesson and applied it only to artifact bodies:

> Artifact bodies do not belong on a command line: argv caps out near 32K chars on Windows and every shell metacharacter must survive quoting

Every word of that applies with more force to `--text`, `--instruction`, and `--reason`. It had not been applied.

## The change

`--instruction-file` / `--text-file` / `--reason-file` across `open`, `amend`, `note`, `frontier`, `accept`, `cancel` — mutually exclusive with the inline forms, required as a pair. Reads with `newline=''` so recorded bytes are supplied bytes; strips one trailing newline, which is an artifact of heredocs and editors rather than part of what the operator said.

## Verification

New tests assert a **byte-identical round-trip** through `open`/`amend`/`note`/`frontier` for a deliberately hostile string — backticks, `$VAR`, `$(...)`, single and double quotes, `& < > | %` — plus mutual-exclusion and neither-flag refusals. All 7 suites green (`test_custody_cli`, `custody_mission`, `custody_store`, `mission_custody`, `custody_gate`, `custody_hook`, `custody_process_proof`).

SECURITY.md documents the channel, because this failure is invisible to the chain **by construction** — no future guarantee can catch it, so the only defense is using the file variants for anything whose exactness matters.

## Note on scope

Deliberately does **not** make `--text-file` mandatory for `amend`, though there's a real argument for it (#133 raises it). That's a breaking ergonomic change worth deciding separately from shipping the capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ