### PR TITLE
fix(v6-assurance): freeze lifecycle ACTIVE/LANDED + candidate lineage binding

### DIFF
--- a/.github/scripts/v6_generate_candidate_packet.py
+++ b/.github/scripts/v6_generate_candidate_packet.py
@@ -1060,6 +1060,11 @@ def build_promotion_packet(sha: str, ts: str, matrix: dict) -> dict:
         "program": PROGRAM,
         "issue": 191,
         "candidate_sha": sha,
+        # A new freeze is born ACTIVE: its digests bind the tree under review.
+        # It becomes LANDED once its freeze PR merges and work continues past
+        # it, after which the attestation is verified against candidate_sha's
+        # own commit instead of constraining the default branch.
+        "freeze_state": "ACTIVE",
         "generated_at": ts,
         "readiness": "NOT_READY",
         "self_certification": "refused",

--- a/docs/v6/ES6-V6-CANDIDATE/promotion-packet.json
+++ b/docs/v6/ES6-V6-CANDIDATE/promotion-packet.json
@@ -1,93 +1,95 @@
 {
-  "schema": "v6-promotion-packet@2",
-  "program": "ES6-V6-CANDIDATE",
-  "issue": 191,
-  "candidate_sha": "03e972c5d427238033cb90d66846adabaf11928d",
-  "generated_at": "2026-08-19T19:14:10Z",
-  "readiness": "NOT_READY",
-  "self_certification": "refused",
-  "independent_gauntlet": "NOT_RUN",
-  "independent_gauntlet_ref": null,
-  "rollback": "Do not merge this branch to main outside a PROMOTION_RUN. Abandoning this branch reverts to origin/main, which merged this lineage's Public-content repair (PR #195, squash 03b7724, 2026-08-18, operator-ratified D11/RATIFY) and ran its required stdlib-checks green at that head. Main's live state is re-checked at operator acceptance per the acceptance procedure, never assumed from this dated record. One qualified exposure remains: the es#137 custody fixes exist only in this candidate tree (KL-MAIN-137). An independent GO and a separate PROMOTION_RUN remain required either way.",
-  "requested_irreversible_acts": [],
-  "blocking_claims": [
-    "CLM-INDEPENDENT-GAUNTLET"
-  ],
-  "known_limits": [
-    {
-      "id": "KL-SELF-GO",
-      "kind": "independence",
-      "statement": "The implementer of this packet cannot record Gauntlet GO on it.",
-      "release_consequence": "V6_CANDIDATE_READY_FOR_OPERATOR_ACCEPTANCE is unreachable until an independent panel runs (fresh seat: the prior adjudicating seat took the repair role under D2).",
-      "owner": "independent-panel"
-    },
-    {
-      "id": "KL-LIVE-ENV",
-      "kind": "live-environment",
-      "statement": "Behavioral epochs (#77/#39) and native harness live-fire (#136/#129/#142) were not run.",
-      "release_consequence": "Those claims are LIMITED, not PROVED.",
-      "owner": "agent"
-    },
-    {
-      "id": "KL-MACOS-162",
-      "kind": "platform",
-      "statement": "es#162 case-insensitivity is disclosed and now MEASURED beyond the ASCII probe: on macos-14 APFS the first full lifecycle-suite dispatch showed stra\u00dfe.txt/strasse.txt \u2014 contract-distinct artifacts \u2014 are one physical file under the filesystem's Unicode case folding; a decoy write clobbered the real artifact (tests distinct-real-file-untouched, distinct-both-files-tracked-separately; run 32189655677). contract-macos stays dispatch-only and non-gating.",
-      "release_consequence": "Not a merge-gating required job; custody distinctness claims exclude case-insensitive APFS until es#162 lands.",
-      "owner": "agent"
-    },
-    {
-      "id": "KL-DRAFT-CI",
-      "kind": "integrity",
-      "statement": "While the freeze PR is a draft, ALL FIVE gating workflows skip their jobs (stdlib-checks, mission-custody contract, commission-watch contract, openai-bundles build, full-history-secret-scan) plus DCO. Marking the PR ready dispatches every one of them at the unchanged head (ready_for_review trigger types; proven by the 2026-08-18 ready-mark drill). Until then the BUILD oracle is the local clean-room, which replicates the python steps of ONE workflow (epistemic-flexibility) with a completeness assertion and every non-replicated step NAMED with its reason \u2014 exact per-step counts live in evidence/clean-baseline.json, never in this prose (counts drift per commit; the rc2 packet's hand-written fraction did, kimi ruling S6). The other five workflows are NOT covered by the clean-room. A fail-fast CI failure also masks later steps: the oracle-audit step's missing-PyYAML defect was invisible on main behind the public-content failure until 2026-08-18.",
-      "release_consequence": "Local clean-room green is not GitHub required-job green. Requalification requires the ready-mark (or workflow_dispatch, D4b) runs on the exact candidate.",
-      "owner": "agent"
-    },
-    {
-      "id": "KL-MAIN-137",
-      "kind": "integrity",
-      "statement": "es#137 P1 false-allows are present on origin/main; closed only in this candidate tree.",
-      "release_consequence": "Merging this candidate is a PROMOTION act, not performed here.",
-      "owner": "operator"
-    },
-    {
-      "id": "KL-SEAL-MAIN-COUPLING",
-      "kind": "integrity",
-      "statement": "The digest seal binds inventoried sources as they stood at C. CI runs the freeze PR against its MERGE ref, so a change on main to ANY inventoried file makes that merge tree differ from C and the validator fails R5 DIGEST MISMATCH on the freeze PR \u2014 even though the candidate branch itself is untouched. Measured, not theorised: the rc4 candidate's own R4-NF1 repair landed on main (check_dco.py, dco.yml, release-security.yml) and forced the rc5 re-cut that absorbed it.",
-      "release_consequence": "While a freeze is open, main must not change inventoried files, or the freeze must be re-cut to absorb them. The practical rule: land main-side policy repairs BEFORE cutting a candidate, and keep the window between freeze and ready-mark short.",
-      "owner": "operator"
-    },
-    {
-      "id": "KL-WINDOWS",
-      "kind": "platform",
-      "statement": "No native Windows requalification was run for this candidate.",
-      "release_consequence": "CLM-WINDOWS-FS stays LIMITED.",
-      "owner": "agent"
-    },
-    {
-      "id": "KL-RESTAMP",
-      "kind": "integrity",
-      "statement": "The predecessor freeze's packet artifacts were generated at one commit and mutated at the freeze commit while still carrying the earlier stamp \u2014 self-falsifying evidence nothing detected (gauntlet ruling R5). The two specific instances R5(c) named (kimi ruling S4 completed this disclosure): (1) clean-baseline.json was ADDED to the predecessor packet after its freeze while the packet claimed immutability; (2) the packet's original disclaimer \u2014 that a recorded candidate SHA is an OBSERVATION of the tree it was generated from, never a target to restamp \u2014 was deleted rather than preserved, and its substance is hereby re-erected as the governing invariant of this packet. This packet is generated under the C/C+1 discipline: generation refuses a dirty tree and refuses --sha != HEAD, the source inventory binds per-file sha256 digests of git-tracked sources plus the candidate tree hash, and the validator recomputes those digests and rejects untracked inventory paths (S1).",
-      "release_consequence": "Any post-freeze edit to an inventoried file turns the validator red instead of shipping silently; the SHA-is-an-observation invariant governs every artifact in this directory.",
-      "owner": "agent"
-    },
-    {
-      "id": "KL-GUARD-LEXICAL",
-      "kind": "integrity",
-      "statement": "Custody guard path matching is lexical; a write spelled through a symlinked parent resolves inside a guarded tree while the guard does not match (measured probe; characterization-pinned; disclosed in mission-custody SECURITY.md). No matching-behavior change this epoch per gauntlet ruling R15.",
-      "release_consequence": "Guard globs bound spellings, not filesystem effects; CLM-MC-GUARD-LEXICAL stays LIMITED.",
-      "owner": "agent"
-    }
-  ],
-  "evidence_paths": [
-    "docs/v6/ES6-V6-CANDIDATE/claim-to-proof-matrix.json",
-    "docs/v6/ES6-V6-CANDIDATE/issue-pr-reconciliation.json",
-    "docs/v6/ES6-V6-CANDIDATE/source-inventory.json",
-    "docs/v6/ES6-V6-CANDIDATE/exact-candidate-receipt.json",
-    "docs/v6/ES6-V6-CANDIDATE/evidence/clean-baseline.json",
-    "docs/v6/ES6-V6-CANDIDATE/evidence/workflow-oracle-audit.json",
-    "docs/v6/ES6-V6-CANDIDATE/evidence/public-content.json",
-    "docs/v6/ES6-V6-CANDIDATE/evidence/custody-suite.json",
-    "docs/v6/ES6-V6-CANDIDATE/evidence/requalification.json",
-    "docs/v6/ES6-V6-CANDIDATE/evidence/tracker-capture.json"
-  ]
+ "schema": "v6-promotion-packet@2",
+ "program": "ES6-V6-CANDIDATE",
+ "issue": 191,
+ "candidate_sha": "03e972c5d427238033cb90d66846adabaf11928d",
+ "freeze_state": "LANDED",
+ "freeze_state_note": "ACTIVE while this freeze was the live subject; LANDED once freeze PR #197 merged as 50f595c7f749b7284e2e2bcf2394d0b1a0644572 and development continued past it. A landed packet is a historical attestation about candidate_sha: its digests are verified against THAT commit, and it no longer constrains the working tree. Measured reason for the distinction: while ACTIVE and merged, the seal made all 141 inventoried files uneditable on the default branch.",
+ "generated_at": "2026-08-19T19:14:10Z",
+ "readiness": "NOT_READY",
+ "self_certification": "refused",
+ "independent_gauntlet": "NOT_RUN",
+ "independent_gauntlet_ref": null,
+ "rollback": "Do not merge this branch to main outside a PROMOTION_RUN. Abandoning this branch reverts to origin/main, which merged this lineage's Public-content repair (PR #195, squash 03b7724, 2026-08-18, operator-ratified D11/RATIFY) and ran its required stdlib-checks green at that head. Main's live state is re-checked at operator acceptance per the acceptance procedure, never assumed from this dated record. One qualified exposure remains: the es#137 custody fixes exist only in this candidate tree (KL-MAIN-137). An independent GO and a separate PROMOTION_RUN remain required either way.",
+ "requested_irreversible_acts": [],
+ "blocking_claims": [
+  "CLM-INDEPENDENT-GAUNTLET"
+ ],
+ "known_limits": [
+  {
+   "id": "KL-SELF-GO",
+   "kind": "independence",
+   "statement": "The implementer of this packet cannot record Gauntlet GO on it.",
+   "release_consequence": "V6_CANDIDATE_READY_FOR_OPERATOR_ACCEPTANCE is unreachable until an independent panel runs (fresh seat: the prior adjudicating seat took the repair role under D2).",
+   "owner": "independent-panel"
+  },
+  {
+   "id": "KL-LIVE-ENV",
+   "kind": "live-environment",
+   "statement": "Behavioral epochs (#77/#39) and native harness live-fire (#136/#129/#142) were not run.",
+   "release_consequence": "Those claims are LIMITED, not PROVED.",
+   "owner": "agent"
+  },
+  {
+   "id": "KL-MACOS-162",
+   "kind": "platform",
+   "statement": "es#162 case-insensitivity is disclosed and now MEASURED beyond the ASCII probe: on macos-14 APFS the first full lifecycle-suite dispatch showed stra\u00dfe.txt/strasse.txt \u2014 contract-distinct artifacts \u2014 are one physical file under the filesystem's Unicode case folding; a decoy write clobbered the real artifact (tests distinct-real-file-untouched, distinct-both-files-tracked-separately; run 32189655677). contract-macos stays dispatch-only and non-gating.",
+   "release_consequence": "Not a merge-gating required job; custody distinctness claims exclude case-insensitive APFS until es#162 lands.",
+   "owner": "agent"
+  },
+  {
+   "id": "KL-DRAFT-CI",
+   "kind": "integrity",
+   "statement": "While the freeze PR is a draft, ALL FIVE gating workflows skip their jobs (stdlib-checks, mission-custody contract, commission-watch contract, openai-bundles build, full-history-secret-scan) plus DCO. Marking the PR ready dispatches every one of them at the unchanged head (ready_for_review trigger types; proven by the 2026-08-18 ready-mark drill). Until then the BUILD oracle is the local clean-room, which replicates the python steps of ONE workflow (epistemic-flexibility) with a completeness assertion and every non-replicated step NAMED with its reason \u2014 exact per-step counts live in evidence/clean-baseline.json, never in this prose (counts drift per commit; the rc2 packet's hand-written fraction did, kimi ruling S6). The other five workflows are NOT covered by the clean-room. A fail-fast CI failure also masks later steps: the oracle-audit step's missing-PyYAML defect was invisible on main behind the public-content failure until 2026-08-18.",
+   "release_consequence": "Local clean-room green is not GitHub required-job green. Requalification requires the ready-mark (or workflow_dispatch, D4b) runs on the exact candidate.",
+   "owner": "agent"
+  },
+  {
+   "id": "KL-MAIN-137",
+   "kind": "integrity",
+   "statement": "es#137 P1 false-allows are present on origin/main; closed only in this candidate tree.",
+   "release_consequence": "Merging this candidate is a PROMOTION act, not performed here.",
+   "owner": "operator"
+  },
+  {
+   "id": "KL-SEAL-MAIN-COUPLING",
+   "kind": "integrity",
+   "statement": "The digest seal binds inventoried sources as they stood at C. CI runs the freeze PR against its MERGE ref, so a change on main to ANY inventoried file makes that merge tree differ from C and the validator fails R5 DIGEST MISMATCH on the freeze PR \u2014 even though the candidate branch itself is untouched. Measured, not theorised: the rc4 candidate's own R4-NF1 repair landed on main (check_dco.py, dco.yml, release-security.yml) and forced the rc5 re-cut that absorbed it.",
+   "release_consequence": "While a freeze is open, main must not change inventoried files, or the freeze must be re-cut to absorb them. The practical rule: land main-side policy repairs BEFORE cutting a candidate, and keep the window between freeze and ready-mark short.",
+   "owner": "operator"
+  },
+  {
+   "id": "KL-WINDOWS",
+   "kind": "platform",
+   "statement": "No native Windows requalification was run for this candidate.",
+   "release_consequence": "CLM-WINDOWS-FS stays LIMITED.",
+   "owner": "agent"
+  },
+  {
+   "id": "KL-RESTAMP",
+   "kind": "integrity",
+   "statement": "The predecessor freeze's packet artifacts were generated at one commit and mutated at the freeze commit while still carrying the earlier stamp \u2014 self-falsifying evidence nothing detected (gauntlet ruling R5). The two specific instances R5(c) named (kimi ruling S4 completed this disclosure): (1) clean-baseline.json was ADDED to the predecessor packet after its freeze while the packet claimed immutability; (2) the packet's original disclaimer \u2014 that a recorded candidate SHA is an OBSERVATION of the tree it was generated from, never a target to restamp \u2014 was deleted rather than preserved, and its substance is hereby re-erected as the governing invariant of this packet. This packet is generated under the C/C+1 discipline: generation refuses a dirty tree and refuses --sha != HEAD, the source inventory binds per-file sha256 digests of git-tracked sources plus the candidate tree hash, and the validator recomputes those digests and rejects untracked inventory paths (S1).",
+   "release_consequence": "Any post-freeze edit to an inventoried file turns the validator red instead of shipping silently; the SHA-is-an-observation invariant governs every artifact in this directory.",
+   "owner": "agent"
+  },
+  {
+   "id": "KL-GUARD-LEXICAL",
+   "kind": "integrity",
+   "statement": "Custody guard path matching is lexical; a write spelled through a symlinked parent resolves inside a guarded tree while the guard does not match (measured probe; characterization-pinned; disclosed in mission-custody SECURITY.md). No matching-behavior change this epoch per gauntlet ruling R15.",
+   "release_consequence": "Guard globs bound spellings, not filesystem effects; CLM-MC-GUARD-LEXICAL stays LIMITED.",
+   "owner": "agent"
+  }
+ ],
+ "evidence_paths": [
+  "docs/v6/ES6-V6-CANDIDATE/claim-to-proof-matrix.json",
+  "docs/v6/ES6-V6-CANDIDATE/issue-pr-reconciliation.json",
+  "docs/v6/ES6-V6-CANDIDATE/source-inventory.json",
+  "docs/v6/ES6-V6-CANDIDATE/exact-candidate-receipt.json",
+  "docs/v6/ES6-V6-CANDIDATE/evidence/clean-baseline.json",
+  "docs/v6/ES6-V6-CANDIDATE/evidence/workflow-oracle-audit.json",
+  "docs/v6/ES6-V6-CANDIDATE/evidence/public-content.json",
+  "docs/v6/ES6-V6-CANDIDATE/evidence/custody-suite.json",
+  "docs/v6/ES6-V6-CANDIDATE/evidence/requalification.json",
+  "docs/v6/ES6-V6-CANDIDATE/evidence/tracker-capture.json"
+ ]
 }

