### PR TITLE
fix(plugin): register skills in plain clones via .claude/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../plugins/epistemic-skills/skills


### PR DESCRIPTION
`/metacognate` — and every other skill in the collection — was unreachable in any session whose harness had not installed the plugin. A plain clone, including cloud sessions working on this very repo, exposed no skills at all: the collection ships under `plugins/epistemic-skills/skills/`, which no harness scans for project skills, and the repo had no `.claude/` directory.

One symlink cures it, in the convention the repo already uses at the root (`skills`, `agents`):

```
.claude/skills -> plugins/epistemic-skills/skills
```

Every clone now exposes the collection as project skills with no install step. Where the plugin **is** installed, the harness's scoped naming disambiguates the duplicate registration. Registration is snapshotted at session start, so the fix takes effect from the next session onward.

Found live: the operator invoked `/metacognate` in a cloud session attached to this repo and got "Unknown command" — the estate's entry-point seat was uninvocable from inside its own repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UTnWoqb6559TLUGisAuYKb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTnWoqb6559TLUGisAuYKb)_