### PR TITLE
chore(gitignore): ignore missions/ mission-custody runtime checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ pilot/runs/
 # Deterministic OpenAI/ChatGPT archives are CI artifacts, not source.
 dist/openai/
 
+# Mission-custody checkpoints — live mission chains are fleet-local runtime
+# state (like run telemetry), not source.
+missions/
+
 # Skill run telemetry — real ledger/adjudication lines are runtime state
 # (operator-private), not public content; only the synthetic example ships
 # (see plugins/epistemic-skills/skills/gauntlet/runs/README.md).


### PR DESCRIPTION
Live mission chains (checkpoint JSONs under `missions/`, e.g. `missions/custody-instrument/checkpoints/`) are fleet-local runtime state created by the mission-custody hook at runtime — never tracked in git history (`git log --all -- missions/` is empty). They currently show as untracked noise in the canonical checkout.

This adds `missions/` to `.gitignore` alongside the existing telemetry ignores. .gitignore change only; no mission content committed.