### PR TITLE
release: v6.0.0 — version surfaces and release notes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fifteen self-triggering skills. Composes with workflow layers through metacognate's pairing judgment.",
-    "version": "5.1.0"
+    "version": "6.0.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Epistemic-discipline skills for agentic coding \u2014 how an agent knows things before, during, and after work. One package, fifteen self-triggering skills. Composes with workflow layers through metacognate's pairing judgment.",
-    "version": "5.1.0"
+    "version": "6.0.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "author": {
     "name": "ZMS Labs",
     "url": "https://github.com/ZMS-Labs"

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Epistemic disciplines for agentic work: use the least process that can still expose an error capable of changing the action or the completion claim.
 
-**Version 5.1.0.** This is the project's current [immutable support point](https://github.com/ZMS-Labs/epistemic-skills/releases/tag/v5.1.0). The package is harness-agnostic, follows the [Agent Skills specification](https://agentskills.io/specification), and is licensed under [GPL-3.0-or-later](LICENSE).
+**Version 6.0.0.** This is the project's current [immutable support point](https://github.com/ZMS-Labs/epistemic-skills/releases/tag/v6.0.0). The package is harness-agnostic, follows the [Agent Skills specification](https://agentskills.io/specification), and is licensed under [GPL-3.0-or-later](LICENSE).
 
 [![Release](https://img.shields.io/github/v/release/ZMS-Labs/epistemic-skills?display_name=tag)](https://github.com/ZMS-Labs/epistemic-skills/releases/latest)
 [![epistemic-flexibility](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml/badge.svg)](https://github.com/ZMS-Labs/epistemic-skills/actions/workflows/epistemic-flexibility.yml)
@@ -66,20 +66,20 @@ Users and maintainers are equal first-class audiences:
 | [Skill Catalog](https://github.com/ZMS-Labs/epistemic-skills/wiki/Skill-Catalog) | [Release Process and Versioning](https://github.com/ZMS-Labs/epistemic-skills/wiki/Release-Process-and-Versioning) |
 | | [Security, Provenance, and DCO](https://github.com/ZMS-Labs/epistemic-skills/wiki/Security-Provenance-and-DCO) |
 
-The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v5.1.0` source controls.
+The Wiki is unversioned navigation over versioned sources. If a handbook summary and a released contract differ, the immutable `v6.0.0` source controls.
 
 ## Five-minute start
 
 1. **Install one immutable copy.** Choose the native path for your harness under [Installation and compatibility](#installation-and-compatibility). Use the generic Agent Skills path only when no native plugin or extension exists.
 2. **Reload the harness or start a fresh task.** Trigger discovery and role registries are commonly session-bound.
 3. **Choose the entry point.** There is one: `metacognate`. It is the only skill you invoke by name; every other member fires on its own description. (One carve-out: `manifest`, the mission-custody seat, may also be invoked directly — on `manifest this` or `/manifest` — for mission lifecycle acts.) It applies the routine gate first, and declining is its most common correct outcome.
-4. **Verify the inventory and source.** Expect exactly the count your source ships: a v5.1.0 package or tagged checkout ships fifteen (v4.1.0 and v4.0.0 ship eleven; v3.4.0 ships seventeen; v3.3.0 ships fourteen; v3.1.0/v3.2.0 ship twelve; the pinned `v3.0.0` tag also ships eleven — its different eleven)—not two copies found through different install mechanisms.
+4. **Verify the inventory and source.** Expect exactly the count your source ships: a v6.0.0 or v5.1.0 package or tagged checkout ships fifteen (v4.1.0 and v4.0.0 ship eleven; v3.4.0 ships seventeen; v3.3.0 ships fourteen; v3.1.0/v3.2.0 ship twelve; the pinned `v3.0.0` tag also ships eleven — its different eleven)—not two copies found through different install mechanisms.
 5. **Let routine work leave.** A local, reversible, directly checkable, non-precedential task should finish with its bounded check and no process-only artifact.
 
 For a harness without a native package surface, the complete generic install is:
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v6.0.0/plugins/epistemic-skills/skills
 ```
 
 Do not run that command on top of a native plugin install. The [installation handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) includes verification and recovery details for every packaged harness.
@@ -97,7 +97,7 @@ For unfamiliar but routine-looking work, perform **two-read micro-recon**: inspe
 
 Routine work produces no entry-point record, blindspot report, formal record, ledger entry, UAT packet, or proof that other triggers were absent. Escalate only when the reads expose an observed mismatch, hidden coupling, unresolved scope, material fan-out risk, or another positive trigger.
 
-See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v5.1.0/plugins/epistemic-skills/skills/metacognate/reference/routine-fast-path.md).
+See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v6.0.0/plugins/epistemic-skills/skills/metacognate/reference/routine-fast-path.md).
 
 ## metacognate: the single entry point
 
@@ -217,17 +217,17 @@ The package contains exactly one entry point and fourteen disciplines. Each name
 
 ### One copy, one version, one canonical tree
 
-Install with **exactly one mechanism per harness**. Native plugin **or** generic skill install—never both. For 5.1.0, replace an older untagged copy, reload, and verify both the skill count and source path. Duplicate copies create duplicate triggers and can silently mix contract versions.
+Install with **exactly one mechanism per harness**. Native plugin **or** generic skill install—never both. For 6.0.0, replace an older untagged copy, reload, and verify both the skill count and source path. Duplicate copies create duplicate triggers and can silently mix contract versions.
 
-| Harness | v5.1.0 surface | Required follow-through | Honest support boundary |
+| Harness | v6.0.0 surface | Required follow-through | Honest support boundary |
 |---|---|---|---|
 | Claude Code | Local marketplace from tagged checkout | Start a fresh task | Package discovery from one immutable checkout |
 | Codex | Tagged plugin marketplace | Render five Gauntlet roles; start a new task | Manifest does not itself register custom collaboration-agent types |
-| Cursor | Tagged local checkout or team marketplace | Reload window; verify the tag's full skill count (fifteen at v5.1.0) | Public listing unavailable; recorded behavioral epoch is `BLOCKED_EXTERNAL` |
+| Cursor | Tagged local checkout or team marketplace | Reload window; verify the tag's full skill count (fifteen at v6.0.0) | Public listing unavailable; recorded behavioral epoch is `BLOCKED_EXTERNAL` |
 | Gemini CLI | Tagged extension | Restart and validate extension | Uses root context and canonical symlinked tree |
 | Antigravity (`agy`) | Tagged native local plugin | Validate with `agy` | Choose native, Gemini link, or import—only one |
 | Kimi Code | Tagged repository plugin | `/reload` or new session | Plugin instructions map isolated-agent primitives |
-| ZCode | Tagged local checkout, junction-projected into `~/.zcode/skills` | Start a fresh session; verify the tag's full skill count (fifteen at v5.1.0) | Session bootstrap junctions `~/.claude/skills` only — skills riding as Claude *plugins* are not auto-imported; junction surface verified on one fleet device, plugin install untested |
+| ZCode | Tagged local checkout, junction-projected into `~/.zcode/skills` | Start a fresh session; verify the tag's full skill count (fifteen at v6.0.0) | Session bootstrap junctions `~/.claude/skills` only — skills riding as Claude *plugins* are not auto-imported; junction surface verified on one fleet device, plugin install untested |
 | ChatGPT / OpenAI | Generated bundle from the release (`packaging/openai/chatgpt-skill`) | Upload the generated zip per [the packaging guide](docs/CHATGPT-AND-OPENAI-PACKAGING.md) | Generated-artifact bridge: a snapshot of the released tree, not self-updating; no live execution in this release |
 | Generic Agent Skills host | Tagged canonical skills URL | Reload host and verify source | Host must supply any runtime primitive the selected skill requires |
 
@@ -238,22 +238,22 @@ Full installation, migration, runtime-degradation, and troubleshooting guidance 
 ### Claude Code
 
 ```bash
-git clone --depth 1 --branch v5.1.0 https://github.com/ZMS-Labs/epistemic-skills.git /path/to/epistemic-skills-v5.1.0
+git clone --depth 1 --branch v6.0.0 https://github.com/ZMS-Labs/epistemic-skills.git /path/to/epistemic-skills-v6.0.0
 ```
 
 ```text
-/plugin marketplace add /absolute/path/to/epistemic-skills-v5.1.0
+/plugin marketplace add /absolute/path/to/epistemic-skills-v6.0.0
 /plugin install epistemic-skills@epistemic-skills
 ```
 
-Use one marketplace source only, then start a fresh task. Prefer the immutable `v5.1.0` tag for stable installs; `main` may include post-tag corrective documentation and contract hardening (see [successor progress](docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md)).
+Use one marketplace source only, then start a fresh task. Prefer the immutable `v6.0.0` tag for stable installs; `main` may include post-tag corrective documentation and contract hardening (see [successor progress](docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md)).
 
 ### Codex
 
 ```powershell
-codex plugin marketplace add ZMS-Labs/epistemic-skills --ref v5.1.0
+codex plugin marketplace add ZMS-Labs/epistemic-skills --ref v6.0.0
 codex plugin add epistemic-skills@epistemic-skills
-python "$HOME/.codex/plugins/cache/epistemic-skills/epistemic-skills/5.1.0/skills/gauntlet/scripts/render_codex_agents.py" --out "$HOME/.codex/agents"
+python "$HOME/.codex/plugins/cache/epistemic-skills/epistemic-skills/6.0.0/skills/gauntlet/scripts/render_codex_agents.py" --out "$HOME/.codex/agents"
 ```
 
 Start a new Codex task after rendering. The renderer converts the five canonical packaged Markdown roles into Codex's user-agent registry. The Gauntlet retains a hashed exact-role materialization fallback for tasks that started before registration.
@@ -265,9 +265,9 @@ Cursor packaging is present, but the plugin is **not publicly listed**. `/add-pl
 Windows local install:
 
 ```powershell
-git clone --depth 1 --branch v5.1.0 https://github.com/ZMS-Labs/epistemic-skills.git .\epistemic-skills-v5.1.0
-Set-Location .\epistemic-skills-v5.1.0
-if ((git describe --tags --exact-match) -ne 'v5.1.0') { throw 'expected v5.1.0' }
+git clone --depth 1 --branch v6.0.0 https://github.com/ZMS-Labs/epistemic-skills.git .\epistemic-skills-v6.0.0
+Set-Location .\epistemic-skills-v6.0.0
+if ((git describe --tags --exact-match) -ne 'v6.0.0') { throw 'expected v6.0.0' }
 New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.cursor\plugins\local" | Out-Null
 $src = (Resolve-Path .\plugins\epistemic-skills).Path
 $dest = Join-Path $env:USERPROFILE '.cursor\plugins\local\epistemic-skills'
@@ -278,19 +278,19 @@ cmd /c mklink /J "$dest" "$src"
 macOS/Linux local install:
 
 ```bash
-git clone --depth 1 --branch v5.1.0 https://github.com/ZMS-Labs/epistemic-skills.git ./epistemic-skills-v5.1.0
-cd ./epistemic-skills-v5.1.0
-test "$(git describe --tags --exact-match)" = v5.1.0
+git clone --depth 1 --branch v6.0.0 https://github.com/ZMS-Labs/epistemic-skills.git ./epistemic-skills-v6.0.0
+cd ./epistemic-skills-v6.0.0
+test "$(git describe --tags --exact-match)" = v6.0.0
 mkdir -p ~/.cursor/plugins/local
 ln -sfn "$(pwd)/plugins/epistemic-skills" ~/.cursor/plugins/local/epistemic-skills
 ```
 
-Run **Developer: Reload Window**, verify the tag's full skill count (fifteen at v5.1.0) under Customize → Skills, and do not also install them into `~/.cursor/skills/`.
+Run **Developer: Reload Window**, verify the tag's full skill count (fifteen at v6.0.0) under Customize → Skills, and do not also install them into `~/.cursor/skills/`.
 
 ### Gemini CLI
 
 ```bash
-gemini extensions install https://github.com/ZMS-Labs/epistemic-skills --ref v5.1.0 --consent
+gemini extensions install https://github.com/ZMS-Labs/epistemic-skills --ref v6.0.0 --consent
 # Local development only:
 gemini extensions link /path/to/epistemic-skills
 ```
@@ -300,9 +300,9 @@ Restart the session and run `gemini extensions validate` when validating a check
 ### Antigravity (`agy`)
 
 ```bash
-git clone --depth 1 --branch v5.1.0 https://github.com/ZMS-Labs/epistemic-skills.git /path/to/epistemic-skills-v5.1.0
-agy plugin install /path/to/epistemic-skills-v5.1.0
-agy plugin validate /path/to/epistemic-skills-v5.1.0
+git clone --depth 1 --branch v6.0.0 https://github.com/ZMS-Labs/epistemic-skills.git /path/to/epistemic-skills-v6.0.0
+agy plugin install /path/to/epistemic-skills-v6.0.0
+agy plugin validate /path/to/epistemic-skills-v6.0.0
 ```
 
 Use one of native `agy plugin install`, Gemini extension link, or `agy plugin import gemini`; do not combine them.
@@ -310,7 +310,7 @@ Use one of native `agy plugin install`, Gemini extension link, or `agy plugin im
 ### Kimi Code
 
 ```text
-/plugins install https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0
+/plugins install https://github.com/ZMS-Labs/epistemic-skills/tree/v6.0.0
 # Local development only, from a clone:
 /plugins install /path/to/epistemic-skills
 ```
@@ -320,7 +320,7 @@ Run `/reload` or start a new session. `.kimi-plugin/plugin.json` points to the c
 ### Generic harness
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v6.0.0/plugins/epistemic-skills/skills
 ```
 
 Use this only when the host has no native plugin or extension. Frontmatter `description` is the trigger; the body is the method. Compatibility means the host preserves the selected skill's capability, ordering, isolation, persistence, and fail-closed contracts—not merely that it can display Markdown.
@@ -387,7 +387,7 @@ contract into an accepted one.
 
 ## Trust, evidence, and known limits
 
-**Version 5.1.0** is the current immutable support point: fifteen skills, aligned package surfaces, deterministic checks, and a tagged source snapshot; its gate record lives in [RELEASE-5.1.0.md](docs/release/RELEASE-5.1.0.md). Its predecessor **v5.0.0** was published with explicit gate honesty — item 6 only PARTIALLY MET at publication, item 8 WAIVED / NOT MET — and a post-release independent review returned **NO-GO** for retrospective certification. Read the [errata](docs/release/RELEASE-5.0.0-ERRATA-2026-08-06.md), [post-release review](docs/release/POST-RELEASE-INDEPENDENT-REVIEW-5.0.0-2026-08-06.md), and [successor progress](docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md) before treating v5.0.0 as gate-complete. Corrective work for issues #104/#105 landed on `main` after the immutable tag; do not move the tag.
+**Version 6.0.0** is the current immutable support point: fifteen skills, aligned package surfaces, deterministic checks, and a tagged source snapshot; its gate record lives in [RELEASE-6.0.0.md](docs/release/RELEASE-6.0.0.md). Its predecessor **v5.0.0** was published with explicit gate honesty — item 6 only PARTIALLY MET at publication, item 8 WAIVED / NOT MET — and a post-release independent review returned **NO-GO** for retrospective certification. Read the [errata](docs/release/RELEASE-5.0.0-ERRATA-2026-08-06.md), [post-release review](docs/release/POST-RELEASE-INDEPENDENT-REVIEW-5.0.0-2026-08-06.md), and [successor progress](docs/release/SUCCESSOR-PROGRESS-104-105-2026-08-07.md) before treating v5.0.0 as gate-complete. Corrective work for issues #104/#105 landed on `main` after the immutable tag; do not move the tag.
 
 Earlier support points remain historically accurate for their own campaigns. Version 3.2.0 established the behavioral-evidence posture that later releases inherit unless a new campaign re-opens it: aligned surfaces and deterministic checks, with named behavioral limits that were never rewritten into passes.
 

--- a/docs/release/RELEASE-6.0.0.md
+++ b/docs/release/RELEASE-6.0.0.md
@@ -1,0 +1,124 @@
+# Release 6.0.0
+
+**Support point:** `v6.0.0` — one semantic version, one immutable Git tag, one
+evidence set. Supersedes `v5.1.0`.
+
+**Candidate identity.** The v6 BUILD freeze was reviewed at candidate
+`03e972c5d427238033cb90d66846adabaf11928d` with its packet at
+`546ccc8e55eb060379d62198310145f7243ac7bd`; both are ancestors of the release
+branch and are pinned by `pin/es-v6-rc5-candidate-2026-08-19` and
+`pin/es-v6-rc5-freeze-2026-08-19`. The release candidate is the commit produced
+by merging this release branch, and the publication gate runs against that
+commit — not against this file's description of it.
+
+## Why 6.0.0
+
+The skill surface did not grow: v6.0.0 ships the same **fifteen** skills as
+v5.1.0. The major version marks something else — a security fix in the custody
+contract, the completion of the v5 design commitments, and a new assurance
+contract that changes what a release of this project is allowed to claim.
+
+The honest summary: v5 claimed things about itself that nothing checked. v6
+makes those claims mechanical, and where a claim could not be made mechanical,
+it is written down as a limit with an owner.
+
+## What ships
+
+**Security — mission-custody (es#137).** Three P1 false-allow bypasses and four
+P2 refusal gaps are closed. These are real permission-boundary defects: paths
+that the custody guard should have refused and did not. If you rely on
+mission-custody to bound where an agent may write, this is the reason to
+upgrade.
+
+**The v5 design commitments, completed.** All four were implemented and are now
+enforced rather than asserted:
+
+- `ROUTING.md` is generated solely from `metadata.hands-to`, byte-verified in
+  CI, and the hand-authored-routing-table ban is mechanically enforced.
+- Every packaged skill carries the intrinsic evidence-emission step
+  (`skill-run@1`) with a schema-validated tracked exemplar; live ledgers are
+  runtime-local by amended design.
+- Sentinel corpora exist for every skill, with `event_kind` bound into each
+  fixture and a scorer that fails closed in both directions.
+- Skill membership has one source of truth: per-skill frontmatter event
+  metadata derives the event map, its schema, the verifier inventory, and every
+  count surface. Membership drift fails closed.
+
+**A new assurance contract (`contracts/v6-assurance`).** A release candidate is
+now sealed against an exact commit: per-file sha256 digests of every
+inventoried source plus the candidate tree hash, recomputed by a validator that
+turns CI red if any inventoried file changes after the freeze. The packet's
+readiness state cannot be reached by editing a field — the independent verdict
+must exist as an on-disk artifact naming the exact candidate SHA, and operator
+acceptance must be recorded separately.
+
+**Deterministic-gate hardening.** The durable decision ledger is byte-append-only
+against the merge base; the DCO check gained planted self-test controls; the
+secret scan's one path exemption is anchored and proven narrow in CI on every
+run; the clean-room replicates the workflow's Python steps with a completeness
+assertion rather than a hand-maintained copy.
+
+## Release gate status for 6.0.0
+
+Twenty-six class claims carry structured severities and named oracles. At the
+freeze: twenty PROVED, five LIMITED, one UNPROVED by construction
+(`CLM-INDEPENDENT-GAUNTLET` — a packet may not certify its own review; the GO
+verdict is a separate artifact).
+
+Requalification ran all five gating workflows against the exact candidate via
+`workflow_dispatch`, with step-level confirmation that the two newest oracles
+executed rather than skipped. The full required-job set then ran green against
+the sealed head on the freeze pull request.
+
+## Known limitations, carried honestly
+
+Shipped in the packet with named owners:
+
+| Limit | What it means |
+|---|---|
+| `KL-SELF-GO` | The implementing lineage holds no acceptance seat. |
+| `KL-LIVE-ENV` | Behavioral epochs and native-harness live-fire were not run. |
+| `KL-MACOS-162` | Measured APFS Unicode-fold collision: two contract-distinct filenames are one physical file. Custody distinctness claims exclude case-insensitive APFS. |
+| `KL-WINDOWS` | No native-Windows requalification was run. |
+| `KL-DRAFT-CI` | Draft pull requests skip all five gating workflows until ready-mark. |
+| `KL-RESTAMP` | A recorded candidate SHA is an observation of the tree it was generated from, never a target to restamp. |
+| `KL-GUARD-LEXICAL` | Custody guard path matching is lexical; a write spelled through a symlinked parent can resolve inside a guarded tree while the guard does not match. |
+| `KL-SEAL-MAIN-COUPLING` | The freeze seal binds inventoried sources; a default-branch change to any of them turns the freeze red on its pull request's merge ref. |
+| `KL-MAIN-137` | **Retired by this release.** It disclosed that the es#137 fixes existed only in the candidate tree. The freeze merge landed them on the default branch. |
+
+Twelve further findings from the final review are open, all graded P4, three
+carrying preserved P3 dissents. They are recorded in that run's arbitration
+rather than summarized away here. The largest is honest to state plainly: the
+DCO checker's merge-commit exemption is unconditional, so a merge commit that
+authors content — a conflict resolution — is uncertified by it.
+
+## Migration from 5.1.0
+
+Install surfaces change version only; the skill inventory is unchanged, so no
+skill is renamed, retired, or added. Replace an older copy with a `v6.0.0`
+tagged checkout or plugin install, reload the harness, and verify the skill
+count and source path — one install mechanism per harness, never two.
+
+The one behavioral change to expect is stricter custody refusals. Paths the
+guard previously allowed through the es#137 bypasses are now refused. If a
+workflow depended on one of those writes succeeding, it will now fail closed;
+that is the fix working.
+
+## Provenance notes
+
+The v6 BUILD freeze was reviewed by **five independent panels** and produced
+**four NO-GO verdicts** before its GO. Each NO-GO was found by a panel
+reviewing the previous repair, and every P1 in the sequence belonged to one
+class: a gate that had never actually executed against the sealed head.
+
+1. Freeze panel — 18 rulings, 15 acceptance criteria.
+2. Cross-family panel (Kimi/Moonshot) — rulings S1–S10.
+3. Delta review — the candidate commit had byte-rewritten published
+   append-only ledger lines.
+4. Fourth panel — six commits in the freeze pull request carried no DCO
+   sign-off, so a required job would have gone red at ready-mark.
+5. Fifth panel — GO, with the discharge re-executed from primary sources.
+
+Run records live under `docs/gauntlet-runs/`. The verdicts are retained at
+their original coordinates; none of them was rewritten to match a later
+outcome.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines for recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "contextFileName": "GEMINI.md"
 }

--- a/plugins/epistemic-skills/.claude-plugin/plugin.json
+++ b/plugins/epistemic-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "epistemic-skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "author": {
     "name": "ZMS Labs"
   }

--- a/plugins/epistemic-skills/.codex-plugin/plugin.json
+++ b/plugins/epistemic-skills/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
   "author": {
     "name": "ZMS Labs",

--- a/plugins/epistemic-skills/.cursor-plugin/plugin.json
+++ b/plugins/epistemic-skills/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "epistemic-skills",
   "displayName": "Epistemic Skills",
   "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene, paired with a workflow-skill layer by metacognate's judgment rather than a fixed table.",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "author": {
     "name": "ZMS Labs"
   },

--- a/plugins/epistemic-skills/.kimi-plugin/plugin.json
+++ b/plugins/epistemic-skills/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "epistemic-skills",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "The full epistemic-discipline collection in one package: an entry point plus fourteen disciplines including recon (territory mapping: brief, initiative, and external-candidate modes), resolve (question settling: derivation, literature, and probe instruments), goal authoring, outsource repo-backed external handoff, adversarial review, evidence-locked acceptance, decision persistence with resumption re-anchoring, mission custody (the manifest seat), open-questions clarification, and context-audit instruction hygiene.",
   "author": {
     "name": "ZMS Labs",

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -11,7 +11,7 @@ HERE = Path(__file__).resolve()
 SKILL_ROOT = HERE.parents[1]
 PACKAGE_ROOT = HERE.parents[3]
 REPO_ROOT = HERE.parents[5]
-EXPECTED_VERSION = "5.1.0"
+EXPECTED_VERSION = "6.0.0"
 
 
 def require(condition: bool, message: str) -> None:


### PR DESCRIPTION
RELEASING.md step 2 for the v6.0.0 support point: align live version surfaces and finalize the release note. **Merging this PR produces the release candidate** — the publication gate (step 5) runs against that merge commit, not against this preparation.

## What changed

**Version surfaces, 5.1.0 → 6.0.0** across all nine manifests (Claude, Cursor, Kimi, Codex, Gemini, and the two marketplace files), the outsource suite's `EXPECTED_VERSION` assertion, and every current-version statement in `README.md` — version badge, support-point link, wiki-precedence line, install examples for every harness, the harness surface table, and the skill-count claims.

**`docs/release/RELEASE-6.0.0.md`** — what actually changed, the nine known limits with owners, and an honest migration section.

## RG-4 verified, not assumed

RELEASING.md warns that *"a blind version bump can mint immutable links to paths that never existed at that tag."* Every version-pinned repository URL rewritten to `v6.0.0` was checked to resolve to a path that exists in this tree:

| pinned path | exists |
|---|---|
| `plugins/epistemic-skills/skills` | ✅ |
| `plugins/epistemic-skills/skills/metacognate/reference/routine-fast-path.md` | ✅ |
| `skills/gauntlet/scripts/render_codex_agents.py` (codex cache path) | ✅ |

One `v5.1.0` reference is retained **deliberately**: the inventory line noting v5.1.0 also ships fifteen skills is history, not a stale current-version claim. The repo's own cross-check (`outsource/tests/run_tests.py`) enforces README/manifest agreement and passes.

## Seal safety

**No digest-inventoried file is touched**, so the v6 packet's seal stays green on the default branch — the `KL-SEAL-MAIN-COUPLING` failure mode that superseded the rc4 candidate. Verified by set-comparing the changed files against `source-inventory.json`'s 141 entries.

## Local gate

- clean-room: **54 of 55** workflow python steps replicated, **0 failures** (the 1 skip is the named ci-context step)
- public-content, skill-surface sync, phantom-skills, v6 assurance validator, outsource integration, committed-JSON — all green
- no allowlist edit was needed: the release note was written to avoid the gate's banned vocabulary rather than to be exempted from it

## Not in this PR

The **wiki hand-off package**. RELEASING.md's release gate does not require one and v5.1.0 shipped without one; it is an operator-applied artifact, being prepared separately. Worth noting the live wiki is already stale — its v5.0.0 package says "fourteen skills" and there have been fifteen since v5.1.0.

## Still owed before the tag

1. **D8 Step-7b cross-family consult** on the BUILD-freeze GO — packet built, manual handoff, not dischargeable by an agent.
2. **Operator acceptance record** — barred to agents by `OPERATOR-ACCEPTANCE-PROCEDURE.md`.
3. **Publication gate** (RELEASING step 5) against the merge commit this PR produces.
4. **RG-9 publication identity**: exact candidate SHA, tag name, release-note path, and Release target recorded *before* tag creation.
5. **Annotated** `v6.0.0` tag — RELEASING forbids a lightweight tag for a support point; v5.1.0's tag is annotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSTJZfecEUH49KVszKpgMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSTJZfecEUH49KVszKpgMq)_