### PR TITLE
fix(dco,security): attest inherited unsigned commits; carry the record-path scan exemption to main

### DIFF
--- a/.github/scripts/check_dco.py
+++ b/.github/scripts/check_dco.py
@@ -11,10 +11,44 @@ import urllib.request
 
 SIGNOFF = re.compile(r"^Signed-off-by:\s*(.+?)\s*<([^<>\s]+@[^<>\s]+)>\s*$", re.I | re.M)
 
+# Commits the repository owner certifies under the DCO by exact SHA.
+#
+# These five predate this workflow's coverage of the branch they live on: they
+# were produced by the owner's own Cursor Agent tool run against the owner's own
+# repository, and were never amended with a sign-off line. The owner's ruling of
+# 2026-08-19 (full wording in docs/v6/operator-decision-record-2026-08-19.md)
+# certifies them under the Developer Certificate of Origin. The exemption is
+# keyed on the full 40-hex SHA, which is content-bound: it exempts exactly these
+# six trees-and-messages and nothing else, and any amend or rebase produces a
+# different SHA that fails closed. This list is CLOSED — a new unsigned commit
+# is a defect to fix with `git commit --amend --signoff`, never a new entry here.
+ATTESTED_UNSIGNED = {
+    "dc33de288077b367ce804d5de7220367bf77721f": "es#137 P1 false-allow closure (Cursor Agent, 2026-08-18)",
+    "e8a476c730750a9b3e51ac1001b96825996187cc": "es#137 P2 contract/refusal gaps (Cursor Agent, 2026-08-18)",
+    "00e5146e43ff9011153452b83fedda706723c52b": "ES6-V6-CANDIDATE original BUILD freeze packet (Cursor Agent, 2026-08-18)",
+    "36df665e80a3d4abe3b5e849cd07397561f16f05": "ES6-V6-CANDIDATE restamp (Cursor Agent, 2026-08-18)",
+    "7de88fab412e56268b73371e1cd44138987911ae": "ES6-V6-CANDIDATE tracker freeze (Cursor Agent, 2026-08-18)",
+}
+
+
+def is_merge(item: dict) -> bool:
+    """A merge commit joins two histories; its content is the mechanical result
+    of that join, and its author is whoever ran `git merge`. The DCO certifies
+    authored contributions, so merge commits are exempt — the same default
+    GitHub's own DCO app applies. Recorded limit: content a merge commit DOES
+    author, namely conflict resolutions, is uncertified by this exemption. Keep
+    merges clean, and prefer `git merge --signoff` where the sign-off matters.
+    """
+    return len(item.get("parents") or []) > 1
+
 
 def unsigned_commits(commits: list[dict]) -> list[str]:
     unsigned: list[str] = []
     for item in commits:
+        if is_merge(item):
+            continue
+        if str(item.get("sha") or "") in ATTESTED_UNSIGNED:
+            continue
         commit = item.get("commit") or {}
         author = commit.get("author") or {}
         expected_name = str(author.get("name") or "").strip().casefold()
@@ -61,7 +95,58 @@ def github_commits() -> list[dict]:
         page += 1
 
 
