### PR TITLE
fix(mission-custody): close three fail-open gaps found by bot review of merged #135

### DIFF
--- a/.github/workflows/mission-custody-contract.yml
+++ b/.github/workflows/mission-custody-contract.yml
@@ -51,5 +51,17 @@ jobs:
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
       - name: Custody CLI black-box tests
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+      - name: Custody gate unit tests
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
+      # The Stage-C enforcement hook's own suite was NOT run by any workflow.
+      # Its platform-aware assertions are written to discriminate on POSIX --
+      # `native = "c:/ok" if os.name == "nt" else "/c:/ok"` -- so on a Windows
+      # dev host they assert the Windows branch and the POSIX branch executed
+      # nowhere at all. Two rounds of fixes to POSIX workspace-root handling
+      # were therefore verified only by simulation. A test that no runner
+      # executes is not coverage; its green is read as coverage, which is worse
+      # than having none.
+      - name: Custody enforcement hook tests (POSIX branch runs here, not on dev hosts)
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
       - name: Three-subprocess kill/resume/repair continuity proof
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_process_proof.py

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -121,15 +121,19 @@ def _candidate_workspaces(call: dict) -> list[Path]:
         # relative. Both produced `Path(".")` as a candidate: a block naming a
         # rule from a mission the user is not in, and an entry written into
         # that unrelated mission's guard log.
-        # Absolute under EITHER flavour, not under the host's. `Path` on
-        # Windows calls "/opt/u/proj" not-absolute (rooted, but driveless), so
-        # gating on the native answer would discard a genuine POSIX root the
-        # moment the hook ran on Windows -- trading this fail-open for a
-        # different one. "/c:/work" is POSIX-absolute, "c:/work" is
-        # Windows-absolute, and "file:///c:/w" is neither.
+        # NATIVE absoluteness, because `_find_workspace` parses with the
+        # native `Path`. An earlier attempt accepted "absolute under either
+        # flavour", which let `c:/work/project` through on POSIX -- absolute
+        # to PureWindowsPath, relative to the `Path` that actually consumes it,
+        # so the ancestor walk still reached `.`. A gate whose notion of valid
+        # differs from its consumer's is not a gate.
+        #
+        # This is also what makes the two readings correct per platform rather
+        # than by luck: on POSIX the UNSTRIPPED "/c:/work" is native-absolute
+        # and the stripped form is not; on Windows the reverse. Each platform
+        # accepts exactly the reading that is real there.
         try:
-            if not (PurePosixPath(location).is_absolute()
-                    or PureWindowsPath(location).is_absolute()):
+            if not Path(location).is_absolute():
                 return
         except (OSError, ValueError):
             return
@@ -165,8 +169,17 @@ def _candidate_workspaces(call: dict) -> list[Path]:
             # whichever has no missions/ tree, and any-blocks-wins covers the
             # rest -- the same reasoning that made this function return a list
             # instead of a first-wins answer.
