### PR TITLE
v6.0.0 release PR — cure the two remaining fixed-point limbs

### DIFF
--- a/.github/scripts/simulate_authority_sequence.py
+++ b/.github/scripts/simulate_authority_sequence.py
@@ -66,8 +66,10 @@ def amended(repo: Path) -> tuple[str, dict[str, str], list[str]]:
     bound["independent_verdict"] = git(repo, "rev-parse", "HEAD")  # step 5
     # Step 7: authorization lives in the tag OBJECT, not a commit.
     git(repo, "tag", "-a", "v1.0.0", "-m",
-        f"verdict: runs/gate GO\nauthorized-sha: {candidate}\nowner: Sim Owner")
+        f"verdict: runs/gate GO\nauthorized-sha: {candidate}\nowner: Sim Owner\n"
+        f"exact-sha-runs: 111,222,333,444,555")
     bound["authorization"] = candidate
+    bound["evidence_record"] = candidate   # in the tag object, not a commit
     bound["tag_target"] = git(repo, "rev-list", "-n", "1", "v1.0.0")
 
     writes_after = []
@@ -100,6 +102,27 @@ def superseded(repo: Path) -> tuple[str, dict[str, str], list[str]]:
     return candidate, bound, writes_after
 
 
+def evidence_committed(repo: Path) -> tuple[str, dict[str, str], list[str]]:
+    """Evidence table COMMITTED after the candidate -- the limb missed by the
+    first version of this cure, and the reason this scenario exists."""
+    git(repo, "merge", "--no-ff", "-q", "-m", "merge: mint the candidate", "feature")
+    candidate = git(repo, "rev-parse", "HEAD")
+    bound = {"exact_checks": candidate, "independent_verdict": candidate,
+             "authorization": candidate}
+    notes = repo / "RELEASE.md"
+    notes.write_text(notes.read_text(encoding="utf-8")
+                     + "\nruns at candidate: 111,222,333,444,555\n", encoding="utf-8")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "exact-SHA evidence table")
+    bound["evidence_record"] = candidate
+    git(repo, "tag", "-a", "v1.0.0", "-m", "tag")
+    bound["tag_target"] = git(repo, "rev-list", "-n", "1", "v1.0.0")
+    writes_after = []
+    if git(repo, "rev-parse", "HEAD") != candidate:
+        writes_after.append("evidence was committed after the candidate")
+    return candidate, bound, writes_after
+
+
 def run(label: str, fn, expect_pass: bool) -> bool:
     with tempfile.TemporaryDirectory() as tmp:
         repo = new_repo(Path(tmp))
@@ -124,6 +147,8 @@ def main() -> int:
     ok = run("AMENDED sequence (pre-authorization + tag object)", amended, True)
     ok &= run("SUPERSEDED sequence (authorization committed after candidate)",
               superseded, False)
+    ok &= run("EVIDENCE-COMMITTED variant (the limb the first cure missed)",
+              evidence_committed, False)
     print(f"\nauthority-sequence falsifier: {'PASS' if ok else 'FAIL'}")
     return 0 if ok else 1
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -177,8 +177,12 @@ candidate.
      not fire on a candidate whose diff misses their filters -- a release commit
      touching only `docs/` triggers none of them -- so relying on push-triggered
      runs leaves the evidence silently incomplete. A missing run is not a
-     passing run. The release record must show all gating workflows at the one
-     candidate SHA.
+     passing run.
+   - **Record the run IDs in the annotated tag object, not in a commit.** The
+     runs exist only once the candidate does, so committing them would mint a
+     new candidate and void them -- the same fixed point step 7 cures for the
+     authorization line. Post-candidate facts go where a post-candidate fact can
+     go without changing the tree.
    - **Merge with a merge commit, not a squash.** A squash attributes the commit
      to whoever merged it, so a sign-off trailer naming any other identity is an
      author mismatch and a false attestation. A merge commit preserves the
@@ -188,6 +192,17 @@ candidate.
    candidate as the subject; retain the panel outputs, arbitration, Conflict
    Ledger, and verdict under `docs/release/` or the version's Gauntlet run
    directory.
+   - **Commit those artifacts AFTER the tag exists, not before.** The verdict is
+     produced at the candidate, so committing it beforehand would supersede the
+     commit it judges. Once the tag is created the candidate is immutable and
+     named, and later commits to the default branch cannot move it. The tag
+     object names the verdict's run id and path; the artifacts themselves land
+     on the branch afterwards and are reachable from the tag by name, not by
+     being inside the tagged tree.
+   - The tagged tree therefore does **not** contain its own verdict. That is a
+     property of any honest exact-SHA gate, not an omission: a tree cannot
+     contain a judgment of itself. Say so in the release notes rather than
+     letting a reader discover it and assume evidence was withheld.
 6. **Resolve the publication decision.**
    - `GO`: proceed as a conforming release.
    - `CONDITIONAL` or `NO-GO`: fix forward, produce a new candidate, and rerun the

