### PR TITLE
docs(readme): add ZCode row to the installation/compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Install with **exactly one mechanism per harness**. Native plugin **or** generic
 | Gemini CLI | Tagged extension | Restart and validate extension | Uses root context and canonical symlinked tree |
 | Antigravity (`agy`) | Tagged native local plugin | Validate with `agy` | Choose native, Gemini link, or import—only one |
 | Kimi Code | Tagged repository plugin | `/reload` or new session | Plugin instructions map isolated-agent primitives |
+| ZCode | Tagged local checkout, junction-projected into `~/.zcode/skills` | Start a fresh session; verify the tag's full skill count (fourteen at v5.0.0) | Session bootstrap junctions `~/.claude/skills` only — skills riding as Claude *plugins* are not auto-imported; junction surface verified on one fleet device, plugin install untested |
 | Generic Agent Skills host | Tagged canonical skills URL | Reload host and verify source | Host must supply any runtime primitive the selected skill requires |
 
 Full installation, migration, runtime-degradation, and troubleshooting guidance lives in the [installation handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility).


### PR DESCRIPTION
Refs [private tracker redacted; issue #1557]

Adds ZCode to the harness table: junction projection from a tagged local checkout into `~/.zcode/skills` (the same one-canonical-clone pattern the zms fleet uses for its personal-skills package). One mechanism per harness is preserved — ZCode gets plain-skill junctions; no plugin install.

Honest boundary recorded in the row: the ZCode session bootstrap junctions `~/.claude/skills` only, so installs that ride as Claude plugins are not auto-imported (this is exactly how the package went missing there); junction surface verified on one fleet device (example-workstation, 14/14 skills readable through the links, installer `-Verify` exit 0); plugin-marketplace install untested.

Routine reversible docs change per CONTRIBUTING (no discipline artifact owed).

> Privacy edit (2026-09-18): personal identifiers and local coordinates in this historical text are redacted. Synthetic example values do not reproduce the original bytes. Findings and outcomes are unchanged.