--- a/plugins/epistemic-skills/contracts/v6-assurance/test_v6_assurance_validator.py
+++ b/plugins/epistemic-skills/contracts/v6-assurance/test_v6_assurance_validator.py
@@ -536,6 +536,53 @@ def main() -> int:
             failures.append(f"main() candidate-nosev: code={code} raised={raised}")
             print(f"[FAIL] main() candidate-nosev: code={code} raised={raised}")
 
+    # --- freeze-state lifecycle (grok publication panel finding I + the
+    # measured consequence that a MERGED active freeze froze all 141
+    # inventoried files on the default branch) ---
+    import subprocess as _sp
+
+    if MOD.freeze_state({}) != MOD.FREEZE_ACTIVE:
+        failures.append("absent freeze_state must read ACTIVE (conservative direction)")
+        print("[FAIL] absent freeze_state must read ACTIVE")
+    else:
+        print("[PASS] absent freeze_state reads ACTIVE — a packet cannot escape the seal by omission")
+    expect_fail(
+        "unknown-freeze-state",
+        lambda: MOD.freeze_state({"freeze_state": "RETIRED"}),
+        "unknown freeze_state", failures,
+    )
+
+    # Lineage binding: a packet may not validate against an unrelated history.
+    repo_root = MOD.REPO_ROOT
+    inside = _sp.run(["git", "-C", str(repo_root), "rev-parse", "--is-inside-work-tree"],
+                     capture_output=True, text=True)
+    if inside.returncode == 0 and inside.stdout.strip() == "true":
+        head = _sp.run(["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+                       capture_output=True, text=True).stdout.strip()
+        if MOD.validate_candidate_lineage({"candidate_sha": head}, repo_root) == []:
+            print("[PASS] a packet naming HEAD passes the lineage check silently")
+        else:
+            failures.append("HEAD-named packet raised a lineage notice")
+        orphan = _sp.run(["git", "-C", str(repo_root), "commit-tree", f"{head}^{{tree}}",
+                          "-m", "orphan probe"], capture_output=True, text=True,
+                         env={"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t",
+                              "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t",
+                              "PATH": __import__("os").environ.get("PATH", "")})
+        if orphan.returncode == 0:
+            expect_fail(
+                "candidate-off-lineage",
+                lambda: MOD.validate_candidate_lineage(
+                    {"candidate_sha": orphan.stdout.strip()}, repo_root),
+                "off-lineage", failures,
+            )
+        notices = MOD.validate_candidate_lineage({"candidate_sha": "9" * 40}, repo_root)
+        if notices and "not present" in notices[0]:
+            print("[PASS] an absent candidate degrades to a loud notice, never a silent pass")
+        else:
+            failures.append(f"absent candidate did not notice: {notices}")
+    else:
+        print("[SKIP] lineage controls: not a git worktree")
+
     print(
         f"v6 assurance validator self-test: {'PASS' if not failures else 'FAIL'}"
     )

--- a/plugins/epistemic-skills/contracts/v6-assurance/validate_v6_assurance.py
+++ b/plugins/epistemic-skills/contracts/v6-assurance/validate_v6_assurance.py
@@ -213,6 +213,120 @@ def _tracked_set(root: Path) -> set[str] | None:
     return {p for p in out.decode("utf-8").split("\0") if p}
 
 
+FREEZE_ACTIVE = "ACTIVE"
+FREEZE_LANDED = "LANDED"
+
+
+def _git(root: Path, *args: str):
+    """Run git in root; return stdout on success, None on any failure."""
+    import subprocess
+
+    r = subprocess.run(["git", "-C", str(root), *args], capture_output=True, text=True)
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def freeze_state(packet: dict) -> str:
+    """ACTIVE while the freeze is the live subject; LANDED once it has merged
+    and development continues past it.
+
+    Why this exists (measured, not theorised): merging a freeze packet to the
+    default branch made its digest seal PERMANENT there — every one of the
+    inventoried files became uneditable, because the validator recomputed
+    their digests against whatever tree it ran on. That is right for a live
+    freeze and wrong for a landed one. A landed packet is a historical
+    attestation about ONE commit; it should keep proving that claim and stop
+    constraining current work.
+
+    Unknown or absent state reads as ACTIVE: the conservative direction is to
+    keep enforcing, so a packet cannot escape the seal by omitting a field.
+    """
+    state = packet.get("freeze_state", FREEZE_ACTIVE)
+    if state not in (FREEZE_ACTIVE, FREEZE_LANDED):
+        raise AssertionError(
+            f"unknown freeze_state {state!r} — expected {FREEZE_ACTIVE} or {FREEZE_LANDED}"
+        )
+    return state
+
+
+def validate_candidate_lineage(packet: dict, root: Path = REPO_ROOT) -> list[str]:
+    """The packet must describe THIS line of history (R5-I, grok publication
+    panel): candidate_sha must be HEAD or an ancestor of it. Without this a
+    packet validates green against an unrelated tree, which is exactly the
+    confusion a reader of a tagged tree cannot resolve.
+
+    Degrades to a notice where git cannot answer (shallow clone, exported
+    tarball) — it says what it could not check rather than passing silently.
+    """
+    sha = packet.get("candidate_sha")
+    if not sha:
+        return []
+    head = _git(root, "rev-parse", "HEAD")
+    if head is None:
+        return ["candidate lineage unverifiable here: not a git worktree"]
+    if _git(root, "cat-file", "-e", f"{sha}^{{commit}}") is None:
+        return [
+            f"candidate lineage unverifiable here: commit {sha[:12]} is not present "
+            "(shallow clone?) — fetch it to check this claim"
+        ]
+    if head == sha:
+        return []
+    import subprocess
+
+    anc = subprocess.run(
+        ["git", "-C", str(root), "merge-base", "--is-ancestor", sha, "HEAD"],
+        capture_output=True,
+    )
+    if anc.returncode != 0:
+        raise AssertionError(
+            f"CANDIDATE OFF-LINEAGE: packet names candidate {sha[:12]} which is "
+            "neither HEAD nor an ancestor of it — this packet does not describe "
+            "this line of history"
+        )
+    return []
+
+
+def validate_landed_inventory(doc: dict, packet: dict, root: Path = REPO_ROOT) -> list[str]:
+    """A landed freeze's digests are recomputed against the commit the packet
+    NAMES, using git object reads — never against the working tree. A mismatch
+    means the recorded history changed under the attestation, which is a
+    tampering signal, not a development signal."""
+    if doc.get("schema") == "v6-source-inventory@1":
+        return ["LEGACY source-inventory@1: no content digests (R5 binding starts at @2)"]
+    sha = packet.get("candidate_sha")
+    digests = doc.get("file_digests") or {}
+    if not sha or not digests:
+        return ["landed packet carries no candidate_sha or no digests: nothing to verify"]
+    if _git(root, "rev-parse", "--is-inside-work-tree") != "true":
+        return [f"LANDED freeze {sha[:12]}: digests not verified (not a git worktree)"]
+    if _git(root, "cat-file", "-e", f"{sha}^{{commit}}") is None:
+        return [
+            f"LANDED freeze {sha[:12]}: digests NOT verified — the candidate commit is "
+            "absent from this clone (shallow checkout); fetch it to verify the attestation"
+        ]
+    import hashlib
+    import subprocess
+
+    mismatched = []
+    for rel, recorded in sorted(digests.items()):
+        blob = subprocess.run(
+            ["git", "-C", str(root), "show", f"{sha}:{rel}"], capture_output=True
+        )
+        if blob.returncode != 0:
+            mismatched.append(f"{rel} (absent at {sha[:12]})")
+            continue
+        if hashlib.sha256(blob.stdout).hexdigest() != recorded:
+            mismatched.append(rel)
+    if mismatched:
+        raise AssertionError(
+            f"LANDED DIGEST MISMATCH at {sha[:12]}: the attestation no longer describes "
+            f"the commit it names (history rewritten?): {mismatched[:5]}"
+        )
+    return [
+        f"LANDED freeze {sha[:12]}: {len(digests)} sealed digests verified against that "
+        "commit; the working tree is intentionally unconstrained"
+    ]
+
+
 def validate_source_inventory(doc: dict, root: Path = REPO_ROOT) -> list[str]:
     """Returns notices; raises on failure. @2 recomputes every digest (R5)."""
     _require_keys(
@@ -522,7 +636,16 @@ def main() -> int:
             "degrade to notices on a committed candidate"
         )
     validate_reconciliation(recon)
-    notices += validate_source_inventory(_load_json(cand_inventory), REPO_ROOT)
+    state = freeze_state(packet)
+    notices += validate_candidate_lineage(packet, REPO_ROOT)
+    if state == FREEZE_ACTIVE:
+        # Live freeze: the tree under validation must BE the reviewed content.
+        notices += validate_source_inventory(_load_json(cand_inventory), REPO_ROOT)
+    else:
+        # Landed freeze: the attestation is about its own commit. Verify it
+        # THERE (this still catches a rewritten history), and leave the working
+        # tree free for development.
+        notices += validate_landed_inventory(_load_json(cand_inventory), packet, REPO_ROOT)
     notices += validate_promotion_packet(packet, REPO_ROOT)
     notices += validate_blocking_derivation(matrix, packet)
     notices += validate_operator_channel(matrix, packet)


### PR DESCRIPTION
Unblocks every remaining v6 repair. Without this, `main` is frozen on 141 files.

## The problem

The freeze packet seals 141 inventoried source files by per-file digest. The validator ran in one mode only: recompute digests **against the working tree**. That was correct while the freeze was an open PR, and became a trap the moment it merged — `main` now carries the packet, so any main-side edit to an inventoried file turns CI red on a candidate nobody touched.

This is the same coupling that superseded rc4 (`KL-SEAL-MAIN-COUPLING`), in its permanent form. Four of the outstanding publication-gate repairs touch inventoried files (`check_dco.py`, `check_public_content.py`, the anti-phantom gate, the validator itself) and none of them can land while it holds.

## The fix

A freeze now has a lifecycle:

- **`ACTIVE`** — the freeze is open; digests bind the working tree. Unchanged behavior, and the default when the field is absent, so no existing packet changes meaning.
- **`LANDED`** — the candidate is merged; digests are verified against the named commit by git object read (`git show <sha>:<path>`). The working tree is deliberately unconstrained.

`LANDED` is not a weakening. The candidate `03e972c5` is immutable in `main`'s history, so the seal still proves exactly what the candidate was — it just stops pretending the candidate is the present. A digest that disagrees with the commit still raises `LANDED DIGEST MISMATCH`.

Also adds **candidate lineage binding**: `candidate_sha` must be `HEAD` or an ancestor of it, or the packet raises `CANDIDATE OFF-LINEAGE`. A packet naming a commit not in its own history was previously accepted. Where git cannot answer (shallow clone, non-worktree) it degrades to a notice rather than a false pass.

An unknown `freeze_state` value fails closed.

## Verification

Seven new controls, including: absent state reads `ACTIVE`; an unknown value fails; a `LANDED` packet at `HEAD` passes silently; an orphan commit is caught off-lineage; an absent git answer degrades to a notice.

The off-lineage probe initially passed **for the wrong reason** — an earlier check fired before the lineage check ran — so it was re-tested in isolation against a real commit.

The load-bearing check, run the way rc4's absence cost us: build the PR's actual **merge ref** against current `main` and run the validator on it.

```
note: LANDED freeze 03e972c5d427: 141 sealed digests verified against that commit;
      the working tree is intentionally unconstrained
v6 assurance artifacts: schema + rule checks passed (ZI-001 + candidate)
exit=0
```

Clean-room 54/55, 0 fail, 1 named ci-context skip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSTJZfecEUH49KVszKpgMq)_