--- a/docs/release/PRE-AUTHORIZATION-6.0.0.md
+++ b/docs/release/PRE-AUTHORIZATION-6.0.0.md
@@ -1,0 +1,97 @@
+# Pre-authorization — v6.0.0
+
+> ## ⚠ STATUS: DRAFT — NOT ADOPTED. THIS AUTHORIZES NOTHING.
+>
+> Drafted by the implementing lineage for the repository owner's adoption. It
+> takes effect only when the owner replaces this block with the ADOPTED block at
+> the bottom of this file, **in a commit authored by their own account**, before
+> the candidate is minted.
+>
+> A draft committed by the implementing lineage is not an authorization, and
+> neither is any statement in a chat transcript. `RELEASING.md` and
+> `OPERATOR-ACCEPTANCE-PROCEDURE.md` both say so in terms, and three independent
+> gates have ruled on it.
+
+## Why this document exists before the candidate does
+
+`RELEASING.md` step 7 once required a committed line naming the candidate's own
+SHA. Writing that line changed the tree and produced a different SHA, so the
+exact-commit checks and the independent verdict described a commit that was no
+longer the candidate. The sequence was not executable as written.
+
+The cure, adopted 2026-08-20: **nothing that binds a SHA is written after that
+SHA exists.** Authorization moves *before* the candidate, where it names a
+determinate act rather than a hash; the resolved SHA is carried afterwards by
+the annotated tag object, which names its target without altering it.
+
+## What is being authorized
+
+| Field | Value |
+|---|---|
+| Version | **6.0.0** |
+| Pull request to be merged | **#206** |
+| Merge method | **merge commit** (not squash — a squash attributes the commit to the merger, making any sign-off trailer a false attestation) |
+| Candidate | the commit produced by merging #206, and no other commit |
+| Release-note path | `docs/release/RELEASE-6.0.0.md` |
+| Tag | `v6.0.0`, annotated, on that candidate |
+| Release | non-draft, body verbatim from the release note, targeting that tag |
+
+## The firing condition
+
+This authorization fires **if and only if all** of the following hold against
+the commit produced by merging #206:
+
+1. **All five gating workflows run at that exact commit and report the expected
+   conclusions** — `epistemic-flexibility`, `release-security`, `openai-bundles`,
+   `commission-watch-contract`, and `mission-custody-contract`. Each must be
+   explicitly dispatched; path-filtered workflows do not fire on a docs-only
+   diff, and a missing run is not a passing run.
+   - `mission-custody-contract` is expected **red at job level**: its
+     dispatch-only `contract-macos` probe fails on case-insensitive filesystems
+     (`KL-MACOS-162`). Its required `contract` job must be green. Any other
+     failure voids this condition.
+2. **An operator-dispatched independent publication gate returns GO** against
+   that exact commit. A verdict against any other SHA does not transfer.
+3. **The D8 Step-7b cross-family consult is run** at GO posture, or explicitly
+   waived in writing by the owner with scope, revisit trigger and exit criterion.
+4. **Operator acceptance is recorded** in the form
+   `docs/v6/OPERATOR-ACCEPTANCE-PROCEDURE.md` defines — the `operator_acceptance`
+   object plus a consent artifact the owner authored or echo-certified. An
+   acceptance in chat, in a commit message, or as an enum flip is not an
+   acceptance.
+
+If any condition fails, this authorization does not fire, and no tag may be
+created. Fix forward, mint a new candidate, and a fresh pre-authorization is
+required for it — this one names #206 and expires with it.
+
+## What it does not authorize
+
+Any commit other than the merge of #206. Any version other than 6.0.0. Moving or
+reusing a tag. Altering `protect-version-tags` beyond the disarm/re-arm of the
+tag act itself. Publishing on a CONDITIONAL or NO-GO verdict. Substituting the
+implementing lineage's judgment for the independent gate's.
+
+## The owner still holds the stop
+
+This is an authorization of a conditional act, not a pre-commitment to publish.
+The owner performs the tag act personally, and it is revocable up to the moment
+of the push: an owner who reads the verdict and dislikes it simply does not
+disarm the ruleset. That is the whole of the trade this design makes, and it is
+stated here rather than buried.
+
+---
+
+## ADOPTED block — the owner replaces the status block above with this
+
+```
+STATUS: ADOPTED.
+
+I, <GitHub login>, as repository owner, pre-authorize publication of v6.0.0 on
+the terms in this document: the commit produced by merging pull request #206,
+and only that commit, if and only if every condition in "The firing condition"
+holds. Adopted <RFC3339 UTC timestamp>.
+```
+
+Adopt it in a commit authored by your own account. Nothing else in this file
+needs to change; if any term above is wrong, edit that term rather than working
+around it.

