### PR TITLE
docs(releasing): required-job semantics for dispatch-only diagnostics (DRAFT — awaits operator approval)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -111,6 +111,17 @@ candidate.
    - A skipped step is acceptable only when its precondition is inapplicable and
      the reason is recorded; run-level green may not conceal a failed required
      step.
+   - Suite verdicts key on the **required job set** of each workflow on its
+     push/pull event, not on the run-level conclusion of a manual dispatch.
+     A workflow may carry dispatch-only diagnostic jobs (for example, a probe
+     built to settle a filed platform claim). Such a job's failure reddens the
+     run conclusion without falsifying any required-step claim, provided
+     (a) the job's non-gating purpose is documented in the workflow file,
+     (b) the failure is the diagnostic's designed output — a settled, disclosed
+     finding recorded on its issue — and (c) the release record names the exact
+     failing step and tests. Any other red, in any job of a suite dispatched at
+     the candidate, fails this gate. (Ruling lineage: the v5.1.0 publication
+     gauntlet, panel 2, CL-1/CL-2 — `docs/gauntlet-runs/es-v510-publication-2026-08-15/`.)
 6. **Security, public content, and provenance**
    - A redacted full-history secret scan passes on the exact candidate, including
      a positive control proving the scanner detects a planted secret.


### PR DESCRIPTION
## Purpose

es#186 docket / panel-2 CL-4: the v5.1.0 publication exposed a verdict-semantics collision — ruling text keyed on run-level conclusions while a workflow (mission-custody-contract) fuses a dispatch-only diagnostic (contract-macos, built to settle es#162) into that conclusion. Every dispatch reddens the run while the required job stays green, and each occurrence needed a fresh adjudication. This amendment gives that adjudication a durable home.

**This PR waits for operator approval** — panel-2 CL-4 named the operator as owner of this amendment (docket default: agent drafts, operator approves). It will not be merged without a word from @SternOne.

## The amendment

Adds one clause to gate item 5: suite verdicts key on the **required job set** of each workflow on its push/PR event, not on the run-level conclusion of a manual dispatch. A dispatch-only diagnostic job may carry a designed-output failure when (a) its non-gating purpose is documented in the workflow file, (b) the failure is a settled, disclosed finding recorded on its issue, and (c) the release record names the exact failing step and tests. Any other red, in any job, fails the gate.

## Provenance

Ruling lineage: panel-2 CL-1/CL-2 (es-v510-publication-2026-08-15, committed in-tree) — keyed to the named es#162 failure-set with explicit re-escalation, never to job identity.