-            if isinstance(root, str) and root and root != location:
-                consider(root)
+            # The raw value, including from an OBJECT-shaped root. Gating the
+            # second reading on `isinstance(root, str)` skipped
+            # {"uri": "/c:/work/project"} entirely, so on POSIX only the
+            # stripped (and there, relative) form was ever offered and a
+            # mission under the real absolute path was missed -- a fail-open
+            # for exactly the editor shape this module set out to support.
+            raw = root
+            if isinstance(raw, dict):
+                raw = raw.get("uri") or raw.get("path") or ""
+            if isinstance(raw, str) and raw and raw != location:
+                consider(raw)
     return candidates
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -37,8 +37,11 @@ def _find_workspace(cwd: str) -> Path | None:
 
 def _strip_leading_drive_slash(path: str) -> str:
     """'/C:/x' -> 'C:/x'. A URI path and Cursor's bare Windows roots both carry
-    the leading slash; Windows reads the un-stripped form as a driveless path."""
-    if len(path) > 2 and path[0] == "/" and path[2] == ":":
+    the leading slash; Windows reads the un-stripped form as a driveless path.
+
+    The drive letter must be a LETTER. '/1:/x' is not a drive path, and
+    rewriting it would invent a location out of an unrecognised string."""
+    if len(path) > 2 and path[0] == "/" and path[1].isalpha() and path[2] == ":":
         return path[1:]
     return path
 
@@ -116,7 +119,21 @@ def _candidate_workspaces(call: dict) -> list[Path]:
     roots = call.get("workspace_roots")
     if isinstance(roots, list):  # a bare string would iterate per-character
         for root in roots:
-            consider(_root_location(root))
+            location = _root_location(root)
+            consider(location)
+            # '/c:/work/project' has TWO readings: a Windows drive path (which
+            # _root_location resolves) and, on POSIX, a perfectly legal
+            # absolute path, because ':' is an ordinary filename character
+            # there. Choosing one platform's reading gets the other wrong, and
+            # both wrong answers end identically: no workspace found, no
+            # mission consulted, the guarded call SILENTLY ALLOWED.
+            #
+            # So neither is chosen. Both are offered, _find_workspace discards
+            # whichever has no missions/ tree, and any-blocks-wins covers the
+            # rest -- the same reasoning that made this function return a list
+            # instead of a first-wins answer.
+            if isinstance(root, str) and root and root != location:
+                consider(root)
     return candidates
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -35,6 +35,14 @@ def _find_workspace(cwd: str) -> Path | None:
         current = parent
 
 
+def _strip_leading_drive_slash(path: str) -> str:
+    """'/C:/x' -> 'C:/x'. A URI path and Cursor's bare Windows roots both carry
+    the leading slash; Windows reads the un-stripped form as a driveless path."""
+    if len(path) > 2 and path[0] == "/" and path[2] == ":":
+        return path[1:]
+    return path
+
+
 def _root_location(root: object) -> str:
     """Best-effort path string from one workspace_roots entry.
 
@@ -52,16 +60,23 @@ def _root_location(root: object) -> str:
         from urllib.parse import unquote, urlparse
         parsed = urlparse(root)
         path = unquote(parsed.path)
-        if parsed.netloc:
-            # RFC 8089 authority form: file://server/share -> \\server\share.
-            # Dropping the host silently resolves to the WRONG local path, and
-            # this fleet is UNC-heavy (Y: is a mapping of \\10.10.10.127).
+        # RFC 8089 defines "localhost" as EQUIVALENT TO AN EMPTY AUTHORITY, so
+        # file://localhost/C:/work is a LOCAL path. Treating it as a UNC
+        # authority produced \\localhost\C:\work, which resolves nowhere -- a
+        # hole the UNC fix itself opened, caught in review.
+        if parsed.netloc and parsed.netloc.lower() != "localhost":
+            # Authority form: file://server/share -> \\server\share. Dropping
+            # the host silently resolves to the WRONG local path, and this
+            # fleet is UNC-heavy (a mapped drive over a UNC share).
             return "\\\\" + parsed.netloc + path.replace("/", "\\")
-        # file:///C:/x -> /C:/x on Windows; strip the leading slash
-        if len(path) > 2 and path[0] == "/" and path[2] == ":":
-            path = path[1:]
-        return path
-    return root
+        return _strip_leading_drive_slash(path)
+    # Bare (non-URI) roots need the same treatment: Cursor's Windows
+    # workspace_roots use the form "/c:/work/project". Returned unchanged, a
+    # Windows path parse reads that as "\c:\work\project" with NO DRIVE, so
+    # _find_workspace never sees the real missions/ tree and the gate takes the
+    # inert path -- silently allowing exactly the guarded MCP calls this
+    # fallback exists to catch.
+    return _strip_leading_drive_slash(root)
 
 
 def _candidate_workspaces(call: dict) -> list[Path]:
@@ -186,8 +201,24 @@ def main(argv: list[str]) -> int:
                     workspace, tool_call, actor="hook:custody-gate",
                     session_id=call.get("session_id", ""), harness=args.harness)
             except CustodyError as exc:
+                # Tamper keeps its own distinct, greppable signal: a session log
+                # must be searchable for TAMPER, and folding it into the generic
+                # branch below silently retired that marker.
                 print(f"custody gate: TAMPER/custody error detected at "
                       f"{workspace}, failing open for that mission: "
+                      f"{type(exc).__name__}: {exc}", file=sys.stderr)
+                continue
+            except Exception as exc:
+                # Deliberately broad, and per-candidate. Catching ONLY
+                # CustodyError let every other exception -- Mission.load
+                # intentionally propagates environmental OSErrors such as
+                # PermissionError -- escape to the outer handler, which returns
+                # 0 immediately. One unreadable root then silently suppressed
+                # every later root's block: root ORDER causing a false allow,
+                # the exact defect this loop was built to close. Fail open for
+                # the candidate that failed, never for the rest.
+                print(f"custody gate: error evaluating {workspace}, failing "
+                      f"open for that mission only: "
                       f"{type(exc).__name__}: {exc}", file=sys.stderr)
                 continue
             if verdict["decision"] == "block":

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -46,7 +46,7 @@ def _strip_leading_drive_slash(path: str) -> str:
     return path
 
 
-def _root_location(root: object) -> str:
+def _root_location(root: object, *, strip: bool = True) -> str:
     """Best-effort path string from one workspace_roots entry.
 
     The entry shape is taken from Cursor's docs prose, NOT from a captured
@@ -72,14 +72,14 @@ def _root_location(root: object) -> str:
             # the host silently resolves to the WRONG local path, and this
             # fleet is UNC-heavy (a mapped drive over a UNC share).
             return "\\\\" + parsed.netloc + path.replace("/", "\\")
-        return _strip_leading_drive_slash(path)
+        return _strip_leading_drive_slash(path) if strip else path
     # Bare (non-URI) roots need the same treatment: Cursor's Windows
     # workspace_roots use the form "/c:/work/project". Returned unchanged, a
     # Windows path parse reads that as "\c:\work\project" with NO DRIVE, so
     # _find_workspace never sees the real missions/ tree and the gate takes the
     # inert path -- silently allowing exactly the guarded MCP calls this
     # fallback exists to catch.
-    return _strip_leading_drive_slash(root)
+    return _strip_leading_drive_slash(root) if strip else root
 
 
 def _candidate_workspaces(call: dict) -> list[Path]:
@@ -169,17 +169,18 @@ def _candidate_workspaces(call: dict) -> list[Path]:
             # whichever has no missions/ tree, and any-blocks-wins covers the
             # rest -- the same reasoning that made this function return a list
             # instead of a first-wins answer.
-            # The raw value, including from an OBJECT-shaped root. Gating the
-            # second reading on `isinstance(root, str)` skipped
-            # {"uri": "/c:/work/project"} entirely, so on POSIX only the
-            # stripped (and there, relative) form was ever offered and a
-            # mission under the real absolute path was missed -- a fail-open
-            # for exactly the editor shape this module set out to support.
-            raw = root
-            if isinstance(raw, dict):
-                raw = raw.get("uri") or raw.get("path") or ""
-            if isinstance(raw, str) and raw and raw != location:
-                consider(raw)
+            # The alternate reading is the UNSTRIPPED, DECODED path -- never
+            # the raw string. For a bare root those are the same thing, but for
+            # a URI they are not: on POSIX `file:///c:/ok` decodes to the valid
+            # absolute path `/c:/ok`, while the raw URI is relative to `Path`
+            # and gets rejected. Offering the raw form meant BOTH readings were
+            # discarded there and an armed mission under that root failed open.
+            #
+            # This also covers object-shaped roots, which an `isinstance(root,
+            # str)` guard previously skipped entirely.
+            alternate = _root_location(root, strip=False)
+            if alternate and alternate != location:
+                consider(alternate)
     return candidates
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -111,6 +111,28 @@ def _candidate_workspaces(call: dict) -> list[Path]:
     def consider(location: str) -> None:
         if not location:
             return
+        # A RELATIVE location is not a usable root. `_find_workspace` walks
+        # ancestors, and a relative path's chain terminates at `.` -- so a
+        # root the process cannot interpret would resolve to "wherever the
+        # hook happens to be running", which this function's own docstring
+        # promises never happens. Observed with a `file://` URI fed through as
+        # a literal (`Path("file:///c:/w")` is relative on both platforms) and
+        # with the stripped bare-drive form on POSIX, where `c:/work` is
+        # relative. Both produced `Path(".")` as a candidate: a block naming a
+        # rule from a mission the user is not in, and an entry written into
+        # that unrelated mission's guard log.
+        # Absolute under EITHER flavour, not under the host's. `Path` on
+        # Windows calls "/opt/u/proj" not-absolute (rooted, but driveless), so
+        # gating on the native answer would discard a genuine POSIX root the
+        # moment the hook ran on Windows -- trading this fail-open for a
+        # different one. "/c:/work" is POSIX-absolute, "c:/work" is
+        # Windows-absolute, and "file:///c:/w" is neither.
+        try:
+            if not (PurePosixPath(location).is_absolute()
+                    or PureWindowsPath(location).is_absolute()):
+                return
+        except (OSError, ValueError):
+            return
         workspace = _find_workspace(location)
         if workspace is not None and workspace not in candidates:
             candidates.append(workspace)
@@ -119,7 +141,18 @@ def _candidate_workspaces(call: dict) -> list[Path]:
     roots = call.get("workspace_roots")
     if isinstance(roots, list):  # a bare string would iterate per-character
         for root in roots:
-            location = _root_location(root)
+            try:
+                location = _root_location(root)
+            except Exception as exc:                      # noqa: BLE001
+                # `urlparse` raises ValueError on a malformed authority
+                # ("file://[oops" -> Invalid IPv6 URL). Unhandled, it escaped
+                # discovery into the outer handler and returned ALLOW with an
+                # empty stderr -- one malformed IDE-supplied root silently
+                # disarming an armed guard, which is verbatim the fail-open
+                # the per-candidate handler downstream was added to close.
+                print(f"custody-gate: unreadable workspace root, skipping: "
+                      f"{type(exc).__name__}", file=sys.stderr)
+                continue
             consider(location)
             # '/c:/work/project' has TWO readings: a Windows drive path (which
             # _root_location resolves) and, on POSIX, a perfectly legal

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -399,6 +399,40 @@ def test_object_shaped_root_also_offers_both_readings() -> None:
               all(Path(a).is_absolute() for a in asked))
 
 
+def test_drive_shaped_file_uri_offers_the_decoded_posix_reading() -> None:
+    """`file:///c:/ok` decodes to `/c:/ok`, which is absolute on POSIX.
+
+    The alternate reading used to be the RAW string. For a bare root that is
+    the same thing, but for a URI it is not: the raw `file:///c:/ok` is
+    relative to `Path` on both platforms, so on POSIX the stripped reading was
+    rejected as relative AND the raw fallback was rejected too -- both readings
+    discarded, workspace never evaluated, an armed mission there failing open.
+
+    The alternate is now the unstripped DECODED path, so each platform still
+    sees the reading that is absolute there."""
+    import custody_hook
+    check("uri-primary-is-the-windows-reading",
+          custody_hook._root_location("file:///c:/ok") == "c:/ok")
+    check("uri-alternate-is-the-posix-reading",
+          custody_hook._root_location("file:///c:/ok", strip=False) == "/c:/ok")
+    # UNC resolves before any stripping, so both readings agree
+    unc = "\\" + "\\" + "server" + "\\" + "share" + "\\" + "p"
+    check("uri-unc-unaffected-by-strip",
+          custody_hook._root_location("file://server/share/p", strip=False) == unc)
+
+    asked: list[str] = []
+    original = custody_hook._find_workspace
+    custody_hook._find_workspace = lambda loc: (asked.append(loc), None)[1]
+    try:
+        custody_hook._candidate_workspaces({"workspace_roots": ["file:///c:/ok"]})
+    finally:
+        custody_hook._find_workspace = original
+    native = "c:/ok" if os.name == "nt" else "/c:/ok"
+    check("uri-native-reading-probed", native in asked)
+    check("uri-probes-nothing-relative",
+          all(Path(a).is_absolute() for a in asked))
+
+
 def test_malformed_root_does_not_disarm_the_others() -> None:
     """`urlparse` raises on a malformed authority; unhandled it returned ALLOW.
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -343,6 +343,56 @@ def test_root_location_uri_forms() -> None:
               custody_hook._root_location(src) == want)
 
 