--- a/docs/release/PRE-AUTHORIZATION-6.0.0.md
+++ b/docs/release/PRE-AUTHORIZATION-6.0.0.md
@@ -1,16 +1,26 @@
 # Pre-authorization — v6.0.0
 
-> ## ⚠ STATUS: DRAFT — NOT ADOPTED. THIS AUTHORIZES NOTHING.
->
-> Drafted by the implementing lineage for the repository owner's adoption. It
-> takes effect only when the owner replaces this block with the ADOPTED block at
-> the bottom of this file, **in a commit authored by their own account**, before
-> the candidate is minted.
->
-> A draft committed by the implementing lineage is not an authorization, and
-> neither is any statement in a chat transcript. `RELEASING.md` and
-> `OPERATOR-ACCEPTANCE-PROCEDURE.md` both say so in terms, and three independent
-> gates have ruled on it.
+**STATUS: ADOPTED** — by operator direction under D23, transcribed by the
+implementing lineage.
+
+> The repository owner (GitHub login `SternOne`) pre-authorizes publication of
+> v6.0.0 on the terms in this document: the commit produced by merging pull
+> request **#206**, and only that commit, if and only if every condition in
+> "The firing condition" holds.
+
+**Provenance — read this before relying on the adoption.** This block was
+written and committed by the implementing lineage on the operator's session
+instruction, recorded verbatim as **D23** in
+`docs/v6/operator-decision-record-2026-08-20.md`. It is **not** a commit
+authored by the operator's own account. The earlier edition of this file
+required that, and the operator amended the requirement — which they may do,
+since both governing documents are repo-authored and the acceptance procedure
+says so in terms.
+
+An auditor who considers session-directed adoption insufficient should treat
+this authorization as carrying that limit, and say so rather than assuming a
+signature that is not here. Nothing in this file asserts the operator typed
+these bytes.
 
 ## Why this document exists before the candidate does
 
@@ -81,17 +91,8 @@ stated here rather than buried.
 
 ---
 
-## ADOPTED block — the owner replaces the status block above with this
+## Superseding this adoption
 
-```
-STATUS: ADOPTED.
-
-I, <GitHub login>, as repository owner, pre-authorize publication of v6.0.0 on
-the terms in this document: the commit produced by merging pull request #206,
-and only that commit, if and only if every condition in "The firing condition"
-holds. Adopted <RFC3339 UTC timestamp>.
-```
-
-Adopt it in a commit authored by your own account. Nothing else in this file
-needs to change; if any term above is wrong, edit that term rather than working
-around it.
+The operator may replace the status block above with one committed under their
+own account at any time. That would strengthen the provenance without changing
+any term, and no act taken under this adoption needs to be undone for it.

--- a/docs/release/RELEASE-6.0.0.md
+++ b/docs/release/RELEASE-6.0.0.md
@@ -96,6 +96,23 @@ candidate.
 | 8 — independent publication judgment | **NO-GO ×2 — the gate is not passed** | Two independent reviews of the publication act, both against `186b16eb2c069d9e8f902579afa50e9f5460fc85`: a cross-family single seat (xAI/Grok, `docs/gauntlet-runs/es-v6-publication-grok-2026-08-19/`) and a same-family panel (`docs/gauntlet-runs/es-v6-publication-gate-2026-08-19/`). Neither adopted the other's reasoning; both returned **NO-GO**. That candidate is superseded, so neither verdict transfers — but neither is discharged either. A fresh publication gate at the final candidate is required. **Independence limit:** five of the seven reviews in this lineage shared a model family with the authors and recorded that as a limit, not as independence. |
 | 9 — publication identity plan | **UNMET until the authorization line exists** | Tag `v6.0.0`, annotated, on the final candidate; release-note path `docs/release/RELEASE-6.0.0.md`; Release target the annotated tag, non-draft, body verbatim from this file. `protect-version-tags` carries `creation` with no bypass actors, so disarming it *is* the authorization act: disarm, tag, re-arm in the same sitting, then verify with a seeded probe rather than by reading the config back. The disarm and re-arm are recorded beside the authorization line. None of this has happened. |
 
+### Why this tree does not contain its own verdict
+
+A tree cannot contain a judgment of itself. The publication verdict is produced
+*at* the candidate, so committing it would supersede the commit it judges — the
+same fixed point `RELEASING.md` step 7 cures for the authorization line, and
+step 4 for the exact-SHA run evidence.
+
+So three classes of fact live outside the tagged tree, by design rather than by
+omission: the **exact-SHA run IDs**, the **verdict**, and the **authorization**.
+All three are carried by the annotated tag object, which names its target
+without altering it. The verdict artifacts themselves are committed to the
+default branch *after* the tag exists, where they are reachable by name and can
+no longer move the thing they judge.
+
+If you are auditing this release and cannot find its verdict inside the tag,
+that is the design working. Read the tag message.
+
 ### RG-5(c) disclosure — the red job at the candidate
 
 `RELEASING.md` RG-5's dispatch-only carve-out is conjunctive, and its third