+def self_test() -> int:
+    """Planted RED controls: every exemption must be provable and fail closed."""
+    def c(sha, msg, name="A Dev", email="dev@example.test", parents=1):
+        return {
+            "sha": sha,
+            "parents": [{"sha": "p"}] * parents,
+            "commit": {"message": msg, "author": {"name": name, "email": email}},
+        }
+
+    signed = "feat: thing\n\nSigned-off-by: A Dev <dev@example.test>"
+    attested = sorted(ATTESTED_UNSIGNED)[0]
+    cases = [
+        ("signed commit passes", [c("a" * 40, signed)], []),
+        ("unsigned commit is caught", [c("b" * 40, "feat: thing")], ["b" * 12]),
+        (
+            "sign-off by someone other than the author is caught",
+            [c("c" * 40, "x\n\nSigned-off-by: Other <other@example.test>")],
+            ["c" * 12],
+        ),
+        ("merge commit is exempt", [c("d" * 40, "Merge branch", parents=2)], []),
+        ("attested commit is exempt", [c(attested, "no sign-off here")], []),
+        (
+            "an unsigned commit sharing an attested prefix is NOT exempt",
+            [c(attested[:12] + "0" * 28, "no sign-off here")], [attested[:12]],
+        ),
+        (
+            "one bad commit among good ones is still caught",
+            [c("e" * 40, signed), c("f" * 40, "unsigned"), c(attested, "x")],
+            ["f" * 12],
+        ),
+    ]
+    failures = []
+    for name, commits, expected in cases:
+        got = unsigned_commits(commits)
+        if got != expected:
+            failures.append(f"{name}: expected {expected}, got {got}")
+            print(f"[FAIL] {name}: expected {expected}, got {got}")
+        else:
+            print(f"[PASS] {name}")
+    # The attestation list is closed and structurally exact: full 40-hex only,
+    # so no prefix, branch name, or pattern can ever widen it.
+    for sha in ATTESTED_UNSIGNED:
+        if not re.fullmatch(r"[0-9a-f]{40}", sha):
+            failures.append(f"attested entry is not a full 40-hex SHA: {sha!r}")
+            print(f"[FAIL] attested entry is not a full 40-hex SHA: {sha!r}")
+    print(f"DCO self-test: {'PASS' if not failures else 'FAIL'} ({len(cases)} controls)")
+    return 0 if not failures else 1
+
+
 def main() -> int:
+    if "--self-test" in sys.argv[1:]:
+        return self_test()
     commits = github_commits()
     unsigned = unsigned_commits(commits)
     if unsigned:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
+      - name: DCO checker self-test (planted RED controls)
+        run: python .github/scripts/check_dco.py --self-test
       - name: Require author-matching Signed-off-by lines
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-security.yml
+++ b/.github/workflows/release-security.yml
@@ -75,6 +75,44 @@ jobs:
             echo "gitleaks narrowness control failed with unexpected status $status" >&2
             exit "$status"
           fi
+      - name: Gauntlet-record allowlist narrowness control
+        # R4-NF2 (rc4 delta-review panel): the record-path exemption in
+        # .gitleaks.toml suppresses the generic-api-key ENTROPY heuristic under
+        # docs/gauntlet-runs/ only, because verifier prose there quotes Actions
+        # run ids beside the word "API". This control proves the exemption is
+        # narrow: the SAME planted line must FIRE outside that directory and be
+        # suppressed inside it, and a provider-branded credential must fire even
+        # inside it. A widened exemption turns this step red.
+        run: |
+          fixture="$(mktemp -d)"
+          mkdir -p "$fixture/docs/gauntlet-runs/probe" "$fixture/src"
+          token="$(printf '%s%s' 'zk9x2m4qv7r8t1w3y5u6i9' 'o0p2a4s6d8f0g1h3j5kq')"
+          printf '"api_key": "%s"\n' "$token" > "$fixture/src/config.json"
+          printf '"api_key": "%s"\n' "$token" > "$fixture/docs/gauntlet-runs/probe/report.json"
+          set +e
+          "$RUNNER_TEMP/bin/gitleaks" dir --config .gitleaks.toml --no-banner --redact "$fixture/src"
+          outside=$?
+          "$RUNNER_TEMP/bin/gitleaks" dir --config .gitleaks.toml --no-banner --redact "$fixture/docs"
+          inside=$?
+          set -e
+          if [ "$outside" -ne 1 ]; then
+            echo "narrowness control: planted entropy token did NOT fire outside docs/gauntlet-runs (status $outside)" >&2
+            exit 1
+          fi
+          if [ "$inside" -ne 0 ]; then
+            echo "narrowness control: exemption did not apply inside docs/gauntlet-runs (status $inside)" >&2
+            exit 1
+          fi
+          printf '%s%s\n' 'ghp_' 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8' > "$fixture/docs/gauntlet-runs/probe/branded.txt"
+          set +e
+          "$RUNNER_TEMP/bin/gitleaks" dir --config .gitleaks.toml --no-banner --redact "$fixture/docs"
+          branded=$?
+          set -e
+          if [ "$branded" -ne 1 ]; then
+            echo "narrowness control: a provider-branded credential was suppressed inside docs/gauntlet-runs (status $branded)" >&2
+            exit 1
+          fi
+          echo "narrowness control: entropy exemption is record-path-scoped; branded credentials still fire"
       - name: Scan the complete repository history
         run: |
           "$RUNNER_TEMP/bin/gitleaks" git --config .gitleaks.toml --no-banner --redact --log-opts="--all" .

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,3 +12,21 @@ regexes = [
   '''^\s*printf '%s\\n' '"credentia[l]_digest": "663a543d009ec261190a6ab8a8a45f02ac80ed052aceb90e924ec96a20d76ed8"' > "\$fixture/allowed\.json"$''',
   '''^\s*printf '%s\\n' '"credentia[l]": "663a543d009ec261190a6ab8a8a45f02ac80ed052aceb90e924ec96a20d76ed8"' > "\$fixture/rejected\.json"$''',
 ]
