### PR TITLE
fix(public-content): allowlist ES6-ZI-001 parent-tracker files and the gauntlet challenge record

### DIFF
--- a/.github/scripts/check_public_content.py
+++ b/.github/scripts/check_public_content.py
@@ -116,6 +116,17 @@ ALLOWLIST_EXACT_FILES = {
     "docs/superpowers/plans/2026-08-11-mission-custody-contracts.md": "pre-gate historical record",
     "docs/superpowers/specs/2026-08-07-practical-agency-and-commission-watch-design.md": "pre-gate historical record",
     "docs/wiki-updates/v4.0.0/v4.0.0-wiki-update.patch": "pre-gate historical record",
+    # v6 program parent-tracker coordinate (GitHub issue pointer). The string
+    # is the durable program id, not a fleet overlay. Exact-file so a future
+    # doc cannot smuggle topology by sitting next to the packet.
+    "docs/v6/ES6-ZI-001/exact-start-receipt.json": "v6 program parent tracker coordinate",
+    ".github/scripts/v6_generate_baseline_claims.py": "v6 program parent tracker coordinate",
+    # Independent-gauntlet run record (es-v6-candidate-freeze-2026-08-18): the
+    # Step-0 challenger evidence quotes the candidate's allowlist diff, so it
+    # must name the scrub vocabulary for the review trail to stay intelligible.
+    # Exact-file, frozen under the run's evidence-root pin (operator decision
+    # D7, docs/v6/operator-decision-record-2026-08-18.md).
+    "docs/gauntlet-runs/es-v6-candidate-freeze-2026-08-18/evidence/dossier-challenge-2026-08-18.json": "gauntlet run record quoting the scrub vocabulary",
 }
 
 

--- a/.github/workflows/epistemic-flexibility.yml
+++ b/.github/workflows/epistemic-flexibility.yml
@@ -248,6 +248,13 @@ jobs:
           python .github/scripts/check_ledger_append_only.py             --base "$RUNNER_TEMP/base-ledger.jsonl" --current .ledger/entries.jsonl
       - name: v6 workflow oracle audit (ES6-ORACLE-AUDIT)
         run: |
+          # PyYAML is this suite's one non-stdlib dependency (the audit parses
+          # workflow YAML; the script's own error text names pip install as the
+          # remedy). Installed here, scoped to this step, so the rest of the
+          # suite stays stdlib-only. This step had never executed in CI before
+          # 2026-08-18: on main it sat behind the fail-fast public-content
+          # failure this PR fixes, and draft PRs skip the job entirely.
+          pip install --quiet pyyaml
           python .github/scripts/test_v6_audit_workflow_oracles.py
           python .github/scripts/v6_audit_workflow_oracles.py
       - name: v6 assurance artifacts (ES6-BASELINE-CLAIMS)


### PR DESCRIPTION
## What

Two scoped fixes that make `main` green on its own required suite again:

**Commit 1 — allowlist entries** (`.github/scripts/check_public_content.py`, 39 → 42 exact files, no pattern/code-path changes):
1. `docs/v6/ES6-ZI-001/exact-start-receipt.json` — v6 program parent-tracker coordinate
2. `.github/scripts/v6_generate_baseline_claims.py` — same
3. `docs/gauntlet-runs/es-v6-candidate-freeze-2026-08-18/evidence/dossier-challenge-2026-08-18.json` — independent-gauntlet run record quoting the scrub vocabulary (operator decision D7; the file merges with the run record, so this entry is inert on main until then)

**Commit 2 — unmask repair**: the first CI execution of the `v6 workflow oracle audit` step (unmasked by commit 1) died with `RuntimeError: PyYAML required` — the bare setup-python runner has no pyyaml, and the step had never executed in CI (masked on main by the fail-fast public-content failure; skipped on draft PRs). Scoped `pip install --quiet pyyaml` inside that one step; every other suite step stays stdlib-only. Its prior local/clean-room greens came from dev hosts that happen to carry pyyaml — exactly the evidence-from-mutable-hosts class the v6 gauntlet flagged (rulings R9/R14).

## Why

`origin/main`'s head `a2b9c0d` fails its own required Public-content gate: the ES6-ZI-001 merge (#192, operator-ratified per D1) landed the first two files without the exact-file exemptions the v6 candidate carries, so the `epistemic-flexibility` push run on main fails at the Public-content step and eleven release-gate steps short-circuit behind it (run `32107889882`; gauntlet ruling **R10** — the v6 packet's rollback premise "main remains the last PROMOTION-valid channel" is false while main is red).

Authorized by operator decision **D11** (`docs/v6/operator-decision-record-2026-08-18.md` on `claude/epistemic-skills-v6-completion-nwptmc` @ `d7c4178`). Merging remains the operator's act.

## Verification

- `check_public_content.py --self-test` (7 seeded RED controls) + live gate: exit 0, "7 patterns, 42 allowlisted exact files"
- Workflow YAML parses; `python -m py_compile` clean on the changed script
- Non-stdlib import sweep over all `.github/scripts/*.py`: `v6_audit_workflow_oracles.py` is the only yaml importer — one dependency, one step
- This PR is non-draft, so required `stdlib-checks` runs here — its first-ever full execution past the public-content step on GitHub CI

Relates to #191, #105, #145. Does not close anything.