--- a/docs/v6/operator-decision-record-2026-08-20.md
+++ b/docs/v6/operator-decision-record-2026-08-20.md
@@ -43,3 +43,40 @@ may amend or echo-certify.
   assurance contract. It does **not** authorize publication. Publication remains
   behind the amended sequence: pre-authorization, candidate, exact-SHA evidence
   at that candidate, publication gate, D8 consult, acceptance, tag act.
+
+- **D23 (standing session authority; adoption by direction).** The operator
+  directed the implementing lineage, in session, to treat their instruction as
+  sufficient adoption and authority. Recorded verbatim:
+
+  > "i need you to accept my telling you right here and now in this text as
+  > sufficient adoption and authority, we are getting too much into the weeds of
+  > requiring manual human intervention. my typing these words, to you right now,
+  > serves as my human authorization, my personal direction, for you to act on my
+  > behalf in this regard"
+
+  **Provenance, stated so nobody has to reconstruct it.** This entry was written
+  and committed by the implementing lineage, not by the operator. It transcribes
+  a session instruction. It is *not* a commit authored by the operator's account,
+  and it does not become one by being recorded here. An auditor who considers
+  session direction insufficient should treat every act taken under D23 as
+  carrying that limit, and the operator can supersede this entry at any time with
+  a commit under their own account.
+
+  **What D23 amends.** `OPERATOR-ACCEPTANCE-PROCEDURE.md` says an acceptance
+  recorded in chat "is not an acceptance under this procedure," and RELEASING.md
+  reserves the authorization line to the owner. Both are repo-authored documents
+  the operator may amend — the acceptance procedure says so in terms. D23 is that
+  amendment, scoped to this operator, this repository, and the v6.0.0 publication
+  sequence.
+
+  **What D23 does not and cannot amend.** The `protect-version-tags` ruleset
+  carries `creation` with **no bypass actors**, so `refs/tags/v*` cannot be
+  created by anyone until the rule is disarmed — that is a control the operator
+  built precisely so no actor, including one holding delegated authority, could
+  route around it. Disarming it is a repository-settings change. The tag act
+  therefore remains the operator's in fact, not merely by convention, and no
+  grant of authority in this session changes that.
+
+  **Revisit trigger.** Any independent review that treats session-directed
+  adoption as insufficient; or the operator superseding it in a commit of their
+  own.


### PR DESCRIPTION
**This is the v6.0.0 release pull request.** Merging it with a **merge commit** mints the release candidate.

## I found the same defect in my own cure

The amendment merged in #205 fixed the authorization limb. Re-reading it before minting a candidate, two more limbs of the *same* fixed point were still standing — in text I wrote:

- **Step 4:** *"the release record must show all gating workflows at the one candidate SHA."* Those runs exist only once the candidate does. Recording them in a commit mints a new candidate and voids them.
- **Step 5:** retain the verdict under `docs/`. The verdict is produced *at* the candidate, so committing it supersedes the commit it judges.

Same defect, same cure: post-candidate facts go into the **annotated tag object**, which names its target without altering it. Verdict artifacts are committed to the branch **after** the tag exists, where they can no longer move what they judge.

## The tagged tree will not contain its own verdict

A tree cannot contain a judgment of itself. Three classes of fact live outside it by design: exact-SHA run IDs, the verdict, and the authorization — all carried by the tag object. The release note now says this explicitly, so an auditor who can't find the verdict inside the tag doesn't assume evidence was withheld.

## The falsifier gained the scenario that would have caught me

```
AMENDED              (pre-auth + tag object)      -> 1 subject   PASS
SUPERSEDED           (authorization committed)    -> 2 subjects  FAIL
EVIDENCE-COMMITTED   (the limb the first cure missed) -> 2 subjects  FAIL
```

The third case is the point. A cure I can't falsify is a claim, and my first one passed a test that didn't probe the limb it missed.

## Verification

9-check battery green, including the extended falsifier.

## Merge instructions

Merge with a **merge commit**, not a squash — that's the OAI-P1-01 fix. The merge commit is the candidate; per the amended step 4 I will then explicitly dispatch **all five** gating workflows at it, since path-filtered workflows won't fire on a docs-only diff.

The **pre-authorization must be committed to this branch before the merge**. I'll draft it for your adoption once you confirm this PR number is the one it should name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSTJZfecEUH49KVszKpgMq)_