+
+[[allowlists]]
+# Gauntlet verdict-record branches are immutable by design (a recorded
+# arbitration is never rewritten), and their machine reports are dense with
+# public identifiers — commit SHAs, Actions run ids, digest hex — that sit
+# next to words like "API" in verifier prose. gitleaks v8.30.1's
+# generic-api-key entropy heuristic fired on exactly that (run
+# es-v6-rc4 requalification: reports/verify-blast.json at 2d835b9,
+# evidence_log naming live-API run conclusions). Scope: ONLY the entropy
+# heuristic, ONLY under docs/gauntlet-runs/ — every other rule (private
+# keys, provider-specific tokens) still applies there, and the
+# public-content gate scans the same files for the repo's banned
+# vocabulary classes.
+description = "Immutable gauntlet-record reports carry public run/commit identifiers, not credentials"
+targetRules = ["generic-api-key"]
+paths = [
+  '''docs/gauntlet-runs/.*''',
+]

--- a/docs/v6/operator-decision-record-2026-08-19.md
+++ b/docs/v6/operator-decision-record-2026-08-19.md
@@ -110,3 +110,47 @@ entries for D18 and D19 are appended after the freeze resolves, in the
 candidate lineage or after promotion, whichever comes first. D16 and D17
 are already in the candidate's ledger as entries 20 and 21 because they
 were recorded before the rc4 freeze was cut.
+
+## Addendum — the record-path secret-scan exemption on `main` (D18a)
+
+Opening the DCO repair PR surfaced a second live defect on `main`, found
+by CI rather than by reasoning: the required `full-history-secret-scan`
+job scans **all refs**, so the two pushed gauntlet-record branches put
+`main` in a state where every pull request goes red. Two findings, both
+the same non-credential class — verifier prose in record reports quoting
+an Actions run id beside the word "API"
+— the shape is the literal word "API", a colon, then a run id joined by
+`=` to a workflow name — which trips gitleaks' generic-api-key entropy
+heuristic. The shape is described rather than quoted here on purpose:
+quoting it verbatim reproduces the trigger, and this file sits outside
+the record-path exemption. That is not hypothetical — the first version
+of this document did quote it, and the scan caught it. Reproduced locally with the
+pinned scanner version and read in full: public identifiers, no
+credential. `main`'s own push runs were green because a push scans only
+the pushed ref; the exposure appears on pull-request runs.
+
+The rc4 candidate already carries a rule-scoped exemption for
+`docs/gauntlet-runs/`. `main` takes that file's text **byte-identically**
+rather than an improved variant, for a reason that was measured, not
+assumed: merging the frozen candidate into a `main` that carries a
+*different* allowlist block conflicts in `.gitleaks.toml` at promotion,
+while an identical block merges clean and yields exactly the candidate's
+file. A merge conflict on the promotion act is a landmine this program
+should not lay for the sake of a P4 improvement.
+
+The improvement itself is therefore **deferred, not dropped**: the fourth
+panel's R4-NF2 asks for an anchored path regex and a refreshed falsifier,
+and both copies of the file must change together, so that belongs to the
+next freeze's P4 sweep (the arbitration's own Next-action 5 class). What
+does land now is the part that needs no shared edit: an in-CI
+**narrowness control** in `release-security.yml`, which plants one
+high-entropy token inside and outside the record directory and fails the
+job unless the exemption fires exactly where intended, plus a branded
+credential inside the directory that must still be caught. Proven
+locally against the pinned scanner: fires outside (exit 1), suppressed
+inside (exit 0), branded credential still caught (exit 1), and the full
+`--all` history scan clean.
+
+`release-security.yml` is untouched by the rc4 delta, so this main-side
+change survives the promotion merge by the same mechanism verified for
+`check_dco.py`.

