### PR TITLE
docs(release): add the missing publication-authorization step; tag creation is now gated

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -179,19 +179,39 @@ candidate.
    - Owner exception: record `WAIVED`/`UNMET` and the authorization in the
      committed release notes **before** tagging. Do not describe the result as a
      GO or conforming release.
-7. **Create and push the annotated tag.** Tag `v<version>` on the exact candidate
+7. **Authorize publication explicitly, then disarm the tag rule.** A verdict is
+   advice until an owner acts on it. Until 2026-08-13 nothing here recorded that
+   act, and nothing prevented it from being skipped.
+   - Record, in the committed release notes, a line naming **the verdict read,
+     the exact candidate SHA authorized, and the owner**. A verdict without a
+     resolvable subject authorizes nothing: a `GO` for one SHA is not a `GO` for
+     the SHA about to be tagged unless they are the same string.
+   - The ruleset `protect-version-tags` carries `creation` with **no bypass
+     actors**, so `refs/tags/v*` cannot be created by anyone — including an
+     owner, and including automation acting with an owner's credential. That is
+     deliberate: this repository is pushed with the same credential automation
+     runs under, so an admin bypass would have exempted exactly the actors the
+     rule exists to constrain.
+   - **Disarming the rule is therefore the authorization act.** Remove the
+     `creation` rule (or set the ruleset's enforcement to `disabled`), create and
+     push the tag, then **re-arm it in the same sitting**. Record the disarm and
+     re-arm alongside the authorization line.
+   - Verify the rule is armed again before closing the release, with a seeded
+     probe rather than by reading the config back. A release that ends with the
+     gate left open has removed the control it was meant to satisfy.
+8. **Create and push the annotated tag.** Tag `v<version>` on the exact candidate
    SHA. Never use a lightweight tag for a support point.
-8. **Create the GitHub Release.** Use the committed release-note file verbatim as
+9. **Create the GitHub Release.** Use the committed release-note file verbatim as
    the body. The Release must be non-draft and must target the annotated tag.
-9. **Verify publication identity.** Through the GitHub API, verify that:
-   - the tag exists and is annotated;
-   - the peeled tag target equals the candidate SHA;
-   - the GitHub Release targets the same tag or exact candidate;
-   - the committed release-note body and normalized GitHub Release body are
-     equal; and
-   - `main` contains the release commit or an explicitly documented fast-forward
-     successor.
-10. **Record any post-publication discovery honestly.** Correct documentation on
+10. **Verify publication identity.** Through the GitHub API, verify that:
+    - the tag exists and is annotated;
+    - the peeled tag target equals the candidate SHA;
+    - the GitHub Release targets the same tag or exact candidate;
+    - the committed release-note body and normalized GitHub Release body are
+      equal; and
+    - `main` contains the release commit or an explicitly documented fast-forward
+      successor.
+11. **Record any post-publication discovery honestly.** Correct documentation on
     `main`, add a clearly labeled erratum or post-release review, and ship artifact
     changes under a new semantic version. Never rewrite the immutable tag or imply
     a missing pre-publication event occurred.


### PR DESCRIPTION
## What

Adds procedure step 7, **"Authorize publication explicitly, then disarm the tag rule"**, and renumbers 8–11.

## Why

The Gauntlet publication gate run for v5.0.1 (verdict: **NO-GO** on candidate `2438768`) found that `RELEASING.md` steps 6–7 had **no step where an owner authorizes publication**. Step 6 resolved a verdict; step 7 created a tag. Nothing recorded who acted on the verdict, against which SHA — and nothing prevented the act from being skipped. This file's own history records the gate being waived once already, for v5.0.0.

The same review established by live probe that `refs/tags/v*` creation was **ungated**: ruleset `protect-version-tags` carried `update` and `deletion` but no `creation` rule, so any push credential could create a version tag regardless of any verdict.

## The control, and why it has no admin bypass

`creation` has been added to the ruleset with `bypass_actors: []`. Verified by seeded positive control rather than by reading the config back:

```
! [remote rejected] v0.0.0-guardprobe (push declined due to repository rule violations)
git ls-remote --tags origin | grep guardprobe  ->  nothing
```

No bypass for admin, deliberately: this repository is pushed with the same credential automation runs under, so an admin bypass would have exempted precisely the actors the rule exists to constrain — a control that reads as installed and is not.

**So disarming the rule is the authorization act**, and the new step says so: record the verdict read, the exact SHA, and the owner; disarm; tag; re-arm in the same sitting; verify re-armed with a seeded probe.

> A verdict without a resolvable subject authorizes nothing — a `GO` for one SHA is not a `GO` for the SHA about to be tagged unless they are the same string.

## Scope note

This is one repo's fix for a gap that is estate-wide: five ZMS-Labs repos carry 66 immutable tags between them and this is the only one with any tag governance, one of the ungoverned being public with 30 tags. Estate rollout is tracked separately.