+def test_relative_root_never_becomes_a_candidate() -> None:
+    """A root the process cannot interpret must not resolve to the cwd.
+
+    `_find_workspace` walks ancestors, and a RELATIVE path's chain terminates
+    at `.`, so a `file://` URI fed through as a literal (Path("file:///c:/w")
+    is relative on both platforms) made `Path(".")` -- "wherever the hook
+    happens to be running" -- a candidate. Consequences measured: a block
+    naming a rule from a mission the user is not in, and an entry written into
+    that unrelated mission's guard log. The same shape hits the stripped
+    bare-drive form on POSIX, where `c:/work` is relative."""
+    import custody_hook
+    asked: list[str] = []
+    original = custody_hook._find_workspace
+    custody_hook._find_workspace = lambda loc: (asked.append(loc), None)[1]
+    try:
+        custody_hook._candidate_workspaces(
+            {"workspace_roots": ["file:///c:/some/other/project"]})
+    finally:
+        custody_hook._find_workspace = original
+    check("uri-literal-not-probed",
+          not any(a.startswith("file:") for a in asked))
+    check("no-relative-location-probed",
+          all(Path(a).is_absolute() for a in asked))
+
+
+def test_malformed_root_does_not_disarm_the_others() -> None:
+    """`urlparse` raises on a malformed authority; unhandled it returned ALLOW.
+
+    "file://[oops" -> ValueError: Invalid IPv6 URL escaped discovery into the
+    outer handler, so ONE malformed IDE-supplied root silently disarmed an
+    armed guard with an empty stderr -- verbatim the fail-open the
+    per-candidate handler downstream exists to close, left open one function
+    earlier."""
+    import custody_hook
+    asked: list[str] = []
+    original = custody_hook._find_workspace
+    custody_hook._find_workspace = lambda loc: (asked.append(loc), None)[1]
+    try:
+        custody_hook._candidate_workspaces(
+            {"workspace_roots": ["file://[oops", "file:///c:/ok"]})
+    except Exception as exc:                                  # noqa: BLE001
+        check("malformed-root-does-not-raise", False)
+        print(f"  raised {type(exc).__name__}")
+    else:
+        check("malformed-root-does-not-raise", True)
+    finally:
+        custody_hook._find_workspace = original
+    check("later-root-still-evaluated", any("ok" in a for a in asked))
+
+
 def test_bare_drive_root_offers_both_readings() -> None:
     """'/c:/work/project' is a Windows drive path AND a legal POSIX path.
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -334,10 +334,47 @@ def test_root_location_uri_forms() -> None:
         ("file://LOCALHOST/C:/work/proj", "C:/work/proj"),
         # a bare POSIX path must not be mangled by the drive-slash strip
         ("/opt/u/proj", "/opt/u/proj"),
+        # the drive letter must be a LETTER: rewriting "/1:/x" would invent a
+        # location out of a string nothing identified as a drive path
+        ("/1:/work/project", "/1:/work/project"),
     ]
     for src, want in cases:
         check(f"root-location-{str(src)[:28]}",
               custody_hook._root_location(src) == want)
+
+
+def test_bare_drive_root_offers_both_readings() -> None:
+    """'/c:/work/project' is a Windows drive path AND a legal POSIX path.
+
+    On POSIX ':' is an ordinary filename character, so stripping the leading
+    slash there yields a RELATIVE path: `_find_workspace` would search from
+    wherever the hook process happens to run, find nothing, and silently allow
+    the guarded call. Gating the rewrite on the platform only moves the
+    fail-open to the other platform -- both wrong readings end the same way.
+
+    So neither reading is chosen. Both are offered as candidates,
+    `_find_workspace` drops whichever has no missions/ tree, and any-blocks-wins
+    does the rest."""
+    import custody_hook
+    asked: list[str] = []
+    original = custody_hook._find_workspace
+    custody_hook._find_workspace = lambda loc: (asked.append(loc), None)[1]
+    try:
+        custody_hook._candidate_workspaces(
+            {"workspace_roots": ["/c:/work/project"]})
+    finally:
+        custody_hook._find_workspace = original
+    check("bare-drive-offers-stripped-reading", "c:/work/project" in asked)
+    check("bare-drive-offers-unstripped-reading", "/c:/work/project" in asked)
+    # a path with only ONE reading must not be probed twice
+    asked.clear()
+    custody_hook._find_workspace = lambda loc: (asked.append(loc), None)[1]
+    try:
+        custody_hook._candidate_workspaces(
+            {"workspace_roots": ["/opt/u/proj"]})
+    finally:
+        custody_hook._find_workspace = original
+    check("single-reading-probed-once", asked == ["/opt/u/proj"])
 
 
 def test_missing_payload_cwd_is_inert_even_when_hook_process_runs_inside_armed_workspace() -> None:

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -320,6 +320,20 @@ def test_root_location_uri_forms() -> None:
         (12345, ""),
         (None, ""),
         ({}, ""),
+        # BARE Windows form. Cursor's Windows workspace_roots use "/c:/...".
+        # Returned unchanged it parses as a DRIVELESS "\\c:\\..." on Windows,
+        # so the mission tree is never found and guarded MCP calls fail open --
+        # exactly the hole the workspace_roots fallback exists to close.
+        ("/c:/work/project", "c:/work/project"),
+        ("/C:/work/project", "C:/work/project"),
+        # RFC 8089: "localhost" is EQUIVALENT TO AN EMPTY AUTHORITY, i.e. a
+        # LOCAL path. The UNC fix originally turned it into \\localhost\C:\...,
+        # which resolves nowhere -- a hole that fix itself opened.
+        ("file://localhost/C:/work/proj", "C:/work/proj"),
+        ("file://localhost/opt/u/proj", "/opt/u/proj"),
+        ("file://LOCALHOST/C:/work/proj", "C:/work/proj"),
+        # a bare POSIX path must not be mangled by the drive-slash strip
+        ("/opt/u/proj", "/opt/u/proj"),
     ]
     for src, want in cases:
         check(f"root-location-{str(src)[:28]}",
@@ -356,6 +370,37 @@ def test_missing_payload_cwd_is_inert_even_when_hook_process_runs_inside_armed_w
         check("no-cwd-no-roots-is-inert-not-process-relative",
               r.returncode == 0)
         check("inert-path-emits-no-block", "BLOCKED" not in r.stderr)
+
+
+def test_non_custody_error_on_one_root_does_not_suppress_a_later_block() -> None:
+    """A non-CustodyError on an earlier candidate must not abort the loop.
+
+    The loop originally caught only CustodyError, so anything else -- and
+    Mission.load intentionally PROPAGATES environmental OSErrors such as
+    PermissionError -- escaped to the outer `except Exception: return 0`. One
+    unreadable root then silently suppressed every later root's block: root
+    ORDER causing a false allow, the exact defect the loop was built to close.
+    """
+    guards = [{"name": "no-deploy", "tool_names": ["Bash"],
+               "command_regexes": ["deploy-prod"], "path_globs": []}]
+    with tempfile.TemporaryDirectory() as tmp:
+        a, b = Path(tmp) / "A", Path(tmp) / "B"
+        a.mkdir(); b.mkdir()
+        # structurally poisoned: a DIRECTORY where a checkpoint file must be,
+        # which raises outside the CustodyError family
+        (a / "missions" / "broken" / "checkpoints").mkdir(parents=True)
+        (a / "missions" / "broken" / "checkpoints" / "r00000001.json").mkdir()
+        live = Mission.open(b, "live", "i", "operator:t", "agent:t",
+                            actor="agent:t", guard_mode="enforce",
+                            actuator_guards=guards)
+        live.approve()
+        payload = {"tool_name": "Bash",
+                   "tool_input": {"command": "deploy-prod now"},
+                   "workspace_roots": [str(a), str(b)]}
+        res = run_hook("cursor", payload)
+        check("poisoned-earlier-root-does-not-suppress-later-block",
+              res.returncode == 2)
+        check("poisoned-root-failure-is-loud", "failing open" in res.stderr)
 
 
 if __name__ == "__main__":

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -364,8 +364,39 @@ def test_relative_root_never_becomes_a_candidate() -> None:
         custody_hook._find_workspace = original
     check("uri-literal-not-probed",
           not any(a.startswith("file:") for a in asked))
+    # NATIVE absoluteness, asserted the same way the gate decides it. An
+    # earlier version of this check passed on Windows and FAILED on POSIX,
+    # because the gate accepted "absolute under either flavour" while
+    # _find_workspace parses natively -- so `c:/work/project` slipped through
+    # on Linux and reached `.`. A platform-dependent assertion is how that got
+    # past a green local run.
     check("no-relative-location-probed",
           all(Path(a).is_absolute() for a in asked))
+
+
+def test_object_shaped_root_also_offers_both_readings() -> None:
+    """An object root must get the dual reading a bare string gets.
+
+    Gating the second reading on `isinstance(root, str)` skipped
+    {"uri": "/c:/work/project"} entirely, so on POSIX only the stripped form
+    -- relative there -- was offered, and a mission under the real absolute
+    path was missed. A fail-open for exactly the editor shape this module set
+    out to support."""
+    import custody_hook
+    for shape in ({"uri": "/c:/work/project"}, {"path": "/c:/work/project"}):
+        asked: list[str] = []
+        original = custody_hook._find_workspace
+        custody_hook._find_workspace = lambda loc: (asked.append(loc), None)[1]
+        try:
+            custody_hook._candidate_workspaces({"workspace_roots": [shape]})
+        finally:
+            custody_hook._find_workspace = original
+        key = "uri" if "uri" in shape else "path"
+        # exactly one reading is native-absolute per platform; the point is
+        # that the object shape gets both OFFERED, not that both survive
+        check(f"object-root-{key}-offers-a-reading", bool(asked))
+        check(f"object-root-{key}-all-native-absolute",
+              all(Path(a).is_absolute() for a in asked))
 
 
 def test_malformed_root_does_not_disarm_the_others() -> None:
@@ -402,9 +433,15 @@ def test_bare_drive_root_offers_both_readings() -> None:
     the guarded call. Gating the rewrite on the platform only moves the
     fail-open to the other platform -- both wrong readings end the same way.
 
-    So neither reading is chosen. Both are offered as candidates,
-    `_find_workspace` drops whichever has no missions/ tree, and any-blocks-wins
-    does the rest."""
+    So neither reading is chosen. Both are OFFERED; the native-absoluteness
+    gate then keeps whichever one is real on this platform, `_find_workspace`
+    drops whichever has no missions/ tree, and any-blocks-wins does the rest.
+
+    The assertion is deliberately platform-aware. Asserting that BOTH readings
+    are probed passed on Windows and would have failed on Linux, because only
+    one of them is native-absolute on any given platform -- and a
+    platform-dependent assertion that happens to hold locally is how a hole
+    reaches CI green."""
     import custody_hook
     asked: list[str] = []
     original = custody_hook._find_workspace
@@ -414,8 +451,12 @@ def test_bare_drive_root_offers_both_readings() -> None:
             {"workspace_roots": ["/c:/work/project"]})
     finally:
         custody_hook._find_workspace = original
-    check("bare-drive-offers-stripped-reading", "c:/work/project" in asked)
-    check("bare-drive-offers-unstripped-reading", "/c:/work/project" in asked)
+    native = "c:/work/project" if os.name == "nt" else "/c:/work/project"
+    other = "/c:/work/project" if os.name == "nt" else "c:/work/project"
+    check("bare-drive-probes-the-native-reading", native in asked)
+    check("bare-drive-drops-the-non-native-reading", other not in asked)
+    check("bare-drive-probes-nothing-relative",
+          all(Path(a).is_absolute() for a in asked))
     # a path with only ONE reading must not be probed twice
     asked.clear()
     custody_hook._find_workspace = lambda loc: (asked.append(loc), None)[1]
@@ -424,7 +465,11 @@ def test_bare_drive_root_offers_both_readings() -> None:
             {"workspace_roots": ["/opt/u/proj"]})
     finally:
         custody_hook._find_workspace = original
-    check("single-reading-probed-once", asked == ["/opt/u/proj"])
+    # A POSIX root has ONE reading. It is probed once where it is real, and
+    # not probed at all on Windows, where "/opt/u/proj" is rooted-but-driveless
+    # and `_find_workspace` would walk it to `.`.
+    check("single-reading-probed-once",
+          asked == ([] if os.name == "nt" else ["/opt/u/proj"]))
 
 
 def test_missing_payload_cwd_is_inert_even_when_hook_process_runs_inside_armed_workspace() -> None:


### PR DESCRIPTION
All three were reported as **review comments** on PR #135 while its **status checks reported green** — and #135 merged on that green. These are the findings that were sitting unread.

Governance follow-up already filed: **RULE-033** (example-infrastructure #1529) — checks and comments are two independent channels and both are must-reads before a merge decision.

## The three gaps

**1 · HIGH (cursor[bot]) — bare Windows root not normalized.**
Cursor's Windows `workspace_roots` use the form `/c:/work/project`. `_root_location` stripped the leading drive slash **only inside the `file://` branch** and returned every other string unchanged, so Windows parsed `/c:/...` as a **driveless** `\c:\...`. `_find_workspace` never saw the `missions/` tree, `main()` took the empty-candidate inert path, and guarded MCP actuators were **silently allowed** — precisely the fail-open #135 existed to close.

**2 · P2 (codex) — `localhost` authority treated as UNC.**
A hole **my own UNC fix opened**. RFC 8089 defines `localhost` as equivalent to an *empty* authority, so `file://localhost/C:/work` is a local path. The netloc branch turned it into `\localhost\C:\work`, which resolves nowhere. Now special-cased, case-insensitively.

**3 · P1 (codex) — non-`CustodyError` aborted the multi-root loop.**
The loop caught only `CustodyError`, so anything else — and `Mission.load` *intentionally* propagates environmental `OSError`s such as `PermissionError` — escaped to the outer `except Exception: return 0`. One unreadable root then silently suppressed every later root's block: **root order causing a false allow**, the exact defect that loop was built to close.

Now per-candidate and broad, while keeping the distinct greppable `TAMPER` signal for `CustodyError` — folding both into one generic message retired that marker, which the existing `hook-tamper-stderr-loud` test caught.

## Method note

Applied deliberately, after five self-inflicted holes in this session. Every one of those was correct for the case I had in mind and wrong for a case I had not enumerated — never a logic error. So the URI/root handling is now specified **as a case table**: 16 asserted forms covering bare-drive, bare-POSIX, drive URI, POSIX URI, percent-encoded, UNC authority, localhost authority (both casings), object shapes and non-string inputs — rather than one assertion per bug fixed.

Plus an end-to-end regression proving a structurally poisoned earlier root does not suppress a later armed root's block.

## Verification

All 7 suites green across 3 consecutive runs; public-content gate run locally before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrCsYy5Bp6dSYLTApKznmJ

> Privacy edit (2026-09-18): personal identifiers and local coordinates in this historical text are redacted. Synthetic example values do not reproduce the original bytes. Findings and outcomes are unchanged.