--- a/docs/v6/operator-decision-record-2026-08-19.md
+++ b/docs/v6/operator-decision-record-2026-08-19.md
@@ -1,0 +1,112 @@
+# Operator decision record — v6 program, 2026-08-19
+
+Provenance: live operator rulings given in the session that produced the
+rc4 BUILD freeze and the fourth independent Gauntlet panel. Four rulings,
+recorded here in full wording. This file is the successor to
+`operator-decision-record-2026-08-18.md` (D1–D15, echo-certified), which
+lives on the v6 candidate branch `claude/v6-candidate-rc2`; this record
+lands on `main` instead, for a reason the last section explains.
+
+Status: recorded, not yet echo-certified. The 2026-08-18 record was
+ratified by an exact SHA-bearing echo under D14. These four rulings were
+given as direct answers to posed decisions rather than through that
+protocol, and the fourth Gauntlet panel flagged exactly that gap
+(finding R4-NF5, P4: the rulings were recorded by the party they
+authorize). The operator discharges it by confirming these four in the
+acceptance record, or by echo-certifying this file under D14.
+
+## Decisions
+
+- **D16 (rc4 repair shape).** The repair of the rc3 NO-GO's findings
+  ships as **rc4, a full C/C+1 re-freeze**: a new candidate commit
+  carries the ledger byte-restoration (R3-NF1) and the prose/derivation
+  repairs (R3-NF2/NF3/NF4 plus the P4 sweep NF5–NF8), and the packet is
+  regenerated at the new candidate and committed as its child. A
+  sanctioned repair commit without a re-freeze was declined: several of
+  those repairs edit digest-inventoried sources, which the RESTAMP
+  discipline refuses to carry under a stale candidate SHA. Recorded
+  durably as ledger entry `v6-rc4-repair-shape-full-refreeze-20260819-20`.
+  Executed: candidate `7408a462b413d0ab41a08de1d37a10b9cdf2a6ea`, freeze
+  `e46c2486535cf847dde05562399fd534f49b85d1`.
+
+- **D17 (first lineage-cap extension).** The three-panel lineage cap,
+  EXHAUSTED at the rc3 verdict, is **extended by exactly one panel**,
+  scoped to a delta-plus-blast-radius review of the rc4 repair by a fresh
+  seat, under the same mode as the rc3 panel. Opening a new lineage was
+  declined: all ten substantive rc2 rulings were closed, the rc4 delta is
+  narrow, and a new lineage would re-litigate closed rulings and discard
+  the standing evidence chain the revision-loop doctrine preserves.
+  Recorded durably as ledger entry
+  `v6-lineage-panel-cap-extension-20260819-21`. **Spent** by the fourth
+  panel's verdict (`docs/gauntlet-runs/es-v6-rc4-delta-review-2026-08-19/`
+  on branch `claude/es-v6-rc4-delta-review`, NO-GO against the rc4
+  candidate on one new P1).
+
+- **D18 (R4-NF1 repair shape — the DCO red).** The fourth panel found
+  that six commits in freeze PR #197's range carry no `Signed-off-by`
+  line, so the DCO gating job lands red the moment the PR is marked
+  ready. The repair is an **amendment to `check_dco.py` on `main`**, in
+  two limbs:
+
+  1. **Merge commits are exempt.** A merge commit joins two histories;
+     its content is the mechanical result of that join and its author is
+     whoever ran `git merge`. The DCO certifies authored contributions.
+     This is the same default GitHub's own DCO app applies. Recorded
+     limit, not hidden: content a merge commit genuinely does author —
+     conflict resolutions — is uncertified by this exemption. Merges are
+     to be kept clean, and `git merge --signoff` used where the sign-off
+     matters.
+  2. **Five inherited commits are attested by exact SHA.** The five
+     unsigned commits authored by the repository owner's Cursor Agent
+     tool run are certified under the Developer Certificate of Origin by
+     the owner, who ran the tool against their own repository. The
+     exemption is keyed on the full 40-hex SHA, which is content-bound:
+     it certifies exactly those commits and nothing else, and any amend
+     or rebase yields a different SHA that fails closed. **The list is
+     closed.** A future unsigned commit is a defect to fix with
+     `git commit --amend --signoff`, never a new entry.
+
+  Declined alternatives: a recorded waiver leaving the job red (it would
+  contradict `RELEASING.md` gate 5 and acceptance-procedure item 5 —
+  precisely the accommodation this program exists to prevent), and
+  re-parenting the candidate branch so the unsigned commits leave the PR
+  range (it would cost a fifth candidate, new coordinates, and another
+  panel to fix a policy-surface problem). History was not rewritten: the
+  five SHAs are subjects and ancestors of verdicts of record, and
+  rewriting them would invalidate three arbitrations and the pushed pin
+  tags.
+
+  Verified before proposal: `dco.yml` runs on `pull_request_target` and
+  checks out the PR's **base** revision, so `main`'s copy of the script
+  is what executes; PR #197's diff does not touch `check_dco.py`, so a
+  main-side amendment survives the eventual promotion merge (proven by
+  simulation, not assumed); and the amended checker takes PR #197 from
+  six unsigned commits to zero against its live commit list.
+
+- **D19 (second lineage-cap extension, narrow).** The cap is **extended
+  by one further panel**, scoped narrowly to: whether R4-NF1 is
+  discharged, whether the fourth panel's eight P4 findings are correctly
+  dispositioned, and a GO/NO-GO on the **same** rc4 coordinates. The
+  fourth panel closed the substance on evidence that can be re-read; the
+  candidate does not change for this repair. A GO from that panel does
+  not authorize promotion, and the standing D8 Step-7b cross-family
+  consult remains owed **before** operator acceptance at any GO posture.
+
+## Why this record is on `main` and not in the durable ledger
+
+The v6 candidate is frozen, and `.ledger/entries.jsonl` is a
+byte-append-only store checked against the freeze PR's **base**: main's
+bytes must survive as an exact prefix of the candidate's file. Appending
+to main's ledger while the candidate is frozen therefore makes main's
+copy longer than the candidate's, and the required append-only check
+fails closed on the freeze PR — the very defect class (R3-NF1) the rc4
+repair exists to fix, reintroduced from the other side. Executed and
+confirmed, not reasoned: appending one entry to main's ledger and
+comparing against the frozen candidate returns `LEDGER-REWRITTEN`.
+
+So, for the duration of a freeze: **do not append to main's ledger.**
+Rulings are recorded in a dated decision record like this one; ledger
+entries for D18 and D19 are appended after the freeze resolves, in the
+candidate lineage or after promotion, whichever comes first. D16 and D17
+are already in the candidate's ledger as entries 20 and 21 because they
+were recorded before the rc4 freeze was cut.


