### PR TITLE
release: 5.1.0 gate evidence + release-diff review fixes (final tag candidate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Windows local install:
 ```powershell
 git clone --depth 1 --branch v5.1.0 https://github.com/ZMS-Labs/epistemic-skills.git .\epistemic-skills-v5.1.0
 Set-Location .\epistemic-skills-v5.1.0
-if ((git describe --tags --exact-match) -ne 'v5.0.0') { throw 'expected v5.0.0' }
+if ((git describe --tags --exact-match) -ne 'v5.1.0') { throw 'expected v5.1.0' }
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.cursor\plugins\local" | Out-Null
 $src = (Resolve-Path .\plugins\epistemic-skills).Path
 $dest = Join-Path $env:USERPROFILE '.cursor\plugins\local\epistemic-skills'
@@ -277,7 +277,7 @@ macOS/Linux local install:
 ```bash
 git clone --depth 1 --branch v5.1.0 https://github.com/ZMS-Labs/epistemic-skills.git ./epistemic-skills-v5.1.0
 cd ./epistemic-skills-v5.1.0
-test "$(git describe --tags --exact-match)" = v5.0.0
+test "$(git describe --tags --exact-match)" = v5.1.0
 mkdir -p ~/.cursor/plugins/local
 ln -sfn "$(pwd)/plugins/epistemic-skills" ~/.cursor/plugins/local/epistemic-skills
 ```
@@ -307,7 +307,7 @@ Use one of native `agy plugin install`, Gemini extension link, or `agy plugin im
 ### Kimi Code
 
 ```text
-/plugins install https://github.com/ZMS-Labs/epistemic-skills/tree/v5.0.0
+/plugins install https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0
 # Local development only, from a clone:
 /plugins install /path/to/epistemic-skills
 ```
@@ -384,7 +384,7 @@ contract into an accepted one.
 
 ## Trust, evidence, and known limits
 
-**Version 5.1.0** is the current immutable support point: fourteen skills, aligned package surfaces, deterministic checks, and a tagged source snapshot. It was **published with explicit gate honesty** — item 6 only PARTIALLY MET at publication, item 8 WAIVED / NOT MET — and a post-release independent review returned **NO-GO** for retrospective certification. Read the [errata](docs/release/RELEASE-5.0.0-ERRATA-2026-08-06.md), [post-release review](docs/release/POST-RELEASE-INDEPENDENT-REVIEW-5.0.0-2026-08-06.md), and [successor progress](docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md) before treating v5.0.0 as gate-complete. Corrective work for issues #104/#105 landed on `main` after the immutable tag; do not move the tag.
+**Version 5.1.0** is the current immutable support point: fifteen skills, aligned package surfaces, deterministic checks, and a tagged source snapshot; its gate record lives in [RELEASE-5.1.0.md](docs/release/RELEASE-5.1.0.md). Its predecessor **v5.0.0** was published with explicit gate honesty — item 6 only PARTIALLY MET at publication, item 8 WAIVED / NOT MET — and a post-release independent review returned **NO-GO** for retrospective certification. Read the [errata](docs/release/RELEASE-5.0.0-ERRATA-2026-08-06.md), [post-release review](docs/release/POST-RELEASE-INDEPENDENT-REVIEW-5.0.0-2026-08-06.md), and [successor progress](docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md) before treating v5.0.0 as gate-complete. Corrective work for issues #104/#105 landed on `main` after the immutable tag; do not move the tag.
 
 Earlier support points remain historically accurate for their own campaigns. Version 3.2.0 established the behavioral-evidence posture that later releases inherit unless a new campaign re-opens it: aligned surfaces and deterministic checks, with named behavioral limits that were never rewritten into passes.
 

--- a/docs/release/RELEASE-5.1.0.md
+++ b/docs/release/RELEASE-5.1.0.md
@@ -1,6 +1,6 @@
 # Release 5.1.0 — manifest ships, corrections land, custody's verify verb stops lying
 
-**Date:** 2026-08-15 (candidate). **Minor.** Fifteen skills — the fourteen of
+**Date:** 2026-08-15. **Minor.** Fifteen skills — the fourteen of
 5.0.0 plus `manifest`, the mission-custody seat, published as a canonical
 junction-reachable skill.
 
@@ -75,13 +75,46 @@ through it, with no clean path back. Now:
 
 ## Release gate status for 5.1.0
 
+Per `RELEASING.md` §Release gate. Rows 4–7 are recorded against the release
+content commit `7ba1f19` (PR #179 squash) together with this gate-evidence
+commit — the commit that carries this table is the final tag candidate, and
+item 8 must reach GO against it before the annotated tag is created.
+Verification is at job and step level, not by run label.
+
 | Item | Status | Evidence |
 |---|---|---|
-| 4 — version/link alignment | met | all ten version-bearing surfaces at 5.1.0; surface-sync `--check` green (15 skills / 14 disciplines); no stale tag URLs |
-| 5 — deterministic suite, DCO, parity, JSON, CodeQL | pending exact-commit CI | local: all custody suites 0 failures; inventory/phantom/budget checks green |
-| 6 — secret scan **and** public-content/provenance review | pending | scan via CI; the public-content half **will be performed on the release diff this time** and recorded here, not waived |
-| 7 — harness surfaces exercised or assigned an honest tier | junction projection verified on one fleet device (zms-pc-2025) post-tag; plugin surfaces inherit 5.0.0 tiers | README install table carries the honest boundaries |
-| 8 — independent Gauntlet publication review reaching GO | **required, scheduled** | v5.0.0 shipped as a documented exception; this release runs the gate |
+| 4 — version/link alignment | **met, after four live-surface stalenesses found and fixed by the release-diff review** | all ten version-bearing surfaces at 5.1.0; surface-sync `--check` green (15 skills / 14 disciplines). The review caught four prose-level stalenesses that no automated surface check covers, fixed in this commit: two Cursor install guards and the Kimi `/plugins install` URL still pinned to `v5.0.0`, and the README support-point paragraph still describing v5.0.0's gate history (fourteen skills, item 6 PARTIALLY MET, item 8 WAIVED) as 5.1.0's. |
+| 5 — deterministic suite, DCO, parity, JSON, CodeQL | **met on `7ba1f19`** | six workflows green at `7ba1f19`, step-verified: `epistemic-flexibility` run 31894206384 (`stdlib-checks` green incl. skill inventory, surface synchronization, no-phantom, description budget, public-content gate steps); `release-security` run 31894206380; `openai-bundles` run 31894206377; `mission-custody-contract` run 31894206404 (its `contract-macos` job correctly skipped — inapplicable platform); `commission-watch-contract` run 31894206405; CodeQL run 31894206293 with all three `Analyze` matrices (`actions`, `javascript-typescript`, `python`) success. This gate-evidence commit's own push-CI is verified green before the tag; its run IDs are recorded in the annotated tag message. |
+| 6 — secret scan **and** public-content/provenance review | **met, both halves, on `7ba1f19`** | scan: `release-security` run 31894206380, every step success — including the planted-secret positive control and the digest-allowlist narrowness control — before the full-history gitleaks pass. Public content: `check_public_content.py --self-test` + live run both exit 0 in the `stdlib-checks` Public-content gate step (run 31894206384), **plus** a manual release-diff review of all 19 changed files (+303/−48) against private paths, internal topology, credentials, personal data, and accidental telemetry — findings and dispositions recorded below. |
+| 7 — harness surfaces exercised or assigned an honest tier | **met via explicit tiers; one live junction verification lands post-tag** | the README install table carries per-harness honest boundaries: Cursor's recorded behavioral epoch stays `BLOCKED_EXTERNAL`; ZCode's junction surface is verified on one fleet device (zms-pc-2025) with plugin install untested; the generic host carries the runtime-primitive caveat. Plugin surfaces inherit their 5.0.0 tiers — no new live plugin-harness executions in this release. |
+| 8 — independent Gauntlet publication review reaching GO | **required — pending, pre-tag** | the panel runs against the frozen final candidate before tag creation; its record lands at an immutable path identifying this candidate's SHA. v5.0.0 shipped as a documented exception — this release does not repeat that. |
+
+### Release-diff public-content review (item 6 record)
+
+Scope: `git diff 1e36da9..7ba1f19` — 19 files, +303/−48 (version surfaces,
+README, release notes, CI config, gitleaks config, custody CLI + mission
+code, custody tests, two SKILL.md touch-ups), plus the current-tree
+`check_public_content.py` pass cited above. Findings and dispositions:
+
+- **No credentials, private paths, internal topology, or telemetry** in the
+  diff. The one hostname-shaped token, `zms-pc-2025` in the item-7 row and
+  tests, names a device with no address, role, or network detail, and
+  device-name mentions of this class are already public in
+  `docs/release/PUBLIC-RELEASE-REVIEW-ADDENDUM-2026-07-21.md`.
+- `operator:SternOne` appears as an `--actor` string in the new custody
+  tests. Disposition: accepted — `SternOne` is the operator's designated
+  public callsign, deliberately not a personal name.
+- `.gitleaks.toml` and the new "digest allowlist is narrow" CI step embed a
+  synthetic SHA-256 fixture. Disposition: accepted — synthetic test data,
+  admitted only by line-anchored allowlist regexes whose narrowness the new
+  control step proves (a neighboring `credential` field is rejected).
+- The release notes name the `media-library-rebuild` mission and the
+  `custody-instrument` steward mission. Disposition: accepted — incident
+  names only, no workspace paths, checkpoint contents, or fleet state.
+- The review's four README staleness findings are recorded under item 4
+  above and fixed in this commit; they are content-truth defects, not
+  disclosure defects, and are listed here because the same review produced
+  them.
 
 ## Known limitations, carried honestly
 


### PR DESCRIPTION
## Purpose

Finalize the v5.1.0 release gate evidence (RELEASING.md §Release gate) and fix four README staleness defects found by the release-diff public-content review. **The squash of this PR is the final v5.1.0 tag candidate** — item 8 (Gauntlet GO) runs against it before the annotated tag.

## What changed

- `docs/release/RELEASE-5.1.0.md` — gate table items 4–7 recorded with step-level evidence against the merged release commit `7ba1f19` (six workflow run IDs, positive-control + narrowness-control steps verified, README tier table cited); new "Release-diff public-content review" subsection records findings and dispositions (all accepted/none material, rationale inline); item 8 stays **required — pending, pre-tag**.
- `README.md` — four fixes the same review caught:
  1. Cursor Windows install guard still expected `v5.0.0` (a correct v5.1.0 install would throw).
  2. Cursor macOS/Linux guard: same.
  3. Kimi `/plugins install` URL still pinned to `tree/v5.0.0`.
  4. Support-point paragraph named v5.1.0 but carried v5.0.0's gate history ("fourteen skills", item 6 PARTIALLY MET, item 8 WAIVED, NO-GO) as its own — now correctly attributed to v5.0.0, with 5.1.0 = fifteen skills pointing at its own gate record.

## Evidence

- Local checks from the worktree root: surface-sync `--check` (15 skills / 14 disciplines), skill inventory, no-phantom, description budget (8,636/8,636), `check_public_content.py --self-test` (4 RED controls) + live — all green.
- Step-level CI verification at `7ba1f19` is recorded in the gate table (runs 31894206384 / 31894206380 / 31894206377 / 31894206404 / 31894206405 / 31894206293).

Closes nothing; precedes the v5.1.0 tag.
