### PR TITLE
feat(gate): RFC1918 / UNC-share / email pattern classes for the public-content gate (es#186 SK-2)

### DIFF
--- a/.github/scripts/check_public_content.py
+++ b/.github/scripts/check_public_content.py
@@ -20,8 +20,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-# Patterns drawn from docs/release/PUBLIC-RELEASE-REVIEW-ADDENDUM-2026-07-21.md.
-# Keep the list small and reasoned. Each entry must have a RED seed below.
+# Patterns drawn from docs/release/PUBLIC-RELEASE-REVIEW-ADDENDUM-2026-07-21.md
+# and the v5.1.0 publication gauntlet (docs/gauntlet-runs/es-v510-publication-
+# 2026-08-15, panel-1 SK-2: the original four patterns could not see the
+# RFC1918/UNC/email classes item 6 enumerates, and the full-window review had
+# to catch them by hand). Keep the list small and reasoned. Each entry must
+# have a RED seed below.
 PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("private-fleet-repo-name", re.compile(r"\bzms-homelab\b", re.I)),
     # Windows user homes in either slash form.
@@ -30,6 +34,20 @@ PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     # substring inside `C:/Users/...`.
     ("posix-user-path", re.compile(r"(?<![A-Za-z:])/Users/[A-Za-z0-9._-]+/")),
     ("y-drive-private-checkout", re.compile(r"[Yy]:[/\\]dev[/\\]zms-homelab", re.I)),
+    # Internal-network topology (es#186 / panel-1 SK-2). RFC1918 ranges only:
+    # internet-facing hosts have legitimate public IPs and must not trip this.
+    ("rfc1918-address", re.compile(
+        r"\b(?:10\.\d{1,3}|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d{1,3}\.\d{1,3}\b")),
+    # SMB share paths whose host is an IP, either slash form
+    # (`\\10.0.0.5\share` / `//10.0.0.5/share`). The lookbehind excludes
+    # URL schemes (`http://...`); bare IPs inside URLs are the pattern above's
+    # job.
+    ("unc-ip-share", re.compile(
+        r"(?<!:)(?:\\\\|//)(?:\d{1,3}\.){3}\d{1,3}[\\/][A-Za-z0-9._$-]+")),
+    # Personal-data class: any real-looking email address. Synthetic RFC
+    # example addresses are neutralized before scanning (see scan_text).
+    ("email-address", re.compile(
+        r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")),
 ]
 
 # Files that must remain able to name the scrub vocabulary so the review trail
@@ -43,6 +61,59 @@ ALLOWLIST_PREFIXES = (
     ".github/scripts/check_public_content.py",
 )
 
+# Exact-file exemptions for content that predates these pattern classes or is
+# itself the disposition record. EXACT files, never prefixes: a new file at a
+# different path still fails closed, and adding a file here is a visible,
+# reviewable act. Rationale per entry:
+#   - "disposition record": the v5.1.0 full-window review (RELEASE-5.1.0.md)
+#     and its committed gauntlet record name the disclosed strings — the same
+#     purpose the review-receipt prefixes serve.
+#   - "dispositioned fixture": custody guard fixtures/tests exercising
+#     path-scoping rules with private-range literals; accepted in the v5.1.0
+#     record, no credential accompanies any occurrence.
+#   - "pre-gate historical record": plan/spec/audit/handoff documents that
+#     carried the operator DCO email (public git-history floor) or custody
+#     design literals before this gate existed. The gate is forward-looking
+#     for this class; editing these files does NOT re-expose anything not
+#     already immutable in git history.
+ALLOWLIST_EXACT_FILES = {
+    # disposition record
+    "docs/release/RELEASE-5.1.0.md": "disposition record (names the disclosed strings)",
+    "docs/gauntlet-runs/es-v510-publication-2026-08-15/arbitration.md": "disposition record",
+    "docs/gauntlet-runs/es-v510-publication-2026-08-15/reports/script-kiddie.md": "disposition record",
+    # dispositioned fixtures (v5.1.0 full-window review)
+    "plugins/epistemic-skills/contracts/mission-custody/examples/valid-manifest-guards.json": "dispositioned fixture",
+    "plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-bad-mode.json": "dispositioned fixture",
+    "plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-bad-regex.json": "dispositioned fixture",
+    "plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-empty-rule.json": "dispositioned fixture",
+    "plugins/epistemic-skills/contracts/mission-custody/examples/invalid-manifest-guard-unknown-field.json": "dispositioned fixture",
+    "plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py": "dispositioned fixture",
+    # pre-gate historical records
+    "docs/superpowers/plans/2026-08-12-stage-c-custody-hook.md": "pre-gate historical record",
+    "docs/superpowers/specs/2026-08-12-stage-c-custody-hook-design.md": "pre-gate historical record",
+    "docs/audits/2026-07-23-suite-stress-test/08-changes-and-verification.md": "pre-gate historical record",
+    "docs/audits/2026-07-23-suite-stress-test/09-final-verification.md": "pre-gate historical record",
+    "docs/gauntlet-runs/epistemic-flexibility-v3-2026-07-22/arbitration.json": "pre-gate historical record",
+    "docs/gauntlet-runs/epistemic-flexibility-v3-2026-07-22/dossier.md": "pre-gate historical record",
+    "docs/gauntlet-runs/epistemic-flexibility-v3-2026-07-22/reports/compliance-litigator.json": "pre-gate historical record",
+    "docs/gauntlet-runs/epistemic-flexibility-v3-2026-07-22/workflow-result.json": "pre-gate historical record",
+    "docs/gauntlet-runs/upgrades-landing-2026-08-03/arbitration.md": "pre-gate historical record",
+    "docs/gauntlet-runs/upgrades-landing-2026-08-03/evidence/commits.txt": "pre-gate historical record",
+    "docs/gauntlet-runs/upgrades-landing-2026-08-03/evidence/dco-check.txt": "pre-gate historical record",
+    "docs/gauntlet-runs/upgrades-landing-2026-08-03/reports/decision-rights-auditor.md": "pre-gate historical record",
+    "docs/gauntlet-runs/upgrades-landing-2026-08-03/reports/disgruntled-maintainer.md": "pre-gate historical record",
+    "docs/gauntlet-runs/upgrades-landing-2026-08-03/reports/ecological-systems-analyst.md": "pre-gate historical record",
+    "docs/outsource/epistemic-skills-pr43-readonly-review/HANDOFF.md": "pre-gate historical record",
+    "docs/outsource/epistemic-skills-suite-stress-test/HANDOFF.md": "pre-gate historical record",
+    "docs/superpowers/plans/2026-07-29-open-questions.md": "pre-gate historical record",
+    "docs/superpowers/plans/2026-08-06-openai-plugin-bundles.md": "pre-gate historical record",
+    "docs/superpowers/plans/2026-08-07-commission-watch-clarification.md": "pre-gate historical record",
+    "docs/superpowers/plans/2026-08-07-practical-agency-bootstrap.md": "pre-gate historical record",
+    "docs/superpowers/plans/2026-08-11-mission-custody-contracts.md": "pre-gate historical record",
+    "docs/superpowers/specs/2026-08-07-practical-agency-and-commission-watch-design.md": "pre-gate historical record",
+    "docs/wiki-updates/v4.0.0/v4.0.0-wiki-update.patch": "pre-gate historical record",
+}
+
 
 def tracked_files() -> list[Path]:
     result = subprocess.run(
@@ -55,6 +126,8 @@ def tracked_files() -> list[Path]:
 
 def is_allowlisted(path: Path) -> bool:
     rel = path.relative_to(REPO_ROOT).as_posix()
+    if rel in ALLOWLIST_EXACT_FILES:
+        return True
     return any(rel.startswith(prefix) or rel == prefix for prefix in ALLOWLIST_PREFIXES)
 
 
@@ -63,8 +136,15 @@ def scan_text(path: Path, text: str) -> list[str]:
     if is_allowlisted(path):
         return defects
     rel = path.relative_to(REPO_ROOT).as_posix()
-    # Synthetic RED-seed usernames used by package tests (not real operator homes).
+    # Synthetic RED-seed usernames and RFC example emails used by package
+    # tests/docs (not real operator data).
     sanitized = re.sub(r"([A-Za-z]:[\\/]Users[\\/]|/Users/)example\b", r"\1<synthetic>", text, flags=re.I)
+    sanitized = re.sub(
+        r"\b[A-Za-z0-9._%+-]+@example\.(?:com|org|net|test)\b",
+        "<synthetic-email>",
+        sanitized,
+        flags=re.I,
+    )
     for name, pattern in PATTERNS:
         if pattern.search(sanitized):
             defects.append(f"{name}: {rel}")
@@ -87,7 +167,8 @@ def run_check() -> int:
         return 1
     print(
         "public-content gate ok: "
-        f"{len(PATTERNS)} patterns, {len(ALLOWLIST_PREFIXES)} allowlist prefixes"
+        f"{len(PATTERNS)} patterns, {len(ALLOWLIST_PREFIXES)} allowlist prefixes, "
+        f"{len(ALLOWLIST_EXACT_FILES)} allowlisted exact files"
     )
     return 0
 
@@ -99,6 +180,9 @@ def run_self_test() -> int:
         "windows-user-path": r"probe under C:\Users\example\.claude\skills",
         "posix-user-path": "probe under /Users/example/.claude/skills",
         "y-drive-private-checkout": r"checkout at Y:\dev\zms-homelab-main",
+        "rfc1918-address": "the service answers on 10.10.10.50 today",
+        "unc-ip-share": r"media lives at \\10.10.10.107\Media and //10.10.10.107/Media",
+        "email-address": "reach the operator at z.stern@personalmailbox.org",
     }
     for expected, blob in seeds.items():
         hits = []
@@ -115,6 +199,27 @@ def run_self_test() -> int:
     )
     if allowlisted:
         failures.append(f"allowlisted review text was rejected: {allowlisted}")
+
+    # Allowlisted EXACT files (disposition records/fixtures) must pass; the
+    # same content at a NON-allowlisted path must fail (exact-file semantics:
+    # the exemption is bound to the path, not the content).
+    exact_hit = scan_text(
+        REPO_ROOT / "docs/release/RELEASE-5.1.0.md",
+        "the endpoint was http://10.10.10.50:7878/api/v3/series",
+    )
+    if exact_hit:
+        failures.append(f"allowlisted exact file was rejected: {exact_hit}")
+    exact_miss = scan_text(
+        REPO_ROOT / "docs/some-new-file.md",
+        "the endpoint was http://10.10.10.50:7878/api/v3/series",
+    )
+    if not exact_miss:
+        failures.append("non-allowlisted path with identical content was NOT rejected (exact-file semantics broken)")
+
+    # Synthetic example emails must not trip the email pattern in tree scans.
+    synthetic = scan_text(REPO_ROOT / "docs/some-new-file.md", "contact us at maintainer@example.com anytime")
+    if synthetic:
+        failures.append(f"synthetic example email was rejected: {synthetic}")
 
     if failures:
         for failure in failures:


### PR DESCRIPTION
## Purpose

First item of the v5.1.0 post-tag docket (#186): the public-content gate could not see the disclosure classes it is cited for. Panel 1 (release gauntlet, `docs/gauntlet-runs/es-v510-publication-2026-08-15`) had to catch RFC1918 topology, IP-hosted UNC paths, and a personal email **by hand** in the full-window review — the automated half of gate item 6 was vacuous for exactly those classes (SK-2).

## What changes

- **Three new pattern classes**, each with a RED seed: `rfc1918-address` (private ranges only — public IPs stay legitimate), `unc-ip-share` (`\\ip\share` and `//ip/share`, scheme-excluding), `email-address` (personal-data class; synthetic RFC `example.*` addresses are neutralized before scanning, mirroring the existing synthetic-username rule).
- **Exact-file allowlist** (new mechanism, deliberately NOT prefixes): 32 files, each with a one-line rationale — the v5.1.0 disposition record and its committed gauntlet record (they name the disclosed strings, same purpose as the review-receipt prefixes), the dispositioned custody fixtures/tests (private-range literals, no credentials), and pre-gate historical records carrying the operator DCO email (public git-history floor). A new file at any other path still fails closed; adding an exemption is a visible, reviewable act.
- **Self-test extended to 7 RED controls**, including the exact-file semantics control (identical content is rejected at a non-allowlisted path) and the synthetic-email exemption control.

## Verification

- `python .github/scripts/check_public_content.py --self-test` → 7 seeded RED controls passed.
- `python .github/scripts/check_public_content.py` → gate ok: 7 patterns, 6 allowlist prefixes, 32 allowlisted exact files (the tree passes because every hit is dispositioned; hit inventory was enumerated before the allowlist was written, not discovered by iteration).

Part of #186 (does not close it — allowlist-prefix narrowing, POSIX guard, and the other docket items remain).