### PR DESCRIPTION
Two policy-surface repairs on `main`. The first discharges **R4-NF1 (P1)**, the finding that decided the fourth independent Gauntlet panel's NO-GO against the v6 rc4 candidate (`docs/gauntlet-runs/es-v6-rc4-delta-review-2026-08-19/arbitration.md` on `claude/es-v6-rc4-delta-review`). The second fixes a live main defect that opening this PR revealed.

All seven checks green, including DCO and the full-history secret scan.

---

## 1. DCO — six unsigned commits in freeze PR #197's range

Six commits carry no `Signed-off-by` line, so the required DCO job lands **red the moment #197 is marked ready** — the takeover this lineage drilled at rc2 precisely because it must work. The oracle is structurally unexercisable before that moment: `dco.yml` is `pull_request_target` (not dispatchable), skipped while the PR is draft, and out of clean-room scope. Reproduced against PR #197's live commit list with the shipped checker before anything was proposed.

Five are Cursor Agent commits from the original BUILD freeze — including `00e5146`, itself a verdict subject — and the sixth is a merge commit.

**Two narrow limbs:**

1. **Merge commits are exempt.** A merge commit joins two histories; its content is the mechanical result of that join and its author is whoever ran `git merge`. The DCO certifies authored contributions — the same default GitHub's own DCO app applies. Recorded limit, not hidden: conflict resolutions a merge commit genuinely *does* author are uncertified by this exemption.
2. **Five inherited commits attested by exact 40-hex SHA** under ruling D18 (`docs/v6/operator-decision-record-2026-08-19.md`). A SHA is content-bound, so this certifies exactly those commits and nothing else; any amend or rebase yields a different SHA and fails closed. **The list is closed** — a future unsigned commit is a defect to fix with `git commit --amend --signoff`, never a new entry.

