### PR TITLE
docs(surfaces): name mission custody in capability enumerations (es#186 AC-5)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.1.0",
   "author": {
     "name": "ZMS Labs",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "version": "5.1.0",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"
@@ -30,7 +30,7 @@
   "interface": {
     "displayName": "Epistemic Skills",
     "shortDescription": "Evidence-grounded methods for agentic work",
-    "longDescription": "Fourteen composable disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
+    "longDescription": "Fourteen composable disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene.",
     "developerName": "ZMS Labs",
     "websiteURL": "https://github.com/ZMS-Labs/epistemic-skills"
   }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.1.0",
   "contextFileName": "GEMINI.md"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://antigravity.google/schemas/v1/plugin.json",
   "name": "epistemic-skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table."
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table."
 }

--- a/plugins/epistemic-skills/.claude-plugin/plugin.json
+++ b/plugins/epistemic-skills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.1.0",
   "author": {
     "name": "ZMS Labs"

--- a/plugins/epistemic-skills/.codex-plugin/plugin.json
+++ b/plugins/epistemic-skills/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "version": "5.1.0",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"
@@ -23,7 +23,7 @@
   "interface": {
     "displayName": "Epistemic Skills",
     "shortDescription": "Evidence-grounded methods for agentic work",
-    "longDescription": "An entry point plus fourteen composable disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
+    "longDescription": "An entry point plus fourteen composable disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
     "developerName": "ZMS Labs",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/epistemic-skills/.cursor-plugin/plugin.json
+++ b/plugins/epistemic-skills/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "version": "5.1.0",
   "author": {
     "name": "ZMS Labs"

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "version": "5.1.0",
-  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
+  "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"
@@ -30,7 +30,7 @@
   "interface": {
     "displayName": "Epistemic Skills",
     "shortDescription": "Evidence-grounded methods for agentic work",
-    "longDescription": "Fourteen composable disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, open-questions clarification, and context-audit instruction hygiene.",
+    "longDescription": "Fourteen composable disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene.",
     "developerName": "ZMS Labs",
     "websiteURL": "https://github.com/ZMS-Labs/epistemic-skills"
   }


### PR DESCRIPTION
## Purpose

es#186 / panel-1 AC-5: the 5.1.0 flagship feature (mission custody, the manifest seat) was invisible in the capability enumerations on every listing surface — the shared sentence named ~11 capabilities with no custody mention, even though the Kimi surface simultaneously gains the custody PreToolUse hook.

## What changes

One consistent insertion — `mission custody (the manifest seat)` after "decision persistence with resumption re-anchoring" — on all **eight** surfaces carrying the enumeration: root + package plugin manifests (claude/codex/cursor/kimi), root plugin.json, gemini-extension.json. Count phrases untouched.

## Verification

All 8 files parse as valid JSON; local gates green: surface-sync --check (15 skills / 14 disciplines), skill inventory, no-phantom, description budget 8,636/8,636, public-content self-test.

Part of #186 (does not close it).