History was **not** rewritten: those SHAs are subjects and ancestors of three verdicts of record and of pushed pin tags.

**Controls** — `check_dco.py --self-test`, wired into `dco.yml` ahead of the live check:

| control | expectation |
|---|---|
| signed commit | passes |
| unsigned commit | caught |
| sign-off by someone other than the author | caught |
| merge commit | exempt |
| attested SHA | exempt |
| unsigned commit sharing an attested **prefix** | **NOT** exempt |
| one bad commit among good ones | still caught |

Every attested entry is asserted to be a full 40-hex SHA, so no prefix or pattern can widen the list.

**Verified, not assumed:** `dco.yml` checks out the PR's **base**, so `main`'s copy executes for #197; #197's diff does not touch `check_dco.py`, so this amendment **survives** the promotion merge (proven by simulation, after an earlier reasoned claim to the contrary was falsified and corrected in the panel-4 run record); and the amended checker takes #197 from **6 unsigned commits to 0**.

## 2. Secret scan — main is red on every PR

Opening this PR surfaced it: `full-history-secret-scan` scans **all refs**, so the two pushed gauntlet-record branches turn every pull request against `main` red. Two findings, both the same non-credential class — verifier prose quoting an Actions run id beside the word "API" — tripping gitleaks' generic-api-key entropy heuristic. Reproduced locally with the pinned version and read in full: public identifiers, no credential. `main`'s own push runs stayed green because a push scans only the pushed ref.

`.gitleaks.toml` takes the frozen candidate's text **byte-identically** rather than an improved variant, and that was measured: merging the candidate into a `main` carrying a *different* allowlist block **conflicts** in `.gitleaks.toml` at promotion, while an identical block merges **clean** and yields exactly the candidate's file. A conflict on the promotion act is not worth a P4 improvement.

The panel's **R4-NF2** improvement (anchored path regex, refreshed falsifier text) is therefore **deferred, not dropped** — both copies must change together, so it belongs to the next freeze's P4 sweep. What lands now is the part needing no shared edit: a **narrowness control** in `release-security.yml` that plants one high-entropy token inside and outside `docs/gauntlet-runs/` and fails unless the exemption applies exactly where intended, plus a branded credential inside the directory that must still be caught. Green in CI on its first run.

`release-security.yml` is untouched by the rc4 delta, so this also survives the promotion merge.

## Also in this PR

`docs/v6/operator-decision-record-2026-08-19.md` — full wording of rulings **D16–D19**, which additionally discharges panel-4 finding **R4-NF5** (the rulings existed only as ledger entries recorded by the party they authorize). It documents why these rulings are *not* ledger entries: appending to main's ledger while the v6 candidate is frozen makes main's copy longer than the candidate's and turns the freeze PR's required append-only check red — confirmed by execution, and the same defect class R3-NF1 exists to prevent, arriving from the other side.

The record *describes* the scanner-triggering prose shape rather than quoting it. An earlier revision quoted it verbatim and reproduced the trigger in `docs/v6/`, outside the exemption. The exemption was deliberately not widened to cover it: explanatory prose is not evidence. Under explicit operator authorization, this branch was squashed from three commits to two so that text leaves its history entirely — `gitleaks git --log-opts=--all` reads commits, so a later reword cannot clear it. Scope was this unmerged branch only.

## Scope

Policy-surface repairs on `main`. This does **not** touch the v6 candidate, whose coordinates (`7408a46` / `e46c248`) are unchanged, and it authorizes nothing about promotion. Merging is the operator's act.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSTJZfecEUH49KVszKpgMq