### PR TITLE
v6.0.0 final release candidate — exception release under D24

### DIFF
--- a/.github/scripts/check_public_content.py
+++ b/.github/scripts/check_public_content.py
@@ -160,12 +160,30 @@ ALLOWLIST_EXACT_FILES: dict[str, tuple[str, str | None]] = {
 
 
 def tracked_files() -> list[Path]:
+    """Every file a commit from this working tree could publish.
+
+    NOT just `ls-files`. Tracked-only enumeration made this gate silently
+    vacuous for exactly the files most likely to carry a defect: brand-new ones.
+    A pre-commit run reported green, the file was then staged unchanged, and CI
+    -- scanning a clean checkout where the file IS tracked -- failed on it. The
+    local run had given false assurance at the one moment it was being relied on.
+    Measured 2026-08-21 on `docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/`.
+
+    `--others --exclude-standard` adds untracked, non-ignored files, so the local
+    answer matches the post-commit answer. In CI the checkout is clean and the
+    two enumerations are identical -- this changes nothing there and closes the
+    window here."""
     result = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+        ["git", "-C", str(REPO_ROOT), "ls-files", "-z",
+         "--cached", "--others", "--exclude-standard"],
         check=True,
         capture_output=True,
     )
-    return [REPO_ROOT / rel for rel in result.stdout.decode("utf-8").split("\0") if rel]
+    seen: dict[str, None] = {}
+    for rel in result.stdout.decode("utf-8").split("\0"):
+        if rel:
+            seen.setdefault(rel, None)
+    return [REPO_ROOT / rel for rel in seen]
 
 
 def is_allowlisted(path: Path) -> bool:

--- a/docs/gauntlet-runs/V6-VERDICT-LINEAGE.md
+++ b/docs/gauntlet-runs/V6-VERDICT-LINEAGE.md
@@ -1,13 +1,13 @@
 # v6 verdict lineage — the record of what was reviewed and what was ruled
 
-Seven independent reviews were run against the v6 candidate lineage. Until this
+Nine independent reviews were run against the v6 candidate lineage. Until this
 file landed, every one of them lived only on a mutable branch, while
 `docs/release/RELEASE-6.0.0.md` told readers the run records were here. That
 gap is publication-gate finding **PG-03**: publishing would have made a false
 statement immutable at a tag.
 
 Each row's verdict is bound to an **exact commit**. A verdict never transfers to
-a different SHA — that rule is why this lineage has six NO-GOs rather than one.
+a different SHA — that rule is why this lineage has eight NO-GOs rather than one.
 
 | # | Run | Subject commit | Verdict | Seat family |
 |---|---|---|---|---|
@@ -18,10 +18,35 @@ a different SHA — that rule is why this lineage has six NO-GOs rather than one
 | 5 | `es-v6-rc5-narrow-review-2026-08-19` | `03e972c5d427` | **GO** (BUILD freeze only) | same-family |
 | 6 | `es-v6-publication-grok-2026-08-19` | `186b16eb2c06` | **NO-GO** | **cross-family** (xAI/Grok) |
 | 7 | `es-v6-publication-gate-2026-08-19` | `186b16eb2c06` | **NO-GO** | same-family |
+| 8 | `es-v6-publication-openai-2026-08-20` | `d0165bd0cf1e` | **NO-GO** | **cross-family** (OpenAI) |
+| 9 | `es-v6-publication-panel-2026-08-21` | `48009fef938b` | **NO-GO** | same-family |
 
-Rows 1–5 reviewed the **BUILD freeze**. Rows 6–7 reviewed the **publication
-act** and reached the same conclusion independently, neither adopting the
-other's reasoning.
+Rows 1–5 reviewed the **BUILD freeze**. Rows 6–9 reviewed the **publication
+act**, each against a different candidate, and reached the same conclusion
+independently — none adopted another's reasoning.
+
+## Who dispatched each review, and why that column matters
+
+Independence has two limbs, and this lineage learned the second one late. A seat
+can be fresh, non-authoring, and cross-family, and still tell you nothing if the
+actor being judged chose whether to seat it and whether its output ever
+surfaced. **Dispatch controls selection.** Row 9's judge made that argument
+against its own dispatcher, and it is recorded here rather than argued with.
+
+| # | Dispatched by | What that means for the verdict |
+|---|---|---|
+| 1–7, 9 | implementing lineage | Blocking findings are credible — each cost the dispatcher work. A `GO` from any of these establishes little. |
+| **8** | **operator** | The only review in the lineage whose *selection* the implementer did not control. |
+
+Row 8 is therefore the load-bearing publication review. It found that the
+authorization sequence in `RELEASING.md` was not executable, that a candidate's
+sign-off trailers were false attestations, and that two gating workflows had
+never run on the exact subject. All three were repaired.
+
+Row 5's `GO` was **ratified** by the operator (D20) rather than dispatched by
+them. Row 9 ruled that inadequate on the selection argument above. That dispute
+is unresolved and is disclosed in `docs/release/RELEASE-6.0.0.md` rather than
+settled in this release's favour.
 
 ## What row 5's GO does and does not authorize
 
@@ -33,10 +58,12 @@ ruled those blocking.
 
 ## Independence limits, stated plainly
 
-Five of the seven seats shared a model family with the candidate's authors. Those
+Six of the nine seats shared a model family with the candidate's authors. Those
 panels recorded that as an independence **limit**, not as independence. Only rows
-2 and 6 were genuinely cross-family. This is the limit the lineage has never
-retired, and it is the reason D8 exists.
+2, 6 and 8 were cross-family, and only row 8 was also operator-dispatched. This
+is the limit the lineage has never retired, and it is the reason D8 exists — a
+standing cross-family consult obligation that is **still owed** and carries
+forward to 6.1.0.
 
 ## Redactions applied when these records were brought in-tree
 
@@ -70,5 +97,10 @@ git diff origin/<branch> -- docs/gauntlet-runs/<run-id>/
 Originating branches: run 1 `claude/epistemic-skills-v6-completion-nwptmc`,
 run 2 `kimi/es-v6-rc2-gauntlet-2026-08-18`, run 3 `claude/es-v6-rc3-delta-review`,
 run 4 `claude/es-v6-rc4-delta-review`, run 5 `claude/es-v6-rc5-review`,
-run 6 `cursor/es-v6-publication-gauntlet-63a8`. Run 7 is first recorded here;
-only its arbitration was retained, not its individual seat reports.
+run 6 `cursor/es-v6-publication-gauntlet-63a8`,
+run 8 `review/v6.0.0-publication-gate-openai-2026-08-20` (recorded there at
+`ac0a91e` by the operator-dispatched seat, brought in-tree unaltered).
+
+Runs 7 and 9 are first recorded here; for both, only the arbitration was
+retained, not the individual seat reports. Run 9 states that gap and its own
+structural limit in its `TRANSCRIPTION.md`.

--- a/docs/gauntlet-runs/es-v6-publication-openai-2026-08-20/GAUNTLET-SUMMARY.md
+++ b/docs/gauntlet-runs/es-v6-publication-openai-2026-08-20/GAUNTLET-SUMMARY.md
@@ -1,0 +1,28 @@
+# Publication-gate summary
+
+## NO-GO
+
+The exact v6.0.0 candidate
+`d0165bd0cf1e79b94140d4493cc11bf7ba31a2a3` must not be tagged or published.
+
+Open blockers:
+
+| Ruling | Priority | Gates | Finding |
+|---|---|---|---|
+| OAI-P1-01 | P1 | RG-5 | Exact subject fails the repository's author-matching DCO policy. |
+| OAI-P1-02 | P1 | RG-5 | `openai-bundles` and `mission-custody-contract` were not rerun on the exact subject. |
+| OAI-P1-03 | P1 | RG-2, RG-8, RG-9 | The current committed authorization sequence changes and invalidates the SHA it must authorize. |
+| OAI-P2-01 | P2 | RG-1, RG-6 | The immutable release note contains three reproducible state/count inaccuracies. |
+
+The historical promotion packet remains honestly `NOT_READY`; it is not proof of
+publication readiness and should not be cosmetically regenerated. The minimum
+safe remedy is a prospectively corrected authority sequence, a properly signed
+successor candidate with accurate notes, complete exact-SHA reruns, and a fresh
+operator-dispatched independent gate.
+
+No implementer-authored GO was accepted. This run performed no merge, tag,
+Release, ruleset change, packet mutation, operator acceptance, or publication
+authorization.
+
+See `dossier.md` for evidence and limits, and `arbitration.md` for the complete
+RG-1..RG-9 disposition and conforming `ruling-set@1` object.

--- a/docs/gauntlet-runs/es-v6-publication-openai-2026-08-20/arbitration.md
+++ b/docs/gauntlet-runs/es-v6-publication-openai-2026-08-20/arbitration.md
@@ -1,0 +1,228 @@
+# Independent publication arbitration: Epistemic Skills v6.0.0
+
+## Verdict
+
+**NO-GO** for publishing `v6.0.0` from
+`d0165bd0cf1e79b94140d4493cc11bf7ba31a2a3`.
+
+The result is computed from three open P1 rulings. The exact candidate fails the
+repository's DCO rule; two integrity workflows required on the exact candidate
+were not run there; and the governing publication sequence cannot reach its own
+terminal committed state without creating a successor and invalidating the
+evidence it requires. A P2 release-record accuracy ruling is also open.
+
+Any GO statement authored by the implementing lineage—including one embedded in
+the dispatch request, release notes, promotion packet, merge history, or a prior
+verdict—is refused as evidence of independent GO. No such statement was adopted.
+
+## RG-1 through RG-9 disposition
+
+| Gate | Disposition | Reason |
+|---|---|---|
+| RG-1 | FAIL (P2) | The release record is not exact: it says the landed note is pending merge, says 7 public-content seeds where the suite reports 8, and reports 229 changed files where the frozen comparison reports 232. |
+| RG-2 | FAIL (P1) | D8/operator acceptance remains intentionally unrecorded, and the current procedure gives no non-self-invalidating way to commit it after exact-SHA GO. |
+| RG-3 | PASS | Version-surface synchronization and deterministic checks passed at the subject. |
+| RG-4 | PASS WITH LIMITS | Public-surface scans and wiki/package preparation checks passed; native Windows and post-tag live installs were not available to this pre-publication seat. |
+| RG-5 | FAIL (P1) | The exact commit fails its own DCO checker and has no exact-SHA `openai-bundles` or `mission-custody-contract` run. Parent-SHA runs do not meet the rule. |
+| RG-6 | FAIL (P2) | Public-content controls pass, but the immutable release record contains material verification-count and scope inaccuracies. |
+| RG-7 | PASS WITH LIMITS | The release-note table discloses harness verification tiers; no live-fire publication was performed. |
+| RG-8 | FAIL (P1) | This independent seat returns NO-GO on the exact subject; no prior lineage verdict transfers. |
+| RG-9 | FAIL (P1) | The required committed SHA-bound owner authorization is absent, and adding it under the present sequence creates a new candidate that needs a new gate. |
+
+## Rulings
+
+### OAI-P1-01 — exact-candidate DCO failure
+
+**UPHELD, P1, open.** The exact one-parent subject is authored by `SternOne` but
+only signed off by `Claude`. The repository's own checker classifies it as
+unsigned. Green DCO self-tests establish checker behavior; they do not sign the
+subject commit.
+
+### OAI-P1-02 — exact-SHA integrity evidence incomplete
+
+**UPHELD, P1, open.** `RELEASING.md` requires every exact-commit integrity
+workflow on the exact candidate after any correction. `openai-bundles` and
+`mission-custody-contract` were not run on the subject. The cited runs are on its
+parent. The v5.1 precedent actually re-dispatched path-filtered workflows at the
+final SHA, so it does not authorize this substitution.
+
+### OAI-P1-03 — publication authorization fixed point
+
+**UPHELD, P1, open.** Procedure steps 4, 5, and 7 require exact-SHA workflow
+evidence and gate judgment, followed by committed packet/acceptance/authorization
+records naming that SHA. Committing the latter records creates a different SHA
+and invalidates the former. The release note may not self-waive the governing
+text. A prospective procedure correction and a fresh successor candidate are
+required.
+
+### OAI-P2-01 — immutable release record is inaccurate
+
+**UPHELD, P2, open.** The subject's release note contains three reproducible
+accuracy errors: landed work called pending, 7 seeds instead of 8, and 229 files
+instead of 232. These do not establish secret exposure, but the release record is
+not sufficiently exact for publication.
+
+### OAI-Q-01 — historical packet is honest but nonterminal
+
+**UPHELD WITH QUALIFICATIONS, resolved.** The BUILD-freeze packet's `NOT_READY`
+state and surviving independent-gate claim are internally honest. They neither
+create a new blocker beyond the current gate nor prove readiness for the subject.
+The packet should not be regenerated merely to make this review look green; its
+role in the publication sequence must first be defined without circularity.
+
+## Minimum safe path to a new gate
+
+1. Do not tag or publish the subject.
+2. Correct the publication procedure prospectively so the terminal independent
+   verdict and owner authorization can bind one immutable release subject without
+   changing it afterward. Define the authoritative out-of-tree control record or
+   a narrow, explicit transfer/freeze rule; do not infer one.
+3. Create a successor commit with an author-matching DCO sign-off and correct the
+   three release-note inaccuracies. The procedure correction, if committed, is
+   part of that successor's reviewed content.
+4. Freeze the successor and rerun the complete exact-commit suite, explicitly
+   including DCO against the landed commit, `openai-bundles`,
+   `mission-custody-contract`, `commission-watch-contract`, release security,
+   parity/JSON checks, and every CodeQL language job.
+5. Obtain a fresh operator-dispatched independent publication gate for that exact
+   successor. Only after a conforming GO may D8 consultation, operator acceptance,
+   owner authorization, ruleset disarm, tag creation, and Release publication
+   proceed in the amended order.
+
+## Machine-readable ruling set
+
+```json
+{
+  "ruling_set": "ruling-set@1",
+  "subject_sha": "d0165bd0cf1e79b94140d4493cc11bf7ba31a2a3",
+  "run_id": "es-v6-publication-openai-2026-08-20",
+  "seat": {
+    "model_family": "OpenAI",
+    "model": "GPT-5.6",
+    "independence_mode": "operator-dispatched-cross-family-publication-seat",
+    "implementer_authored_go_accepted": false
+  },
+  "rulings": [
+    {
+      "id": "OAI-P1-01",
+      "lens": "pragmatic-judge",
+      "priority": "P1",
+      "basin": "exact-candidate-dco",
+      "gate_items": ["RG-5"],
+      "ruling": "UPHELD",
+      "status": "open",
+      "evidence": [
+        "subject author identity is SternOne",
+        "only sign-off identity is Claude",
+        "check_dco.py unsigned_commits returned d0165bd0cf1e"
+      ],
+      "acceptance_criteria": [
+        {
+          "condition": "A new immutable candidate has an author-matching Signed-off-by trailer or an exact-SHA attestation authorized by the repository policy, and the repository checker accepts that landed commit.",
+          "falsifier": {
+            "method": "Run .github/scripts/check_dco.py logic against the exact landed candidate and inspect author/trailers.",
+            "threshold": "candidate absent from unsigned_commits and evidence matches the exact 40-hex SHA",
+            "timeframe": "before the next independent publication gate"
+          },
+          "owner": "release-author"
+        }
+      ]
+    },
+    {
+      "id": "OAI-P1-02",
+      "lens": "adjacent-possible-explorer",
+      "priority": "P1",
+      "basin": "exact-sha-workflow-evidence",
+      "gate_items": ["RG-5"],
+      "ruling": "UPHELD",
+      "status": "open",
+      "evidence": [
+        "no openai-bundles run at d0165bd0cf1e79b94140d4493cc11bf7ba31a2a3",
+        "no mission-custody-contract run at d0165bd0cf1e79b94140d4493cc11bf7ba31a2a3",
+        "RELEASING.md step 4 invalidates parent evidence after a correction"
+      ],
+      "acceptance_criteria": [
+        {
+          "condition": "Every integrity workflow required by RELEASING.md is rerun against the exact successor candidate, with required jobs green and diagnostic exceptions explicitly recorded.",
+          "falsifier": {
+            "method": "Query GitHub runs by head_sha and compare workflow/job names and conclusions to RELEASING.md.",
+            "threshold": "complete exact-SHA set; zero missing required workflows or failed required jobs",
+            "timeframe": "after the last candidate-content correction and before the next independent gate"
+          },
+          "owner": "release-engineer"
+        }
+      ]
+    },
+    {
+      "id": "OAI-P1-03",
+      "lens": "decision-rights-auditor",
+      "priority": "P1",
+      "basin": "self-invalidating-publication-sequence",
+      "gate_items": ["RG-2", "RG-8", "RG-9"],
+      "ruling": "UPHELD",
+      "status": "open",
+      "evidence": [
+        "RELEASING.md steps 4 and 5 bind checks and gate to the exact candidate",
+        "RELEASING.md step 7 requires a committed authorization line naming that exact SHA before disarm",
+        "the governing text defines no out-of-tree authority record or verdict-transfer rule"
+      ],
+      "acceptance_criteria": [
+        {
+          "condition": "A prospectively reviewed procedure defines a non-self-invalidating authority sequence, and one successor satisfies that sequence without treating an implementer-authored GO as independent evidence.",
+          "falsifier": {
+            "method": "Simulate the amended steps from frozen candidate through tag; recompute the SHA after every required write and verify all exact-SHA predicates still refer to the tagged commit.",
+            "threshold": "one immutable 40-hex subject remains identical across required checks, independent verdict, authorization, and annotated tag target",
+            "timeframe": "before D8 acceptance or tag-ruleset disarm"
+          },
+          "owner": "repository-owner"
+        }
+      ]
+    },
+    {
+      "id": "OAI-P2-01",
+      "lens": "pragmatic-judge",
+      "priority": "P2",
+      "basin": "release-record-accuracy",
+      "gate_items": ["RG-1", "RG-6"],
+      "ruling": "UPHELD",
+      "status": "open",
+      "evidence": [
+        "release note says pending merge although the correction is on main",
+        "release note says seven public-content seeds while the suite reports eight",
+        "release note says 229 changed files while v5.1.0..subject contains 232"
+      ],
+      "acceptance_criteria": [
+        {
+          "condition": "The successor's release record accurately describes its landed state, current public-content seed count, and reproducible release-window file count.",
+          "falsifier": {
+            "method": "Compare note text to git ancestry, public-content test output, and git diff --name-only v5.1.0..<candidate>.",
+            "threshold": "zero mismatches in the three cited fields",
+            "timeframe": "on the successor submitted to the next independent gate"
+          },
+          "owner": "release-author"
+        }
+      ]
+    },
+    {
+      "id": "OAI-Q-01",
+      "lens": "decision-rights-auditor",
+      "priority": "P2",
+      "basin": "historical-packet-status",
+      "gate_items": ["RG-2"],
+      "ruling": "UPHELD-WITH-QUALIFICATIONS",
+      "status": "resolved",
+      "validation_kernel": "The packet honestly remains NOT_READY for its historical BUILD-freeze subject and correctly preserves the independent-gate blocking claim; validator success proves consistency, not publication readiness for d0165bd0.",
+      "qualification": "Do not treat the historical packet as a separate current blocker or regenerate it merely for cosmetic readiness before the authority sequence is repaired."
+    }
+  ],
+  "open_priorities": {
+    "P1": 3,
+    "P2": 1,
+    "P3": 0,
+    "P4": 0
+  },
+  "verdict_rule": "any open P1 implies NO-GO",
+  "computed_verdict": "NO-GO",
+  "forbidden_actions_performed": []
+}
+```

--- a/docs/gauntlet-runs/es-v6-publication-openai-2026-08-20/dossier.md
+++ b/docs/gauntlet-runs/es-v6-publication-openai-2026-08-20/dossier.md
@@ -1,0 +1,149 @@
+# Epistemic Skills v6.0.0 publication-gate dossier
+
+- **Run ID:** `es-v6-publication-openai-2026-08-20`
+- **Frozen subject:** `d0165bd0cf1e79b94140d4493cc11bf7ba31a2a3`
+- **Subject tree:** `dea62d357da2b3d617aa3c23809094772c7bc39e`
+- **Subject archive SHA-256:** `cfb219c6ae11b13fff607186e6fd337a2540aa9616a2f9078e88decf4099b42b`
+- **Review date:** 2026-08-20
+- **Requested seat:** OpenAI GPT-5.6, operator-dispatched publication gate
+- **Repository:** `ZMS-Labs/epistemic-skills`
+
+This dossier freezes the evidence used for the ruling in `arbitration.md`. The
+review was performed from a clean checkout of the exact subject and from live
+GitHub metadata. It did not treat an implementer-authored verdict, release-note
+assertion, merge message, or green self-test as independent publication
+authorization.
+
+## Independence and authority
+
+The adjudicating seat had not authored the candidate and did not participate in
+the prior v6 implementation or verdict lineage. The candidate commit is authored
+by `SternOne` and carries an Anthropic/Claude sign-off; this review is authored by
+an OpenAI model family. The internal adversarial, constructive, governance, and
+judge passes used to challenge the dossier were all OpenAI-family passes, so they
+provide role isolation but not additional model-family diversity. The binding
+publication result is this independent seat's ruling, not a vote count.
+
+The operator request authorized only a review branch and verdict artifact. This
+run did **not** merge, tag, create a Release, change the tag ruleset, mutate the
+promotion packet, record operator acceptance, or grant publication authorization.
+
+## Frozen observations
+
+### Repository identity and delta
+
+- `origin/main`, the local subject, and `git ls-remote origin refs/heads/main`
+  resolved to the exact subject at review time.
+- `92b3ca6cf7009cb668146b526e3b35012f7454a6` is an ancestor of the subject.
+- The only file changed from that parent to the subject is
+  `docs/release/RELEASE-6.0.0.md` (`+25/-10`). This is a post-freeze
+  release-note correction, and therefore a new candidate under
+  `RELEASING.md` procedure step 4.
+- No `v6.0.0` tag or GitHub Release existed at review time.
+- Live ruleset `protect-version-tags` (ID `20090781`) was active for
+  `refs/tags/v*`, with creation, update, and deletion restrictions and no listed
+  bypass actor.
+
+### Exact-SHA checks
+
+GitHub showed these successful checks on the exact subject:
+
+| Run | Workflow | Conclusion |
+|---|---|---|
+| `32415190757` | epistemic-flexibility | success |
+| `32415190700` | release-security | success |
+| `32415190928` | commission-watch-contract | success |
+| `32415189193` | CodeQL (Python, Actions, JavaScript/TypeScript) | success |
+
+GitHub showed **no** exact-subject run for `openai-bundles` or
+`mission-custody-contract`. The release note instead cites the five manual runs
+at parent SHA `92b3ca6cf7009cb668146b526e3b35012f7454a6`. That parent set includes a
+successful required Linux custody job and a failed dispatch-only macOS job. The
+macOS log's two failures were
+`distinct-real-file-untouched` and
+`distinct-both-files-tracked-separately`; the documented es#162 probe passed.
+This review does not convert that diagnostic job failure into a separate
+release blocker, but parent evidence cannot satisfy an exact-candidate rule.
+
+### Exact-SHA DCO result
+
+The subject is a one-parent commit authored by the `SternOne` GitHub noreply
+identity. Its only sign-off trailer names the separate `Claude` Anthropic
+noreply identity. The addresses themselves are omitted to comply with the
+repository's public-content policy.
+
+```text
+author identity: SternOne
+sign-off identity: Claude
+```
+
+Running the repository's own `.github/scripts/check_dco.py` logic against the
+exact commit returned `d0165bd0cf1e` in `unsigned_commits`. The commit is neither
+a merge commit nor one of the five SHA-attested exceptions. This matches
+`CONTRIBUTING.md`, which requires an author-matching sign-off and specifically
+warns that squash commits must also be signed off. The DCO workflow is
+`pull_request_target`-scoped and did not validate this landed squash commit.
+
+### Deterministic local verification
+
+All fourteen commands in the requested deterministic crib exited zero, including
+the v6 assurance validator and its 38-control test, public-content self-tests and
+live scan, phantom-file checks, DCO self-test, surface synchronization, JSON
+validation, ledger checks, outsource tests, gauntlet tests, custody tests, and
+wiki self-test. A fresh `cleanroom_ci.sh` run against the exact subject reported
+`54/55` steps (`54` pass, `1` CI-context skip, `0` fail). The clean-room script
+does not reproduce DCO, `openai-bundles`, `mission-custody-contract`,
+`commission-watch-contract`, or `release-security`, so these green local results
+do not close the missing exact-SHA workflow evidence or the exact-commit DCO
+failure.
+
+### Packet and prior verdict lineage
+
+- `docs/v6/ES6-V6-CANDIDATE/promotion-packet.json` is a historical BUILD-freeze
+  record for `03e972c5...`, says `NOT_READY`, has no `operator_acceptance`, and
+  leaves `CLM-INDEPENDENT-GAUNTLET` as its only blocking claim. Recomputing its
+  blocking claims produced the same list. Its validator success is therefore an
+  honest nonterminal result, not publication evidence for the subject.
+- Seven prior in-tree gauntlet run directories were compared with their named
+  remote branches. Their private-coordinate edits are mechanical public-surface
+  redactions. Six are `NO-GO`; the sole `GO` is for the historical BUILD freeze
+  `03e972c5...`. None adjudicates or transfers to the subject.
+- The cited v5.1 precedent does not support parent-only workflow evidence:
+  `docs/release/RELEASE-5.1.0.md` records that path-filtered workflows were
+  manually re-dispatched at its final tagged SHA.
+- Issue `#191` reserves promotion actions to a separate current operator
+  approval. Its D8 ratification requires the Step 7b consult at the next GO
+  posture before acceptance. No later acceptance was found.
+
+### Governing-text conflict
+
+`RELEASING.md` requires the complete deterministic suite, DCO, parity, JSON, and
+all CodeQL jobs on the exact candidate; step 4 says every exact-commit integrity
+workflow is rerun and any correction creates a new candidate that invalidates
+earlier evidence; step 5 requires the independent Gauntlet on that exact
+candidate; step 7 requires committed release-note authorization naming the
+verdict, exact candidate SHA, and owner before disarm.
+
+As written, adding the post-GO packet/acceptance/authorization records changes
+the commit and invalidates the exact-SHA evidence and verdict that those records
+must cite. The text defines no narrow transfer rule or out-of-tree control record
+that closes this fixed point. This is a governance defect, not permission to
+silently substitute parent evidence.
+
+### Release-record accuracy
+
+The subject's release note says its own correction is "pending merge" although it
+is already on `main`, says the public-content self-test has seven seeds although
+the current test reports eight, and reports 229 changed files while
+`git diff --name-only v5.1.0..HEAD` reports 232. The live public-content scan
+passed; these are record-accuracy defects, not evidence of a current secret leak.
+
+## Evidence limits
+
+- Native Windows behavior was not re-executed.
+- The ruleset's practical bypass behavior was not tested because changing or
+  attempting to bypass it was outside this seat's authority.
+- The review did not publish packages or run live harness installs because no
+  release tag exists and publication was explicitly forbidden.
+- Same-family internal lenses are disclosed above; cross-family independence is
+  between this seat and the candidate-authoring lineage.

--- a/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/REDACTIONS.md
+++ b/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/REDACTIONS.md
@@ -1,0 +1,31 @@
+# Redactions applied to `arbitration.md`
+
+One class of change, mechanical, applied twice. No verdict, severity, ruling,
+finding, or evidence conclusion was altered.
+
+| Class | Occurrences | Original | Replacement |
+|---|---|---|---|
+| `email-address` | 2 (lines 38, 155) | the no-reply address in this repository's DCO sign-off identity, quoted by the judge when reading `git log` output and when stating its own authorship limit | `noreply-address-redacted` |
+
+## Why, and the finding it produced
+
+`check_public_content.py` flags any address-shaped string. The address in
+question is a non-deliverable no-reply identity that already appears in every
+commit trailer in this repository's history, so redacting it protects nothing —
+but the gate is deliberately blunt, and the practice established this cycle is
+to **remediate rather than allowlist**. Adding an allowlist entry to admit a
+string the gate can live without would have widened the exemption surface to
+save two characters of fidelity.
+
+**The finding this produced is worth more than the redaction.** The gate did not
+fail locally. It failed in CI, one commit later, on bytes that had not changed.
+The cause: `tracked_files()` enumerated `git ls-files` only, so a **brand-new,
+not-yet-staged file was invisible to it** — precisely the file class most likely
+to carry a defect. A pre-commit run reported green; the file was staged
+unchanged; CI, scanning a clean checkout where the file *is* tracked, failed on
+it. The local gate had given false assurance at the one moment it was relied on.
+
+`tracked_files()` now enumerates `--cached --others --exclude-standard`, so the
+local answer matches the post-commit answer. In CI the checkout is clean and the
+two enumerations are identical; nothing changes there. The window it closes is
+entirely local, which is where it mattered.

--- a/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/TRANSCRIPTION.md
+++ b/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/TRANSCRIPTION.md
@@ -1,0 +1,60 @@
+# Provenance and limits of this record
+
+## What this is
+
+`arbitration.md` in this directory is the verbatim ruling of the isolated judge
+seat of run `es-v6-publication-panel-2026-08-21`, the fourth and last
+publication review of the v6.0.0 lineage. Subject:
+`48009fef938bfa989fb797380080824b050f3bb4`. Verdict: **NO-GO**.
+
+## How it was produced
+
+A fourteen-agent orchestrated panel: five reviewing seats, a verification stage
+that re-executed each seat's load-bearing claims from primary sources, and a
+final judge seat that authored no seat report and did not build the candidate.
+The judge re-executed the pivotal claims itself rather than adopting any seat's
+word — its ruling says which.
+
+Only the judge's arbitration was retained. The individual seat reports and the
+verification stage outputs were not committed. That is a real retention gap and
+it is stated rather than hidden: an auditor cannot reconstruct how the panel
+reached the judge from this directory alone.
+
+## The structural limit that bounds this verdict
+
+**This panel was dispatched by the implementing lineage** — the same actor that
+authored the candidate under review. It shares a model family with that actor.
+
+The consequence is asymmetric and it is the whole point:
+
+- Its **blocking** findings are credible, and one of them (RG1-01, a false scope
+  statement in `docs/release/RELEASE-6.0.0.md` that concealed two material
+  changes) was found against its own dispatcher's work. A panel that finds a
+  defect its dispatcher would have preferred buried has earned that finding.
+- Its **clearing** power is nil. A GO from a panel the implementer seated would
+  establish nothing the implementer did not already believe. Dispatch controls
+  selection — which verdicts reach the operator at all — and no amount of
+  isolation downstream of dispatch repairs that.
+
+So this run can block a release and cannot clear one. It is recorded on those
+terms. The release record credits it only for its blocking findings.
+
+## Relationship to run 8
+
+Run `es-v6-publication-openai-2026-08-20` was **operator-dispatched** and
+cross-family, and does not carry this limit. It judged an earlier candidate
+(`d0165bd0`). Neither verdict transfers across SHAs; neither is discharged.
+
+## Disposition
+
+Every agent-actionable finding in `arbitration.md` was repaired in the successor
+candidate, in a single commit, because step 7 supersedes the candidate on any
+commit and preparing the repairs piecemeal would have compounded the problem.
+The findings the judge classified as reachable only by the operator were not
+repaired by an agent and are disclosed in the release record instead.
+
+The judge's central ruling — that no owner authority reaches past RG-8, and that
+the ruleset disarm is functionally the authorization act — was accepted, not
+worked around. v6.0.0 ships as an **exception release** under `RELEASING.md`
+§ "Independent judgment gate", with the five required disclosures made before
+tag creation.

--- a/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/arbitration.md
+++ b/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/arbitration.md
@@ -1,0 +1,189 @@
+<!-- Transcribed record. See TRANSCRIPTION.md in this directory for provenance
+     and for the structural limit that bounds what this verdict can establish. -->
+
+# ARBITRATION — v6.0.0 PUBLICATION GATE
+
+**Subject:** `48009fef938bfa989fb797380080824b050f3bb4` (= `origin/main`; merge of PR #206; parents `190e57f7`, `e2610ef1`)
+**Seat:** isolated judge, did not author the candidate, did not produce the seat reports
+**Date:** 2026-08-21
+
+## VERDICT: **NO-GO**
+
+Not CONDITIONAL. The distinction is load-bearing and I want it on the record: CONDITIONAL would imply a set of conditions **this SHA** could come to satisfy. None exists. `RELEASING.md` Procedure step 7 states "No commit may be made between the candidate and the tag. If one is required, the candidate is superseded and steps 4-6 re-run from the top." Every cure identified below requires a commit. Therefore this candidate is not conditionally publishable — it is terminally superseded the moment anyone acts on any finding. NO-GO is the honest verdict shape.
+
+Three independent grounds, any one sufficient:
+
+1. **The candidate's own release record grades three of nine gates unmet** — RG-2 `UNMET`, RG-8 `NO-GO ×2`, RG-9 `UNMET`. I did not have to find this; the candidate says it.
+2. **Two P2 findings survived adversarial refutation**, and RG-8's own text is dispositive: "A conforming release requires `GO` with no unresolved P1 or P2."
+3. **The candidate's own pre-authorization does not fire.** Of its four firing conditions I verified condition 1 satisfied and conditions 2, 3, and 4 unsatisfied. By its own terms: "If any condition fails, this authorization does not fire, and no tag may be created."
+
+No `v6.0.0` tag and no `v6.0.0` Release exist (9 releases, newest `v5.1.0`). Nothing has been published; this is a live pre-publication hold, not a post-hoc erratum.
+
+---
+
+## 1. Facts I re-executed myself
+
+I adopted no seat's word on anything load-bearing. Eleven checks, all from primary sources:
+
+| # | Fact | Method | Result |
+|---|---|---|---|
+| 1 | Candidate identity | `git rev-list --parents`, `git ls-remote` | `48009fef` = `origin/main`, merge of #206, parents `190e57f7`/`e2610ef1`. **No `v6.0.0` tag.** |
+| 2 | RG1-01 scope claim | `git diff --stat 92b3ca6c 48009fef` | **10 files, +690/−124, 10 commits.** Note claims "the **only** change… is this table." **FALSE.** Scoped to `docs/release/`: 2 files, not 1. |
+| 3 | RG1-01 parentage claim | `git rev-parse 48009fef^1 ^2` | Parents are `190e57f7`/`e2610ef1`. `92b3ca6c` is an **ancestor, not a parent**. **FALSE as written.** |
+| 4 | RG1-02 third verdict | `ls`, `git ls-remote` | `es-v6-publication-openai-2026-08-20` **absent from candidate tree**; exists only at `refs/heads/review/v6.0.0-publication-gate-openai-2026-08-20` (`ac0a91e1dc51`), a mutable branch. Read its summary: **NO-GO** on `d0165bd0`, rulings OAI-P1-01/02/03, OAI-P2-01. Lineage table carries **7** rows. |
+| 5 | RG-5 substance | GitHub API `actions/runs?head_sha=48009fef` | **9 runs at the exact candidate.** All five gating workflows dispatched: `epistemic-flexibility` 32430457960 ✓, `release-security` 32430459879 ✓, `openai-bundles` 32430452518 ✓, `commission-watch-contract` 32430465696 ✓, `mission-custody-contract` 32430450479 (run-level red). |
+| 6 | **CodeQL — resolving the seat's UNVERIFIED** | API `commits/48009fef/check-runs` | **`Analyze (python)`, `Analyze (javascript-typescript)`, `Analyze (actions)` — all success at the exact candidate.** No workflow file; runs via GitHub default setup. **RG-5's CodeQL limb is satisfied.** Resolved in the candidate's favor. |
+| 7 | Red-job carve-out | API `runs/32430450479/jobs` | `contract` **success**; `contract-macos` **failure at step 8** "Custody mission lifecycle unit tests". Matches the disclosed carve-out shape. |
+| 8 | **D20's actual effect** | packet diff `92b3ca6c`→`48009fef` | `independent_gauntlet`: `NOT_RUN` → **`GO`**; `blocking_claims`: `["CLM-INDEPENDENT-GAUNTLET"]` → **`[]`**. `readiness` remains `NOT_READY`. |
+| 9 | Pre-authorization authorship | `git log -1 -- docs/release/PRE-AUTHORIZATION-6.0.0.md` | Committed at `e2610ef1` by **`Claude <noreply@anthropic.com>`**, msg "adopt … by operator direction (D23)". Step 7 requires "**the owner** commits the pre-authorization." Names no SHA (compliant on that limb). |
+| 10 | Firing condition 4 | `grep operator_acceptance` packet; `OPERATOR-ACCEPTANCE-PROCEDURE.md:100` | `operator_acceptance` object **ABSENT**. Procedure excludes "acceptance recorded any other way (chat message, commit message, enum…)". |
+| 11 | RG4-01 refutation spot-check | `git cat-file -e v5.0.0:<path>` | `helix/SKILL.md`, `using-epistemic-skills/SKILL.md` **absent at v5.0.0** (14 skills there). The 29 links are **already dead**. Refutation upheld. |
+
+Also confirmed from primary source: `RELEASING.md` step 9 ("Use the committed release-note file **verbatim** as the body"), step 4 ("Any correction creates a new candidate and **invalidates earlier exact-commit evidence**"), and line 238 ("this repository is pushed with the **same credential automation runs under**").
+
+---
+
+## 2. Gate classes — and what an owner exception can actually carry
+
+From `RELEASING.md` lines 43-73, read directly:
+
+- **Integrity gates** (line 47): "version/link alignment, deterministic checks, CodeQL, provenance checks, full-history secret scan, public-content review, and **publication identity assertions**" → **RG-4, RG-5, RG-6, RG-9**. "Do not create a tag while one is failing **or unrecorded**."
+- **Harness-evidence gate** → **RG-7**.
+- **Independent judgment gate** → **RG-8**, and RG-8 alone.
+- **Unclassed by that section** → RG-1, RG-2, RG-3.
+
+**The decisive reading.** The exception mechanism is defined *only* for the judgment gate: "**Exception release:** the owner authorizes publication despite an explicitly named unmet **judgment** gate." There is no defined mechanism by which an owner exception carries an integrity gate, and none by which it carries the unclassed gates either. So:
+
+- **RG-8 (NO-GO) — CARRYABLE.** An owner exception can publish over it. Doing so makes this an exception release; step 6 forbids describing it as a GO or conforming release, and RG-8 requires it stay `WAIVED`/`UNMET`, "never `MET`."
+- **RG-1, RG-2, RG-3, RG-5-as-recorded, RG-9 — NOT CARRYABLE.** Integrity or unclassed; no exception mechanism reaches them.
+
+**Consequence:** even a maximally permissive owner exception does not reach publication at this SHA. The judgment gate is the only door an exception opens, and four other doors are shut. This is the single most important structural finding in the arbitration.
+
+---
+
+## 3. Per-gate disposition — RG-1 … RG-9 at `48009fef`
+
+| Gate | Class | Note's grade | **My disposition** | Basis |
+|---|---|---|---|---|
+| **RG-1** candidate identity & scope | unclassed → not carryable | met | **FAIL** | Bullets 1 and 3 hold (`main` = `origin/main`; path and version named). But the row's scope account is materially false (fact 2/3), and step 9 publishes it verbatim. A row recorded falsely is not "recorded against the exact candidate." |
+| **RG-2** decisions & risk acceptance | unclassed → not carryable | **UNMET** | **FAIL** (self-declared) | `operator_acceptance` absent (fact 10); D8 consult owed. Aggravated by RG4-05: the post-tag install-ref obligation has no owner/trigger/exit anywhere. |
+| **RG-3** evidence retention | unclassed → not carryable | met, "PG-03 now closed" | **FAIL** | The 8th and most load-bearing verdict lives solely on a mutable branch (fact 4). PG-03 reproduces exactly. Gate requires dissent "at immutable coordinates." |
+| **RG-4** version & link alignment | **integrity** | met | **PASS with limits** | Bullet 2 passes: no rewritten version-pinned URL in the candidate tree. RG4-01 refuted to P4. Limits owed in the row: RG4-02, -03, -04, -06 (below). |
+| **RG-5** deterministic & static-analysis | **integrity** | "met at `92b3ca6c`, the parent" | **SUBSTANCE MET / RECORD FAILS** | I verified all five workflows **and all three CodeQL matrices** green at the exact candidate (facts 5-7). But the committed row names superseded `323256xxxxx` runs at an ancestor, and step 4 invalidates them. The facts are good; the record is not. Curable — but only by a commit, which supersedes. |
+| **RG-6** security, public content, provenance | **integrity** | met | **PASS (recorded)** | `full-history-secret-scan` success at candidate. *Limit: I did not re-execute the public-content self-test or the planted-secret control.* |
+| **RG-7** supported harness evidence | harness-evidence | met via tiers | **PASS** | Tiers explicit; no live-fire, disclosed as such rather than implied. Honest. |
+| **RG-8** independent publication judgment | **judgment** | NO-GO ×2 | **FAIL — NO-GO ×3** | Count is wrong: three publication reviews, all NO-GO. No GO exists at `48009fef`. **Carryable by owner exception only.** |
+| **RG-9** publication identity plan | **integrity** | **UNMET** | **FAIL** (self-declared, plus one more) | Authorization line absent. **Additionally:** step 7 requires *the owner* to commit the pre-authorization; it was committed by `Claude` under D23 (fact 9). |
+
+**Score: 3 PASS, 1 PASS-with-limits, 5 FAIL** — of which only RG-8 is exception-carryable.
+
+---
+
+## 4. Ruling on the two authority shortcuts
+
+This is the question the lineage most wants answered yes. I weighed it accordingly and the answer is **no** for both — though not for the reason either seat anticipated, and with real credit given where earned.
+
+### D20 (ratification of `CLM-INDEPENDENT-GAUNTLET`) — **NOT ADEQUATE for the use it is put to**
+
+The claim's `closure_path` reserves closure to an **operator-dispatched** independent Gauntlet. D20 substitutes operator **ratification** of an author-dispatched verdict.
+
+**Why the substitution does not hold.** Dispatch is not ceremony — it controls **selection**: who is asked, what they are asked, on which packet, and above all *whether an unfavorable verdict ever surfaces*. Ratification operates only on the verdicts the implementing lineage chose to present. The rc5 seat's freshness, isolation, and non-authorship satisfy the claim's **oracle**; none of them recovers the **selection** property, and selection is exactly what the dispatch limb protects. The record concedes this in terms and invites the reader to decide — I decide it is not sufficient.
+
+**Aggravating.** The rc5 verdict is scoped **"GO (BUILD freeze only)"** on subject `03e972c5`, now superseded. It was used to flip `independent_gauntlet` to `GO` and **empty `blocking_claims`** (fact 8) — a broader effect than its own scope supports.
+
+**Materially aggravating, and this is my finding rather than any seat's:** that flip occurred **inside the ten-commit window the release note describes as containing "only this table."** So RG1-01 is not cosmetic staleness. The false scope statement conceals — unintentionally, but in the immutable body — the single most consequential state change in the window: a blocking claim emptied on the strength of an authority shortcut. That raises RG1-01's weight above the seat's own framing.
+
+**Credit where due.** `readiness` stayed `NOT_READY`. The `closure_note` records "seat was author-dispatched" rather than laundering it. D22 explicitly denies D20 any publication-authorizing role. A revisit trigger exists. This is honest work, and it is why D20 is *inadequate* rather than *deceptive*.
+
+**Ruling.** Adequate as a disclosed, bounded operator judgment about the assurance contract — **if** the operator's instruction is genuine. **Not** adequate as independent evidence for any gate whose purpose is independence from the lineage. It must not be counted toward RG-8, and the `blocking_claims` flip should be re-examined against the rc5 verdict's actual BUILD-freeze scope.
+
+### D23 (standing session authority) — **NOT ADEQUATE, and structurally uncurable by commit**
+
+**The self-defeating limb — the strongest thing I found.** The pre-authorization *adopted under D23* contains **firing condition 4**, requiring operator acceptance "plus a consent artifact the owner authored or echo-certified," and stating: "**An acceptance in chat, in a commit message, or as an enum flip is not an acceptance.**" D23 is precisely an acceptance in chat. So:
+
+- If D23's amendment **reaches** condition 4, the instrument amends away its own precondition — the sequence is circular and authorizes nothing.
+- If it **does not reach** condition 4, condition 4 is unsatisfied — and I verified `operator_acceptance` is absent from the packet (fact 10), so this branch is not hypothetical.
+
+**Both branches block.** There is no reading on which the authorization fires.
+
+**The structural point that matters most.** `RELEASING.md` line 238 concedes the repository "is pushed with the **same credential automation runs under**." I confirmed the operator's account authors non-merge commits in this very lineage (`d0165bd`, `92b3ca6`). Under a shared credential, **commit authorship cannot establish operator authorship at all.** Therefore D23's stated provenance limit is *not* curable by "the operator commits it under their own account" — such a commit would be byte-indistinguishable from an agent commit. This cuts both ways and I want both recorded:
+
+- Against the lineage: no committed artifact, however solemn, can carry operator authority here. Paper authority in this repository is worth less than these documents assume.
+- For the design: the lineage saw this and built the one control that *does* bind — `protect-version-tags` with `creation` and **no bypass actors**, disarmable only by a repository-settings change. D23 concedes it cannot amend this. That control is real, and it holds. **The entire residual integrity of this release rests on it.**
+
+**Ruling.** **Not adequate** to satisfy RG-2 or RG-9. D23 may stand as a disclosed operator preference governing agent behavior *in session*; it may **not** stand as the acceptance artifact condition 4 requires, nor as the owner's commit under step 7. Its own honesty about its limits is the reason it fails cleanly rather than dangerously.
+
+**On the pre-authorization's condition 2 — and on my own seat.** Condition 2 requires "an **operator-dispatched** independent publication gate returns GO." I was dispatched by the implementing lineage. **Even a GO from me would not have satisfied it.** My seat can block; it cannot clear. I state this asymmetry plainly because it is the most important limit on what this document is worth.
+
+---
+
+## 5. Findings table
+
+| ID | Sev | Gates | Class | Blocks | Disposition |
+|---|---|---|---|---|---|
+| **RG1-01** | **P2** | RG-1, RG-5, RG-8 | **integrity** | **YES** | **UPHELD**, weight *increased*. Scope statement and parentage claim both false (facts 2, 3); step 9 publishes verbatim. Refuter's gate correction to RG-1/RG-5/RG-8 (not RG-4) is right. **My addition:** the denied delta contains the `blocking_claims` emptying and `RELEASING.md` itself (+58) — the governing gate changed inside the window the note calls "only this table." |
+| **RG1-02** | **P2** | RG-1, RG-3, RG-8 | **integrity/unclassed** | **YES** | **UPHELD.** Three publication NO-GOs, not two. The 8th verdict — the only operator-dispatched cross-family one — is on a mutable branch. PG-03 reproduces exactly while the note declares it closed. |
+| RG-2 unmet | **P1-equiv** | RG-2 | unclassed | **YES** | Self-declared. `operator_acceptance` absent; D8 consult owed. Not exception-carryable. |
+| RG-9 unmet | **P1-equiv** | RG-9 | **integrity** | **YES** | Self-declared, **plus** the owner-commit defect at fact 9. |
+| RG-8 NO-GO | **P1-equiv** | RG-8 | **judgment** | **YES** | The only blocker an owner exception can carry. |
+| **RG4-01** | **P4** | RG-4 | integrity | no | **REFUTED — refutation upheld** on my own check (fact 11). Mints 0 new dead links; repairs 8. Residual kernel preserved below. |
+| RG1-03 | P3 | RG-1 | — | no | Dispatch packet off-tree; its step-0 tripwire destroyed by SHA substitution. Corroborates RG1-01. |
+| RG4-02 | P3 | RG-4 | integrity | no | **Independently confirmed:** selector matches **0** lines; `router` appears **0** times in README. Check dead since v5.0.0. Surface currently correct → durability defect. Belongs in RG-4's **limits** column, not "met". |
+| RG4-03 | P3 | RG-4 | integrity | no | PG-15 fixed in content, no oracle added. Recurrence silent. |
+| RG4-04 | P3 | RG-4 | integrity | no | 26 pre-existing v5.0.0-pinned dead URLs; outside bullet 2's "rewritten" scope. |
+| RG4-05 | P3 | RG-4, RG-2 | integrity | no | Post-tag install-ref obligation has no owner/trigger/exit. **Should be an RG-2 accepted gap before tagging.** |
+| RG4-06 | P4 | RG-4 | integrity | no | 4 of 15 skills unnamed in manifest descriptions; pre-existing. |
+
+---
+
+## 6. Preserved dissents
+
+Recorded, not resolved away:
+
+1. **RG-4 seat vs. refuter on RG4-01.** The seat graded the blind bump **P2/blocking**; the refuter reduced it to **P4**. I side with the refuter on my own evidence — but the seat's kernel survives and I preserve it: `apply_v6_updates.py` has **no path-existence check and no tag-existence guard**, so it carries 29 pre-existing 404s forward under a new tag instead of surfacing them, and **3 of the 10 affected pages** fall outside its own retired-seat advisory, so nothing in the package names them. The seat's stated de-escalation condition was in fact already satisfied by a committed RG-2 record the seat did not engage. The seat's `x9` breakdown was arithmetically wrong (6 paths / 14 occurrences); headline numbers were right.
+2. **RG-5 seat's dissent that the substance is sound.** Upheld and independently reproduced. This is why RG-5 is a *record* failure, not an artifact failure — and why the cure is cheap in work and expensive only in candidate identity.
+3. **The RG-1/RG-4 seat expressly declined to rule D20/D23** ("that judgment belongs to the RG-2/RG-8/RG-9 seats; I record it, I do not rule it"). That deferral was correct seat discipline. I have now ruled it in §4; the seat's abstention is preserved as the reason the question reached me undecided.
+4. **Seat UNVERIFIED items I resolved.** CodeQL — resolved **in the candidate's favor** (fact 6): all three matrices green at the exact candidate. The seat was right not to assert it absent.
+5. **Items I could not resolve and do not assert either way:** operator authorship of D20/D23 beyond the lineage's transcription (structurally unresolvable — §4); the future annotated tag object's contents (cannot exist pre-tag by design); ruleset protection on the two lightweight `pin/` tags; live harness install behavior; the public-content self-test and planted-secret control, which I did not re-execute.
+
+---
+
+## 7. Independence statement
+
+Stated plainly, because this document is worth exactly what these limits allow:
+
+- **I share a model family with the candidate's authors.** Every substantive commit in the disputed delta is authored by `Claude <noreply@anthropic.com>`; I am Claude. My verdict carries the same family-correlation limit the note's own RG-8 row records for five of the seven prior reviews. It is a limit, not independence.
+- **I was dispatched by the implementing lineage, not by the operator.** The pre-authorization's firing condition 2 requires an operator-dispatched gate. **My verdict cannot satisfy it.** A NO-GO from me still holds (a hold needs no authority it lacks); a GO from me would have been worthless for firing the authorization. My seat can block but cannot clear.
+- **I refuse any implementer-authored GO,** and I did not accept one. No seat's recommendation was adopted; every load-bearing fact in §1 was re-executed from primary sources. Where the evidence favored the candidate (CodeQL, RG-5 substance, RG4-01) I said so.
+- **I did not author the candidate** and **did not produce the seat reports.**
+- **I performed no writes.** No merge, tag, Release, ruleset change, packet mutation, operator acceptance, branch push, or publication authorization. I created one read-only detached worktree under my scratchpad and made read-only GitHub API calls.
+- **This verdict judges `48009fef` only.** It does not transfer to any successor candidate.
+
+---
+
+## 8. Next actions
+
+### OPERATOR-ONLY — cannot be delegated to any agent
+
+1. **Settle D20/D23 through a channel the lineage does not control.** Per §4, a commit will *not* settle it: the credential is shared, so an operator-authored commit is indistinguishable from an agent one. Use a channel that is: the GitHub Release/issue UI under your own session, or simply treat the ruleset disarm as the authorization act — which is what the design already concedes it is.
+2. **Dispatch the independent publication gate yourself** at the successor candidate. Firing condition 2 requires operator dispatch. **No agent can supply this, including me.**
+3. **Record operator acceptance** in the form `OPERATOR-ACCEPTANCE-PROCEDURE.md` defines (the `operator_acceptance` object **plus** an authored-or-echo-certified consent artifact) — **or** amend that procedure explicitly under your own hand if you intend chat to suffice. Do not leave the circularity in §4 unresolved; it currently blocks on both branches.
+4. **Run or explicitly waive the D8 Step-7b cross-family consult**, with scope, revisit trigger, and exit criterion.
+5. **Decide the two RG-2 gaps:** the wiki hand-off (with the RG4-01 kernel disclosed) and the post-tag install-ref advance (RG4-05).
+6. **The tag act:** disarm `protect-version-tags`, tag, re-arm in the same sitting, verify with a seeded probe. Not delegable — and per §4 this is now the *only* control carrying real weight.
+
+### AGENT-MAY-PREPARE — **all of these supersede the candidate; batch into exactly ONE successor**
+
+Step 7 supersedes the candidate on any commit, so preparing these piecemeal is the one way to make this worse. One commit, one new candidate, one full re-run of steps 4-6.
+
+1. **Rewrite the RG-5 row** to name the verified candidate runs — `epistemic-flexibility` 32430457960, `release-security` 32430459879, `openai-bundles` 32430452518, `commission-watch-contract` 32430465696, `mission-custody-contract` 32430450479 (`contract` green, `contract-macos` step 8) — and record the three CodeQL matrices. **Delete** the "only change … is this table" paragraph and the "the parent of this commit" phrase (RG1-01).
+2. **Correct the publication-review count to three**, name the openai NO-GO, and add it to `V6-VERDICT-LINEAGE.md` (RG1-02).
+3. **Commit the openai verdict artifacts in-tree.** Note the distinction that makes this permissible now: step 5 defers verdict artifacts until after the tag because *a tree cannot contain a judgment of itself* — but this verdict judges `d0165bd0`, a **superseded** candidate. It is historical evidence, not self-judgment. Committing it is the genuine PG-03 cure.
+4. **Close the RG-4 durability gaps:** add a non-vacuity control to the mermaid check mirroring PG-07's `require(seen_refs >= 1, …)`; add an oracle for the marketplace "full collection" enumeration; add `--check-paths` and a tag-existence guard to `apply_v6_updates.py`.
+5. **Record RG4-05** as a bounded RG-2 accepted gap with owner, revisit trigger, and exit criterion.
+6. **Move the RG-4 limits into the RG-4 row** rather than grading it flatly "met."
+7. **Draft — do not adopt —** a pre-authorization for the successor. The current one names #206 and expires with it.
+
+---
+
+**Bottom line.** The *artifact* is in better shape than the *record of the artifact*. I verified that requalification genuinely happened at this exact commit, CodeQL included — the engineering holds. What fails is the paperwork that must become immutable, and the authority chain beneath it. Two of the three publication gates this project has run said the same thing in different words; this is the third, and it agrees. The lineage built the one control that binds regardless of what any document claims — the tag ruleset with no bypass actors — and that control is why a NO-GO here is a hold rather than an emergency.

--- a/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/arbitration.md
+++ b/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/arbitration.md
@@ -35,7 +35,7 @@ I adopted no seat's word on anything load-bearing. Eleven checks, all from prima
 | 6 | **CodeQL — resolving the seat's UNVERIFIED** | API `commits/48009fef/check-runs` | **`Analyze (python)`, `Analyze (javascript-typescript)`, `Analyze (actions)` — all success at the exact candidate.** No workflow file; runs via GitHub default setup. **RG-5's CodeQL limb is satisfied.** Resolved in the candidate's favor. |
 | 7 | Red-job carve-out | API `runs/32430450479/jobs` | `contract` **success**; `contract-macos` **failure at step 8** "Custody mission lifecycle unit tests". Matches the disclosed carve-out shape. |
 | 8 | **D20's actual effect** | packet diff `92b3ca6c`→`48009fef` | `independent_gauntlet`: `NOT_RUN` → **`GO`**; `blocking_claims`: `["CLM-INDEPENDENT-GAUNTLET"]` → **`[]`**. `readiness` remains `NOT_READY`. |
-| 9 | Pre-authorization authorship | `git log -1 -- docs/release/PRE-AUTHORIZATION-6.0.0.md` | Committed at `e2610ef1` by **`Claude <noreply@anthropic.com>`**, msg "adopt … by operator direction (D23)". Step 7 requires "**the owner** commits the pre-authorization." Names no SHA (compliant on that limb). |
+| 9 | Pre-authorization authorship | `git log -1 -- docs/release/PRE-AUTHORIZATION-6.0.0.md` | Committed at `e2610ef1` by **`Claude <noreply-address-redacted>`**, msg "adopt … by operator direction (D23)". Step 7 requires "**the owner** commits the pre-authorization." Names no SHA (compliant on that limb). |
 | 10 | Firing condition 4 | `grep operator_acceptance` packet; `OPERATOR-ACCEPTANCE-PROCEDURE.md:100` | `operator_acceptance` object **ABSENT**. Procedure excludes "acceptance recorded any other way (chat message, commit message, enum…)". |
 | 11 | RG4-01 refutation spot-check | `git cat-file -e v5.0.0:<path>` | `helix/SKILL.md`, `using-epistemic-skills/SKILL.md` **absent at v5.0.0** (14 skills there). The 29 links are **already dead**. Refutation upheld. |
 
@@ -152,7 +152,7 @@ Recorded, not resolved away:
 
 Stated plainly, because this document is worth exactly what these limits allow:
 
-- **I share a model family with the candidate's authors.** Every substantive commit in the disputed delta is authored by `Claude <noreply@anthropic.com>`; I am Claude. My verdict carries the same family-correlation limit the note's own RG-8 row records for five of the seven prior reviews. It is a limit, not independence.
+- **I share a model family with the candidate's authors.** Every substantive commit in the disputed delta is authored by `Claude <noreply-address-redacted>`; I am Claude. My verdict carries the same family-correlation limit the note's own RG-8 row records for five of the seven prior reviews. It is a limit, not independence.
 - **I was dispatched by the implementing lineage, not by the operator.** The pre-authorization's firing condition 2 requires an operator-dispatched gate. **My verdict cannot satisfy it.** A NO-GO from me still holds (a hold needs no authority it lacks); a GO from me would have been worthless for firing the authorization. My seat can block but cannot clear.
 - **I refuse any implementer-authored GO,** and I did not accept one. No seat's recommendation was adopted; every load-bearing fact in §1 was re-executed from primary sources. Where the evidence favored the candidate (CodeQL, RG-5 substance, RG4-01) I said so.
 - **I did not author the candidate** and **did not produce the seat reports.**

--- a/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/run-record.json
+++ b/docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/run-record.json
@@ -1,0 +1,25 @@
+{
+  "run_id": "es-v6-publication-panel-2026-08-21",
+  "subject_sha": "48009fef938bfa989fb797380080824b050f3bb4",
+  "scope": "publication act (RG-1..RG-9)",
+  "verdict": "NO_GO",
+  "date": "2026-08-21",
+  "seat_family": "same-family",
+  "dispatched_by": "implementing-lineage",
+  "structure": {
+    "reviewing_seats": 5,
+    "verification_stage": true,
+    "judge": "isolated; authored no seat report and did not build the candidate"
+  },
+  "retention": {
+    "arbitration": "arbitration.md",
+    "seat_reports": "NOT RETAINED",
+    "verification_outputs": "NOT RETAINED"
+  },
+  "limits": [
+    "Implementer-dispatched: can block a release, cannot clear one.",
+    "Same model family as the candidate's authors.",
+    "Seat-level artifacts not retained; the judge's ruling is the only committed output."
+  ],
+  "authorizes": null
+}

--- a/docs/release/PRE-AUTHORIZATION-6.0.0.md
+++ b/docs/release/PRE-AUTHORIZATION-6.0.0.md
@@ -1,55 +1,77 @@
-# Pre-authorization — v6.0.0
+# Pre-authorization — v6.0.0 (exception release)
 
-**STATUS: ADOPTED** — by operator direction under D23, transcribed by the
-implementing lineage.
+**STATUS: ADOPTED** — by operator direction under **D24**, transcribed by the
+implementing lineage. This edition **supersedes** the edition that named pull
+request #206; that candidate is superseded and its authorization expired with it.
 
-> The repository owner (GitHub login `SternOne`) pre-authorizes publication of
-> v6.0.0 on the terms in this document: the commit produced by merging pull
-> request **#206**, and only that commit, if and only if every condition in
-> "The firing condition" holds.
+> The repository owner pre-authorizes publication of v6.0.0 on the terms in this
+> document: the commit produced by merging the pull request named below, and only
+> that commit, if and only if every condition in "The firing condition" holds.
+>
+> This is an **exception release** under `RELEASING.md` § "Independent judgment
+> gate". The owner has read four NO-GO verdicts and elected to publish anyway.
 
 **Provenance — read this before relying on the adoption.** This block was
 written and committed by the implementing lineage on the operator's session
-instruction, recorded verbatim as **D23** in
-`docs/v6/operator-decision-record-2026-08-20.md`. It is **not** a commit
-authored by the operator's own account. The earlier edition of this file
-required that, and the operator amended the requirement — which they may do,
-since both governing documents are repo-authored and the acceptance procedure
-says so in terms.
+instruction, recorded verbatim as **D24** in
+`docs/v6/operator-decision-record-2026-08-20.md`. It is **not** a commit authored
+by the operator's own account, and — because this repository is pushed with the
+same credential its automation runs under — it could not be made
+byte-distinguishable from one even if it claimed to be. Nothing in this file
+asserts the operator typed these bytes.
 
-An auditor who considers session-directed adoption insufficient should treat
-this authorization as carrying that limit, and say so rather than assuming a
-signature that is not here. Nothing in this file asserts the operator typed
-these bytes.
+The one act that cannot be transcribed is the disarm. See "Why the disarm is the
+authorization" below.
 
 ## Why this document exists before the candidate does
 
 `RELEASING.md` step 7 once required a committed line naming the candidate's own
 SHA. Writing that line changed the tree and produced a different SHA, so the
 exact-commit checks and the independent verdict described a commit that was no
-longer the candidate. The sequence was not executable as written.
+longer the candidate. The sequence was not executable as written; an
+operator-dispatched cross-family review found it.
 
 The cure, adopted 2026-08-20: **nothing that binds a SHA is written after that
 SHA exists.** Authorization moves *before* the candidate, where it names a
-determinate act rather than a hash; the resolved SHA is carried afterwards by
-the annotated tag object, which names its target without altering it.
+determinate act rather than a hash; the resolved SHA is carried afterwards by the
+annotated tag object, which names its target without altering it.
+
+## Why the disarm *is* the authorization
+
+The `protect-version-tags` ruleset carries `creation` with **no bypass actors**.
+No actor can create `refs/tags/v*` while it is armed — not automation, not an
+admin, not the owner. That was deliberate: with a shared push credential, an
+admin bypass would have exempted exactly the actors the rule exists to constrain.
+
+The consequence, which the fourth review stated and this document accepts rather
+than works around: **every other artifact of authorization in this repository is
+forgeable by the implementing lineage, and the ruleset change is not.** A
+decision record can be transcribed. A commit trailer can be written. A pre-
+authorization can be adopted by direction. None of them requires the operator's
+hands. Disarming a repository ruleset requires settings access no agent in this
+environment holds.
+
+So the disarm is not a step *before* the authorization. It is the authorization,
+in the only form this repository can make unforgeable. This file fixes what the
+disarm will mean; the operator's hand supplies that it happened.
 
 ## What is being authorized
 
 | Field | Value |
 |---|---|
 | Version | **6.0.0** |
-| Pull request to be merged | **#206** |
+| Pull request to be merged | **the v6.0.0 final release PR opened from `release/v6.0.0-final`** |
 | Merge method | **merge commit** (not squash — a squash attributes the commit to the merger, making any sign-off trailer a false attestation) |
-| Candidate | the commit produced by merging #206, and no other commit |
+| Candidate | the commit produced by that merge, and no other commit |
 | Release-note path | `docs/release/RELEASE-6.0.0.md` |
 | Tag | `v6.0.0`, annotated, on that candidate |
 | Release | non-draft, body verbatim from the release note, targeting that tag |
+| Release class | **exception release** — the notes must say so; they must never say "conforming" |
 
 ## The firing condition
 
-This authorization fires **if and only if all** of the following hold against
-the commit produced by merging #206:
+This authorization fires **if and only if all** of the following hold against the
+commit produced by that merge:
 
 1. **All five gating workflows run at that exact commit and report the expected
    conclusions** — `epistemic-flexibility`, `release-security`, `openai-bundles`,
@@ -57,42 +79,69 @@ the commit produced by merging #206:
    explicitly dispatched; path-filtered workflows do not fire on a docs-only
    diff, and a missing run is not a passing run.
    - `mission-custody-contract` is expected **red at job level**: its
-     dispatch-only `contract-macos` probe fails on case-insensitive filesystems
-     (`KL-MACOS-162`). Its required `contract` job must be green. Any other
-     failure voids this condition.
-2. **An operator-dispatched independent publication gate returns GO** against
-   that exact commit. A verdict against any other SHA does not transfer.
-3. **The D8 Step-7b cross-family consult is run** at GO posture, or explicitly
-   waived in writing by the owner with scope, revisit trigger and exit criterion.
-4. **Operator acceptance is recorded** in the form
-   `docs/v6/OPERATOR-ACCEPTANCE-PROCEDURE.md` defines — the `operator_acceptance`
-   object plus a consent artifact the owner authored or echo-certified. An
-   acceptance in chat, in a commit message, or as an enum flip is not an
-   acceptance.
+     dispatch-only `contract-macos` probe fails at step 8, on the tests
+     `distinct-real-file-untouched` and `distinct-both-files-tracked-separately`,
+     because macOS default volumes fold `straße.txt` and `strasse.txt` to one
+     physical file under full Unicode case folding (`KL-MACOS-162`).
+     Its required `contract` job must be green across all 12 steps. **Any other
+     failure, in any job, voids this condition.**
+2. **The release note carries the exception block** — all five disclosures
+   `RELEASING.md` § "Independent judgment gate" requires, present in the
+   committed file *before* the tag is created, and the release described as an
+   exception release rather than a conforming one.
+3. **Every integrity gate is met on its own terms.** RG-1 accuracy, RG-4
+   alignment, RG-5 evidence, RG-6 security and provenance. **D24 does not reach
+   these and cannot waive them.** If any integrity finding is open at the
+   candidate, this authorization does not fire, regardless of the owner's wish to
+   ship.
+4. **The D8 cross-family consult is recorded as owed and carried forward** to
+   6.1.0, with scope, revisit trigger and exit criterion, in both the release
+   note and the decision record. It is *not* discharged by this release and this
+   condition does not pretend otherwise — it requires the debt to be visible, not
+   paid.
 
-If any condition fails, this authorization does not fire, and no tag may be
+If any condition fails, this authorization does not fire and no tag may be
 created. Fix forward, mint a new candidate, and a fresh pre-authorization is
-required for it — this one names #206 and expires with it.
+required for it — this one names one pull request and expires with it.
+
+### What changed from the superseded edition, and why
+
+The prior edition's conditions 2 and 4 required an **operator-dispatched GO** and
+an **operator acceptance object plus consent artifact**. Neither can be satisfied
+on this lineage: four gates have returned NO-GO and none will return GO, and the
+acceptance procedure's own text ("an acceptance in chat is not an acceptance")
+made the second condition unsatisfiable by the only channel available. Together
+they made the prior edition circular — it could not fire on either branch.
+
+They are not quietly relaxed here. They are **replaced by an exception the
+release documents state in full**, which is the path `RELEASING.md` already
+provides for exactly this situation. The difference between relaxing a condition
+and invoking a documented exception is that the exception leaves a record saying
+what was not done. That record is conditions 2 and 4 above.
 
 ## What it does not authorize
 
-Any commit other than the merge of #206. Any version other than 6.0.0. Moving or
-reusing a tag. Altering `protect-version-tags` beyond the disarm/re-arm of the
-tag act itself. Publishing on a CONDITIONAL or NO-GO verdict. Substituting the
-implementing lineage's judgment for the independent gate's.
+Any commit other than the merge of the named pull request. Any version other than
+6.0.0. Moving or reusing a tag. Altering `protect-version-tags` beyond the
+disarm/re-arm of the tag act itself, or leaving it disarmed past the sitting.
+Describing the result as a conforming release, or the NO-GO verdicts as
+superseded, discharged, or resolved. Waiving any integrity gate. Publishing
+6.1.0 under a second RG-8 exception without first discharging D8.
 
 ## The owner still holds the stop
 
 This is an authorization of a conditional act, not a pre-commitment to publish.
 The owner performs the tag act personally, and it is revocable up to the moment
-of the push: an owner who reads the verdict and dislikes it simply does not
-disarm the ruleset. That is the whole of the trade this design makes, and it is
-stated here rather than buried.
+of the push: an owner who changes their mind simply does not disarm the ruleset.
+That is the whole of the trade this design makes, and it is stated here rather
+than buried.
 
 ---
 
 ## Superseding this adoption
 
 The operator may replace the status block above with one committed under their
-own account at any time. That would strengthen the provenance without changing
-any term, and no act taken under this adoption needs to be undone for it.
+own account at any time. Given the shared-credential concession stated above,
+that would change the provenance narrative but not the cryptographic facts, and
+no act taken under this adoption needs to be undone for it. The disarm remains
+the load-bearing act either way.

--- a/docs/release/PRE-AUTHORIZATION-6.0.0.md
+++ b/docs/release/PRE-AUTHORIZATION-6.0.0.md
@@ -60,7 +60,7 @@ disarm will mean; the operator's hand supplies that it happened.
 | Field | Value |
 |---|---|
 | Version | **6.0.0** |
-| Pull request to be merged | **the v6.0.0 final release PR opened from `release/v6.0.0-final`** |
+| Pull request to be merged | **#207**, the v6.0.0 final release PR from `release/v6.0.0-final` |
 | Merge method | **merge commit** (not squash — a squash attributes the commit to the merger, making any sign-off trailer a false attestation) |
 | Candidate | the commit produced by that merge, and no other commit |
 | Release-note path | `docs/release/RELEASE-6.0.0.md` |
@@ -102,7 +102,7 @@ commit produced by that merge:
 
 If any condition fails, this authorization does not fire and no tag may be
 created. Fix forward, mint a new candidate, and a fresh pre-authorization is
-required for it — this one names one pull request and expires with it.
+required for it — this one names **#207** and expires with it.
 
 ### What changed from the superseded edition, and why
 
@@ -121,7 +121,7 @@ what was not done. That record is conditions 2 and 4 above.
 
 ## What it does not authorize
 
-Any commit other than the merge of the named pull request. Any version other than
+Any commit other than the merge of **#207**. Any version other than
 6.0.0. Moving or reusing a tag. Altering `protect-version-tags` beyond the
 disarm/re-arm of the tag act itself, or leaving it disarmed past the sitting.
 Describing the result as a conforming release, or the NO-GO verdicts as

--- a/docs/release/RELEASE-6.0.0.md
+++ b/docs/release/RELEASE-6.0.0.md
@@ -8,8 +8,10 @@ evidence set. Supersedes `v5.1.0`.
 `546ccc8e55eb060379d62198310145f7243ac7bd`; both are ancestors of the release
 branch and are pinned by `pin/es-v6-rc5-candidate-2026-08-19` and
 `pin/es-v6-rc5-freeze-2026-08-19`. The release candidate is the commit produced
-by merging this release branch, and the publication gate runs against that
-commit — not against this file's description of it.
+by merging this release branch. The integrity gates run against that commit —
+not against this file's description of it. The **publication gate does not**: it
+ran four times, on four earlier candidates, and returned NO-GO every time. See
+the exception block below before reading anything here as an approval.
 
 ## Why 6.0.0
 
@@ -67,34 +69,90 @@ table** — the commit produced by merging the release pull request, per
 `RELEASING.md` Procedure step 4. Every other coordinate below is written in hex
 because it is resolvable in advance.
 
-**Why this file's evidence names its own parent.** Procedure step 4 makes the
-merge commit the candidate and says any correction mints a new one, so a table of
-exact-commit evidence can never sit *in* the commit it describes. The v5.1.0
-precedent resolves this by keeping the delta enumerable: the runs above were
-dispatched at `92b3ca6c`, and the **only** change between that commit and the one
-carrying this table is this table. `git diff 92b3ca6c..HEAD -- docs/release/`
-shows the whole of it. A delta-scoped re-check, not a full requalification, is
-what that difference warrants.
+**Why this file names no run IDs.** Procedure step 4 makes the merge commit the
+candidate and says any correction mints a new one, so a table of exact-commit
+evidence can never sit *in* the commit it describes.
 
-**Authorization — NOT YET GIVEN.** `RELEASING.md` step 7 requires a line naming
-the verdict read, the exact candidate SHA authorized, and the owner. That line is
-the owner's to write and does not exist yet. Until it does, this file is a
-release *preparation* record, not an authorization, and nothing here may be read
-as one. The two publication reviews on record both returned NO-GO
-(§ Provenance); a conforming publication requires a fresh gate at the final
-candidate.
+An earlier draft of this file tried to escape that with a delta-enumerability
+argument — it claimed the *only* change between the commit the runs were
+dispatched at and the commit carrying the table was the table itself. **That
+statement was false**, and an independent panel proved it false: at
+`48009fef938bfa989fb797380080824b050f3bb4` the delta from `92b3ca6c` was ten
+files, +690/-124, across ten commits, and it silently included the emptying of
+`blocking_claims` and an amendment to `RELEASING.md` — the two changes a reader
+scoping a re-check would most need to see. The device did not merely overstate;
+it concealed. It is recorded here as publication-gate finding **RG1-01**, and it
+is retired rather than repaired: no release note in this repository may again
+assert its own delta.
+
+What replaces it is step 4's own rule. Exact-SHA run IDs are **post-candidate
+facts**, and they go in the annotated tag object, which names its target without
+altering it. This table therefore states which gates were run and what tier of
+evidence exists; the tag message states the run IDs, at the SHA they actually
+judge. If you are auditing this release, read the tag message for the numbers.
+
+> ## This is an EXCEPTION RELEASE, not a conforming release
+>
+> `RELEASING.md` § "Independent judgment gate" defines two outcomes. A
+> **conforming release** carries a recorded `GO` from an independent publication
+> gate on the exact candidate. **6.0.0 does not have one and will not get one.**
+> Four independent publication reviews were run across three model families and
+> every one returned **NO-GO** (§ Provenance). The owner has elected to publish
+> anyway, under the exception the same section provides.
+>
+> The five disclosures that section requires **before tag creation**:
+>
+> 1. **The gate did not reach GO.** It was run — four times — and returned NO-GO
+>    four times. This is not an unrun gate; it is an overridden one.
+> 2. **No GO exists.** Not at this candidate, not at any candidate in the v6
+>    lineage. No later review can manufacture one: a post-release review adds
+>    judgment evidence and cannot convert this into a conforming release.
+> 3. **Owner, date, scope, authorization.** Owner: the repository owner,
+>    2026-08-21, recorded as decision **D24** in
+>    `docs/v6/operator-decision-record-2026-08-20.md` with the instruction
+>    quoted verbatim and its provenance stated. Scope: the `v6.0.0` tag and
+>    GitHub Release only. It does not reach any integrity gate — see below.
+> 4. **What evidence remains, and what it cannot establish.** The artifact
+>    itself is well evidenced. Of **31 class claims**: 21 PROVED, 8 LIMITED
+>    within stated bounds, 2 PARTIAL, and **none UNPROVED** — counted from
+>    `docs/v6/ES6-V6-CANDIDATE/claim-to-proof-matrix.json`, whose other 41 rows
+>    are an open-issue census and are not claims about this artifact. The five
+>    gating workflows must be green at the exact candidate before this
+>    authorization fires (pre-authorization condition 1, which states the one
+>    expected job-level red and its failing tests by name); the full-history
+>    secret scan and public-content review are green with planted controls; the
+>    sealed source inventory verifies. What none of that
+>    establishes is the thing the judgment gate exists to establish: that an
+>    actor which did not build this release thinks it should be published. Every
+>    NO-GO was about the *publication act* and its paperwork, not about the
+>    skills. The reader should trust the artifact and discount the ceremony
+>    accordingly.
+> 5. **Successor condition / revisit trigger.** The standing **D8 cross-family
+>    consult** is owed and undischarged; it carries forward to 6.1.0 as a
+>    blocking obligation, not as a nicety. If any of the four NO-GO findings is
+>    later shown to have named a defect in the *artifact* rather than in the
+>    release process, that is an immediate erratum-and-patch trigger under step
+>    11.
+>
+> **The exception reaches exactly one gate.** `RELEASING.md` scopes owner
+> exceptions to the independent judgment gate (RG-8). It does **not** reach the
+> integrity gates — RG-1 accuracy, RG-4 alignment, RG-5 deterministic evidence,
+> RG-6 security and provenance — and no authority in this repository waives
+> those. Every one of them is met on its own terms below. A release note that
+> lied would still be a lie with an owner's signature on it; that is why RG1-01
+> was fixed rather than waived.
 
 | Item | Status | Evidence |
 |---|---|---|
 | 1 — candidate identity and scope | **met** | Freeze candidate `03e972c5d427238033cb90d66846adabaf11928d`, packet commit `546ccc8e55eb060379d62198310145f7243ac7bd`, both ancestors of this branch and pinned by `pin/es-v6-rc5-candidate-2026-08-19` / `pin/es-v6-rc5-freeze-2026-08-19` (lightweight — see PG-17 below). The release candidate is the merge commit of this branch. |
-| 2 — release decisions and risk acceptance | **UNMET** | Operator acceptance under `docs/v6/OPERATOR-ACCEPTANCE-PROCEDURE.md` has not been recorded, and the packet carries no `operator_acceptance` object. The standing D8 cross-family consult is owed and not discharged. Both were ruled blocking by the publication panels. |
-| 3 — evidence retention | **met** | All seven verdicts of this lineage are in-tree under `docs/gauntlet-runs/` with an index at `docs/gauntlet-runs/V6-VERDICT-LINEAGE.md` binding each to its exact subject commit. Previously they lived only on mutable branches while this file asserted otherwise — publication-gate finding PG-03, now closed. |
-| 4 — version and link alignment | **met, after two stalenesses were found and fixed** | Ten version-bearing surfaces at 6.0.0; surface-sync `--check` green (15 skills / 14 disciplines). Fixed since the first candidate: `.kimi-plugin/marketplace.json` had pinned `tree/v3.4.0` for three major versions and was the one manifest no oracle read (PG-07); the README advertised `v6.0.0` as a published support point behind links that returned 404 (PG-18). Both marketplace "full collection" descriptions enumerated fourteen of fifteen skills, omitting `manifest` (PG-15). A new install-ref oracle now fails on any manifest ref that is not the current install pin, with a control asserting it is not vacuous. |
-| 5 — deterministic and static-analysis evidence | **met at `92b3ca6c`, the parent of this commit** | All five gating workflows dispatched at `92b3ca6cf7009cb668146b526e3b35012f7454a6`: `epistemic-flexibility` **32325697974** success; `release-security` **32325699859** success; `openai-bundles` **32325701579** success; `commission-watch-contract` **32325704803** success; `mission-custody-contract` **32325702964** — required job `contract` **success** (all 12 steps), dispatch-only probe job `contract-macos` **failure**, see the RG-5(c) disclosure below. Earlier evidence at the freeze candidate `03e972c5` is superseded and does not transfer. |
+| 2 — release decisions and risk acceptance | **met as an exception, with one bounded gap** | Operator acceptance is recorded as **D24** (2026-08-21) in `docs/v6/operator-decision-record-2026-08-20.md`, electing the RG-8 exception with the five required disclosures made above *before* tag creation. The packet still carries no `operator_acceptance` object and still reads `NOT_READY`: that field tracks *conforming* readiness, and an exception release does not make a packet ready. Leaving it `NOT_READY` is the honest state, not an oversight. **Bounded gap RG4-05:** the D8 cross-family consult is owed and undischarged; it is disclosed above as the successor-release condition and is the one RG-2 obligation this release does not satisfy. |
+| 3 — evidence retention | **met** | All **nine** verdicts of this lineage — the five BUILD panels and the four publication reviews — are in-tree under `docs/gauntlet-runs/` with an index at `docs/gauntlet-runs/V6-VERDICT-LINEAGE.md` binding each to its exact subject commit. Previously they lived only on mutable branches while this file asserted otherwise — publication-gate finding PG-03, now closed. |
+| 4 — version and link alignment | **met, with its limits stated in-row** | Ten version-bearing surfaces at 6.0.0; surface-sync `--check` green (15 skills / 14 disciplines). Fixed since the first candidate: `.kimi-plugin/marketplace.json` had pinned `tree/v3.4.0` for three major versions and was the one manifest no oracle read (PG-07); the README advertised `v6.0.0` as a published support point behind links that returned 404 (PG-18). Both marketplace "full collection" descriptions enumerated fourteen of fifteen skills, omitting `manifest` (PG-15) — an oracle added this cycle now derives the expected set from `plugins/epistemic-skills/skills/` and fails on any omission or invention, so the defect class cannot recur silently. **Limits, stated here rather than in a footnote:** (a) the install-ref pin reads `v5.1.0` in the tagged tree, because at tag time 5.1.0 is still the published support point — the bump is a post-tag commit and is not a version-surface staleness; (b) the wiki is a separate repository that no in-repo oracle can reach, so its alignment is asserted only by `docs/wiki-updates/v6.0.0/apply_v6_updates.py`, which is dry-run-by-default, self-tested, and now refuses to run against a path that does not look like a wiki clone or whose target tag does not yet exist. |
+| 5 — deterministic and static-analysis evidence | **run at the candidate; the IDs are in the tag object, not here** | Per `RELEASING.md` step 4, exact-SHA run IDs are post-candidate facts and are recorded in the annotated tag message, which names its target without altering it. This row states the discipline and the tier: **all five gating workflows dispatched explicitly** at the candidate (path-filtered workflows do not fire on a docs-only diff, so push-triggered runs are not accepted as evidence), plus the required CodeQL matrices — which run under GitHub **default setup** and therefore have no workflow file in `.github/workflows/` and do not appear in the Actions workflow-run listing used to gather the rest of this evidence. Their status is read from the candidate's check runs and recorded in the tag object with the workflow IDs; a reader who greps this repository for a CodeQL workflow and finds none has found the default setup, not a missing gate. Four workflows must be `success`; `mission-custody-contract` must show its required `contract` job `success` with only the dispatch-only `contract-macos` probe red, disclosed by failing test name under RG-5(c). **Lineage, not this commit's evidence:** the last complete dispatch was at the superseded candidate `48009fef938bfa989fb797380080824b050f3bb4` — `epistemic-flexibility` 32430457960, `release-security` 32430459879, `openai-bundles` 32430452518, `commission-watch-contract` 32430465696 all success; `mission-custody-contract` 32430450479 with `contract` (ubuntu-24.04) success across all 12 steps and `contract-macos` failed at step 8. That evidence judges `48009fef` and **does not transfer** to this candidate. |
 | 6 — security, public content, provenance | **met** | `check_public_content.py` self-test (8 seeded RED controls, one per pattern) and live run both exit 0; the exact-file allowlist narrowed by one entry when the exemption's reason was remediated rather than renewed. Full-history secret scan green with its planted positive control and the record-path narrowness control. Provenance: `CONTRIBUTING.md` now states the DCO rule actually enforced, including both exemptions and the check's two limits (PG-13); the 250-commit endpoint fail-open is closed (PG-23). The 6.0.0 release-window public-content review is recorded below: 232 files, zero true defects, with each apparent hit dispositioned and each exemption's reason stated (PG-12). |
 | 7 — supported harness evidence | **met via explicit tiers; no new live-fire** | Per-harness tiers below. No native-harness live-fire ran for this release; `KL-LIVE-ENV` records that, and the honest boundary column in the README install table carries each surface's limit. Cursor's recorded behavioral epoch remains `BLOCKED_EXTERNAL`. |
-| 8 — independent publication judgment | **NO-GO ×2 — the gate is not passed** | Two independent reviews of the publication act, both against `186b16eb2c069d9e8f902579afa50e9f5460fc85`: a cross-family single seat (xAI/Grok, `docs/gauntlet-runs/es-v6-publication-grok-2026-08-19/`) and a same-family panel (`docs/gauntlet-runs/es-v6-publication-gate-2026-08-19/`). Neither adopted the other's reasoning; both returned **NO-GO**. That candidate is superseded, so neither verdict transfers — but neither is discharged either. A fresh publication gate at the final candidate is required. **Independence limit:** five of the seven reviews in this lineage shared a model family with the authors and recorded that as a limit, not as independence. |
-| 9 — publication identity plan | **UNMET until the authorization line exists** | Tag `v6.0.0`, annotated, on the final candidate; release-note path `docs/release/RELEASE-6.0.0.md`; Release target the annotated tag, non-draft, body verbatim from this file. `protect-version-tags` carries `creation` with no bypass actors, so disarming it *is* the authorization act: disarm, tag, re-arm in the same sitting, then verify with a seeded probe rather than by reading the config back. The disarm and re-arm are recorded beside the authorization line. None of this has happened. |
+| 8 — independent publication judgment | **NO-GO ×4 — gate overridden by recorded owner exception (D24)** | Four independent reviews of the *publication act*, none of which adopted another's reasoning, all **NO-GO**: (1) cross-family single seat, xAI/Grok, subject `186b16eb`, `docs/gauntlet-runs/es-v6-publication-grok-2026-08-19/`; (2) same-family panel, subject `186b16eb`, `docs/gauntlet-runs/es-v6-publication-gate-2026-08-19/`; (3) **operator-dispatched** cross-family seat, OpenAI, subject `d0165bd0`, `docs/gauntlet-runs/es-v6-publication-openai-2026-08-20/`; (4) same-lineage panel with an isolated judge, subject `48009fef`, `docs/gauntlet-runs/es-v6-publication-panel-2026-08-21/`. **Two structural limits are disclosed, not glossed:** reviews 2 and 4 shared a model family with the authors, and review 4 was dispatched by the implementing lineage — a panel the implementer seats can block a release but cannot clear one, and this one is credited only for its blocking findings (RG1-01 among them, which it found against its own dispatcher's work). Reviews 1 and 3 judge superseded candidates, so neither verdict transfers to this one — but neither is discharged either. **No GO exists at any candidate.** The owner has overridden this gate under `RELEASING.md` § "Independent judgment gate"; see the exception block above. |
+| 9 — publication identity plan | **pre-authorized; execution pending the owner's hand** | Tag `v6.0.0`, annotated, on the final candidate; release-note path `docs/release/RELEASE-6.0.0.md`; Release target the annotated tag, non-draft, body verbatim from this file. `protect-version-tags` carries `creation` with **no bypass actors** — no actor of any kind can create `refs/tags/v*` while it is armed, including an owner and including automation holding an owner's credential. **Disarming it therefore *is* the authorization act**, and the owner has authorized the disarm (D24). Sequence: disarm, tag, push, Release, re-arm **in the same sitting**, then verify the re-arm with a seeded probe rather than by reading the config back. The disarm and re-arm timestamps are recorded in the tag message beside the authorization line. `docs/release/PRE-AUTHORIZATION-6.0.0.md` fixes the determinate act in advance. **This repository's automation cannot perform any of it:** the ruleset change is a settings write no agent holds, and tag pushes from the build environment are refused at the proxy. The commands are printed for the owner to run. |
 
 ### Why this tree does not contain its own verdict
 
@@ -116,20 +174,35 @@ that is the design working. Read the tag message.
 ### RG-5(c) disclosure — the red job at the candidate
 
 `RELEASING.md` RG-5's dispatch-only carve-out is conjunctive, and its third
-condition requires the release record to name what failed. Naming it, **verified
-at `92b3ca6c` rather than carried forward** from the freeze candidate:
+condition requires the release record to name what failed. The failure is stable
+across every candidate in this lineage and is named here by **test**, which is
+the durable coordinate; the run ID that observed it at the final candidate is in
+the tag object with the rest of the exact-SHA evidence. Last verified at
+`48009fef` (run 32430450479, job `contract-macos`, id 96620818500):
 
-- **Run** 32325702964, workflow `mission-custody-contract`, job **`contract-macos`**
-  (`macos-14`).
+- **Workflow** `mission-custody-contract`, job **`contract-macos`** (`macos-14`),
+  the dispatch-only probe. The required `contract` job on `ubuntu-24.04` passed
+  all 12 steps in the same run.
 - **Step 8**, "Custody mission lifecycle unit tests".
 - **Failing tests, read from that run's log:** `distinct-real-file-untouched`
   and `distinct-both-files-tracked-separately` — exactly two, and the other three
   `distinct-*` cases (`distinct-recover-raised`, `distinct-decoy-did-not-discharge`,
   `distinct-real-recovery-discharges`) pass.
-- **Cause:** macOS default filesystems are case-insensitive, so two
-  contract-distinct filenames resolve to one physical file. This is `KL-MACOS-162`,
-  settled negative before this release cycle, not a regression in it. The job's own
+- **Cause, stated precisely, because two earlier editions of this file described
+  it two different ways.** The two failing cases use the filenames `straße.txt`
+  and `strasse.txt`. macOS default volumes are case-insensitive under **full
+  Unicode case folding**, in which `ß` (U+00DF) folds to `ss` — so those two
+  names are **one physical file** there, and a write to one is observable through
+  the other. The contract's own comparison is not at fault and is not folding:
+  `_same_artifact` in `custody_mission.py` applies an ASCII-only fold and applies
+  it only when `os.name == "nt"`, so on macOS it correctly reports the two paths
+  as distinct artifacts. The disagreement is between a correct contract and a
+  folding filesystem, which is exactly what `KL-MACOS-162` records. Settled
+  negative before this release cycle; not a regression in it. The job's own
   es#162 probe step (step 5) passes — the filesystem behaves as the probe expects.
+  ("Case-insensitive" and "Unicode-fold" are both true of this mechanism and
+  neither is sufficient alone; the folding is case folding, but it is the full
+  Unicode table, not ASCII.)
 - **Unmeasured as a consequence:** steps 9–12 are skipped, so four custody suites
   (CLI black-box, gate unit, enforcement hook, three-subprocess continuity) did
   not run on macOS at this candidate. All four pass on `ubuntu-24.04` in the
@@ -192,7 +265,7 @@ Shipped in the packet with named owners:
 
 | Limit | What it means |
 |---|---|
-| `KL-SELF-GO` | The implementing lineage holds no acceptance seat. |
+| `KL-SELF-GO` | The implementing lineage holds no acceptance seat. **Unretired, and load-bearing for this release:** it is the reason no GO exists at any candidate, and the reason the owner had to override RG-8 rather than satisfy it. The packet's `self_certification` field reads `refused` and its `requested_irreversible_acts` is empty — the implementer asks for nothing and certifies nothing. |
 | `KL-LIVE-ENV` | Behavioral epochs and native-harness live-fire were not run. |
 | `KL-MACOS-162` | Measured APFS Unicode-fold collision: two contract-distinct filenames are one physical file. Custody distinctness claims exclude case-insensitive APFS. |
 | `KL-WINDOWS` | No native-Windows requalification was run. |
@@ -225,7 +298,11 @@ rules must not run before the tag exists.
 - **Owner:** repository owner.
 - **Scope:** the Wiki repository only; no packaged file is affected, and the
   in-tree `SKILL.md` contracts govern wherever the two disagree.
-- **Revisit trigger:** before the v6.0.0 Release is created.
+- **Revisit trigger:** in the window between tag creation and the GitHub
+  Release. Not earlier — the applier's link rules rewrite URLs to `/v6.0.0/`,
+  which is a 404 until the tag exists, and the applier now refuses to run before
+  then rather than trusting an operator to remember. Not later, for the reason
+  in the paragraph below.
 - **Exit criterion:** installation and catalog pages read fifteen skills with
   v6.0.0 install guidance, a `Skill-Manifest` page exists, and retired seats are
   described in the past tense. Measured starting state: 26 stale version banners,
@@ -236,7 +313,10 @@ Recorded here because `RELEASING.md` RG-2 forbids leaving an integrity gap
 *unrecorded* at tag creation. This is a pre-existing condition, not a regression
 introduced by this release — and the v5.1.0 note recorded a post-tag handbook
 pass as a follow-up that was never performed, so "we will fix it after the tag"
-has a 0-for-1 record here and should not be relied on again.
+has a 0-for-1 record here and should not be relied on again. **If the window is
+missed, this becomes a shipped documentation defect, not a pending task**, and
+should be recorded as an erratum under `RELEASING.md` step 11 rather than
+carried as an open intention for another release cycle.
 
 The README no longer routes readers into the stale pages for skill contracts:
 all fifteen catalog rows now link to in-tree sources.
@@ -278,8 +358,10 @@ upgrading for.
 
 ## Provenance notes
 
-The v6 BUILD freeze was reviewed by **five panels** and produced **four NO-GO
-verdicts** before its GO. "Independent" needs qualifying, and the GO record
+This release has been judged **nine times**: five panels on the BUILD freeze,
+then four on the publication act. The BUILD sequence produced **four NO-GO
+verdicts** before its GO. **The publication sequence produced four NO-GOs and no
+GO**, and is the gate the owner has overridden — see the exception block above. "Independent" needs qualifying, and the GO record
 qualifies it: four of those five shared a model family with the candidate's
 authors and recorded that as an independence **limit**, not as independence.
 Only the rc2 panel (Kimi/Moonshot) was cross-family. Each panel also judged a
@@ -294,6 +376,30 @@ class: a gate that had never actually executed against the sealed head.
 4. Fourth panel — six commits in the freeze pull request carried no DCO
    sign-off, so a required job would have gone red at ready-mark.
 5. Fifth panel — GO, with the discharge re-executed from primary sources.
+
+### The four publication reviews
+
+| # | Seat | Family | Dispatched by | Subject | Verdict |
+|---|---|---|---|---|---|
+| 6 | single seat | xAI / Grok — **cross-family** | implementing lineage | `186b16eb` | NO-GO |
+| 7 | panel | same family as authors | implementing lineage | `186b16eb` | NO-GO |
+| 8 | single seat | OpenAI — **cross-family** | **operator** | `d0165bd0` | NO-GO |
+| 9 | panel, isolated judge | same family as authors | implementing lineage | `48009fef` | NO-GO |
+
+Review 8 is the only one of the nine that is both cross-family *and* operator-
+dispatched, and it is worth reading in full: it found that the authorization
+sequence written into `RELEASING.md` was not executable, that a candidate's
+sign-off trailers were false attestations, and that two workflows had never run
+on the exact subject. All three were repaired. Review 9 — dispatched by the
+implementing lineage, so structurally able to block but not to clear — found
+**RG1-01**, a false scope statement in this very file that concealed two
+material changes; that is repaired above, and the device that produced it is
+retired rather than patched.
+
+None of the four found a defect in the shipped skills. Every P1 across the four
+was about the release process, its paperwork, or its authority chain. That is
+the honest shape of this record and the reason the owner's exception is
+defensible: the ceremony failed repeatedly; the artifact did not.
 
 Run records live under `docs/gauntlet-runs/`, indexed by
 `docs/gauntlet-runs/V6-VERDICT-LINEAGE.md`, which binds each verdict to its exact
@@ -319,9 +425,18 @@ The one class claim that stood UNPROVED, `CLM-INDEPENDENT-GAUNTLET`, is closed
 by **operator ratification** of the rc5 verdict (D20), not by an
 operator-dispatched review. The seat was fresh and non-authoring, so the oracle
 is satisfied in full; the dispatch limb of its closure path is closed by the
-operator adopting the verdict after the fact. That distinction is recorded in
-`docs/v6/operator-decision-record-2026-08-20.md` rather than smoothed over, and
-anyone auditing the PROVED status should read it and judge for themselves.
+operator adopting the verdict after the fact.
+
+**Review 9 disputed that, and the dispute is recorded rather than resolved in
+this release's favour.** Its argument: dispatch controls *selection* — whether
+an unfavourable verdict ever reaches the operator at all — and after-the-fact
+ratification can only operate on the verdicts the implementing lineage chose to
+present. Ratifying a GO is therefore not equivalent to having dispatched the
+review that produced it. That is a real gap and it is not closed here. It is why
+`KL-SELF-GO` still ships, why the D8 cross-family consult carries forward as the
+successor condition, and why this is an exception release rather than a
+conforming one. Anyone auditing the PROVED status of `CLM-INDEPENDENT-GAUNTLET`
+should read D20, read this paragraph, and judge for themselves.
 
 The binding is not decorative: removing the ref, pointing it at a verdict that
 is not on disk, naming a different subject SHA, or hand-editing

--- a/docs/v6/operator-decision-record-2026-08-20.md
+++ b/docs/v6/operator-decision-record-2026-08-20.md
@@ -80,3 +80,63 @@ may amend or echo-certify.
   **Revisit trigger.** Any independent review that treats session-directed
   adoption as insufficient; or the operator superseding it in a commit of their
   own.
+
+- **D24 (2026-08-21 — disarm authorized; v6.0.0 ships as an exception release).**
+  After the fourth publication review returned NO-GO, and after that review
+  ruled that no owner authority reaches past RG-8 and that disarming
+  `protect-version-tags` is functionally the authorization act, the operator
+  authorized the disarm and directed completion. Recorded verbatim:
+
+  > "i authorize the disarm and lets stop killing ourselves over this process,
+  > we know the design and its concession, its SOP for us, lets just go"
+
+  **What D24 decides.** Three things, and only three:
+
+  1. **The disarm is authorized.** The operator may remove the `creation` rule
+     from `protect-version-tags`, create and push `v6.0.0`, and re-arm, as a
+     single authorized act rather than a decision still to be made.
+  2. **RG-8 is overridden, deliberately and on the record.** Four independent
+     publication reviews returned NO-GO and no GO exists. The operator elects
+     the exception `RELEASING.md` § "Independent judgment gate" provides. The
+     five disclosures that section requires are made in
+     `docs/release/RELEASE-6.0.0.md` **before** tag creation, and the release is
+     labelled an **exception release** there — never a conforming one.
+  3. **The process is declared settled, not skipped.** "We know the design and
+     its concession" is a statement that the trade-off has been examined and
+     accepted, not that it has been forgotten. The concession is exactly this:
+     a repository pushed with the same credential its automation runs under
+     cannot manufacture an unforgeable human act, so the one control that is
+     genuinely unforgeable — a ruleset only a human operator's settings access
+     can change — is where authorization is made to live.
+
+  **What D24 does not reach.** The integrity gates. `RELEASING.md` scopes owner
+  exceptions to the independent judgment gate alone. RG-1 accuracy, RG-4
+  alignment, RG-5 deterministic evidence and RG-6 security are not waivable by
+  the operator, by this entry, or by any authority in this repository, and none
+  of them was waived: every finding of the fourth review that named an
+  integrity-gate defect was repaired in the successor candidate rather than
+  excused. In particular **RG1-01** — a false statement in the release note that
+  concealed two material changes — was deleted and the device that produced it
+  retired. An owner's signature on a false record would make it an attested
+  false record, which is worse than an unattested one.
+
+  **Provenance, stated so nobody has to reconstruct it.** As with D23: this entry
+  was written and committed by the implementing lineage, transcribing a session
+  instruction. It is not a commit authored by the operator's account, and the
+  shared-credential concession above means it could not be made distinguishable
+  from one even if it tried. The single act this entry cannot fake is the disarm
+  itself — a repository-settings change no agent holds and no credential in this
+  environment can perform. That asymmetry is the point of the design, and it is
+  why the tag remains the operator's act in fact.
+
+  **Obligations that survive D24.** The D8 cross-family consult is owed and
+  undischarged; it carries to 6.1.0 as a blocking obligation. `KL-SELF-GO`
+  ships unretired. If any NO-GO finding is later shown to have named a defect in
+  the artifact rather than in the release process, that is an immediate
+  erratum-and-patch trigger under `RELEASING.md` step 11.
+
+  **Revisit trigger.** Publication of 6.1.0, at which point the D8 consult must
+  be discharged before the judgment gate may be overridden a second time.
+  Overriding RG-8 twice in a row without discharging D8 would convert an
+  exception into a practice, which is the failure mode this entry is written to
+  prevent.

--- a/docs/wiki-updates/v6.0.0/apply_v6_updates.py
+++ b/docs/wiki-updates/v6.0.0/apply_v6_updates.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -108,6 +109,50 @@ def self_test() -> int:
                 failures += 1
                 print(f"[FAIL] {name}\n  want: {want!r}\n  got:  {got!r}")
             (root / "Skill-Manifest.md").unlink(missing_ok=True)
+    # Guard 1: check_paths. Both directions, because a guard that never fires and
+    # a guard that always fires are the same useless guard.
+    with tempfile.TemporaryDirectory() as tmp:
+        wiki = Path(tmp) / "wiki"
+        wiki.mkdir()
+        (wiki / "Home.md").write_text("hi", encoding="utf-8")
+        if not check_paths(wiki):
+            print("[PASS] check_paths accepts a wiki-shaped directory")
+        else:
+            failures += 1
+            print(f"[FAIL] check_paths rejected a wiki-shaped directory: {check_paths(wiki)}")
+        # The damaging case: aimed at the code repository.
+        code = Path(tmp) / "code"
+        (code / "plugins").mkdir(parents=True)
+        (code / "RELEASING.md").write_text("x", encoding="utf-8")
+        (code / "README.md").write_text("x", encoding="utf-8")
+        why = check_paths(code)
+        if any("CODE repository" in r for r in why):
+            print("[PASS] check_paths refuses the code repository")
+        else:
+            failures += 1
+            print(f"[FAIL] check_paths did not refuse the code repository: {why}")
+        empty = Path(tmp) / "empty"
+        empty.mkdir()
+        if check_paths(empty):
+            print("[PASS] check_paths refuses a directory with no pages")
+        else:
+            failures += 1
+            print("[FAIL] check_paths accepted an empty directory")
+
+    # Guard 2: tag_exists must fail closed. It returns True/False/None and the
+    # caller must treat None as "do not write" -- prove the tri-state, not the
+    # network call.
+    if tag_exists.__doc__ and "None is NOT treated as True" in tag_exists.__doc__:
+        observed = tag_exists()
+        if observed in (True, False, None):
+            print(f"[PASS] tag_exists returns a tri-state (observed: {observed!r})")
+        else:
+            failures += 1
+            print(f"[FAIL] tag_exists returned {observed!r}")
+    else:
+        failures += 1
+        print("[FAIL] tag_exists lost its fail-closed contract")
+
     # The present-tense detector is advisory; prove it sees a real case.
     if RETIRED_PRESENT_TENSE.search("`using-epistemic-skills` selects the set"):
         print("[PASS] retired-seat present tense detected")
@@ -118,11 +163,71 @@ def self_test() -> int:
     return 1 if failures else 0
 
 
+# --- Guards. Two ways this script can do real damage, both cheap to prevent. ---
+
+# 1. Pointed at the wrong tree. Its rules rewrite any `*.md` in the given
+#    directory, so aimed at a checkout of THIS repository it would happily
+#    rewrite the release notes it exists to support. A wiki clone is
+#    recognisable: a flat directory of `.md` pages whose git remote ends in
+#    `.wiki.git`, and which carries at least one page this package expects.
+WIKI_SENTINEL_PAGES = ("Home.md", "Installation.md", "Skill-Catalog.md")
+
+
+def check_paths(root: Path) -> list[str]:
+    """Return the reasons `root` does not look like an epistemic-skills wiki clone.
+    Empty list means it does. Never writes."""
+    reasons: list[str] = []
+    if not root.is_dir():
+        return [f"not a directory: {root}"]
+    pages = list(root.glob("*.md"))
+    if not pages:
+        reasons.append("no top-level *.md pages -- a wiki clone is a flat page directory")
+    if not any((root / name).is_file() for name in WIKI_SENTINEL_PAGES):
+        reasons.append(f"none of {list(WIKI_SENTINEL_PAGES)} present")
+    # The unmistakable tell: this is the code repository, not its wiki.
+    for marker in ("RELEASING.md", "plugins", ".github"):
+        if (root / marker).exists():
+            reasons.append(f"{marker!r} present -- this looks like the CODE repository, "
+                           "which this script must never rewrite")
+    remote = ""
+    try:
+        remote = subprocess.run(
+            ["git", "-C", str(root), "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=10).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        remote = ""
+    if remote and not remote.endswith(".wiki.git"):
+        reasons.append(f"git remote {remote!r} does not end in '.wiki.git'")
+    return reasons
+
+
+# 2. Run before the tag exists. `tagged-tree-url` and `applies-to-banner` rewrite
+#    links to point at /v6.0.0/. If that tag has not been created yet, applying
+#    them replaces working v5 links with 404s -- publication-gate finding PG-18,
+#    reproduced in the wiki where no oracle in this repository can see it.
+def tag_exists(version: str = CURRENT_VERSION) -> bool | None:
+    """True/False if it could be determined, None if the check could not run
+    (offline, no git). None is NOT treated as True by the caller."""
+    try:
+        r = subprocess.run(
+            ["git", "ls-remote", "--tags", "origin", f"refs/tags/v{version}"],
+            cwd=Path(__file__).resolve().parent, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        return None
+    return bool(r.stdout.strip())
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("wiki", nargs="?", help="path to a wiki clone")
     ap.add_argument("--apply", action="store_true", help="write changes (default is dry-run)")
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--check-paths", action="store_true",
+                    help="report whether the given path looks like a wiki clone, and exit")
+    ap.add_argument("--force", action="store_true",
+                    help="apply despite a failed guard (states which guard was overridden)")
     args = ap.parse_args()
     if args.self_test:
         return self_test()
@@ -131,7 +236,37 @@ def main() -> int:
     root = Path(args.wiki)
     if not root.is_dir():
         ap.error(f"not a directory: {root}")
+    reasons = check_paths(root)
+    if args.check_paths:
+        if reasons:
+            print(f"{root} does NOT look like an epistemic-skills wiki clone:")
+            for r in reasons:
+                print(f"  - {r}")
+            return 1
+        print(f"{root} looks like an epistemic-skills wiki clone")
+        return 0
     if args.apply:
+        blocked = list(reasons)
+        tag = tag_exists()
+        if tag is False:
+            blocked.append(
+                f"tag v{CURRENT_VERSION} does not exist on origin -- applying now would "
+                "rewrite working links into 404s (PG-18). Tag first, then run this.")
+        elif tag is None:
+            blocked.append(
+                f"could not determine whether tag v{CURRENT_VERSION} exists (offline or "
+                "no git). Failing closed: an unknown tag state is not a present tag.")
+        if blocked and not args.force:
+            print("refusing to write. Guards that failed:")
+            for r in blocked:
+                print(f"  - {r}")
+            print("\nRe-run with --check-paths to inspect, or --force to override "
+                  "deliberately.")
+            return 1
+        if blocked:
+            print("--force: overriding these guards deliberately:")
+            for r in blocked:
+                print(f"  - {r}")
         print(f"changed {apply(root)} page(s) in {root}")
         return 0
     found = plan(root)

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -78,15 +78,78 @@ def check_live_surface_counts(skill_count: int) -> None:
                 require(m.group(1).lower() in ok_words,
                         f"stale count word {m.group(1)!r} on live surface {mp.name}: ...{s[max(0,m.start()-30):m.end()+40]}...")
     readme = read(REPO_ROOT / "README.md")
-    mermaid = [ln for ln in readme.splitlines() if "router and" in ln and "disciplines" in ln]
+    # Select mermaid node lines structurally -- inside a fenced ```mermaid block --
+    # rather than by a prose fragment. The previous selector keyed on "router and",
+    # a phrase the README stopped using; it matched zero lines and the check passed
+    # vacuously for as long as that was true. Two non-vacuity controls below make
+    # that failure mode loud instead of silent.
+    mermaid = []
+    in_block = False
+    for ln in readme.splitlines():
+        if ln.strip().startswith("```"):
+            in_block = ln.strip().startswith("```mermaid")
+            continue
+        if in_block and "disciplines" in ln:
+            mermaid.append(ln)
+    require(mermaid, "README mermaid count check is vacuous: no fenced ```mermaid "
+                     "line mentions 'disciplines'. Either the diagram lost its count "
+                     "node or the selector drifted -- both mean this check guards nothing.")
+    checked = 0
     for ln in mermaid:
         found = [w for w in WORDS.values() if re.search(rf"\b{w}\b", ln.lower())]
+        checked += len(found)
         for w in found:
             require(w in ok_words, f"README mermaid node count stale: {ln.strip()}")
+    require(checked >= 1, "README mermaid count check is vacuous: the selected node "
+                          f"lines carry no spelled count at all: {mermaid!r}")
     gemini = read(REPO_ROOT / "GEMINI.md")
     for m in count_re.finditer(gemini):
         require(m.group(1).lower() in ok_words,
                 f"stale count word {m.group(1)!r} in GEMINI.md")
+
+
+def check_marketplace_enumeration(skill_names: set[str]) -> None:
+    """PG-15: the marketplace "full collection" descriptions enumerate the skills by
+    name, and a hand-maintained enumeration is a projection of a directory -- exactly
+    the drift class the collection warns about in its own README. Both descriptions
+    shipped fourteen of fifteen names for a full release cycle, omitting `manifest`,
+    and no oracle read them.
+
+    The expected set is DERIVED from `plugins/epistemic-skills/skills/`, never written
+    down here: a hard-coded list would reintroduce the projection one layer up. The
+    enumeration is parsed STRUCTURALLY -- the `a + b + c` list after the colon -- not
+    by scanning prose for word-shaped things, so a name that is present, absent, or
+    invented is decided by set equality rather than by substring luck."""
+    enumerating = []
+    for mp in (REPO_ROOT / ".claude-plugin" / "marketplace.json",
+               REPO_ROOT / ".cursor-plugin" / "marketplace.json"):
+        data = json.loads(read(mp))
+        for plugin in data.get("plugins", []):
+            desc = plugin.get("description", "")
+            if "full collection" not in desc.lower():
+                continue
+            enumerating.append(mp.name)
+            require(":" in desc, f"{mp.name} 'full collection' description has no "
+                                 "'<preamble>: a + b + c' enumeration to check")
+            listed = desc.split(":", 1)[1]
+            named = set()
+            for token in listed.split("+"):
+                token = re.sub(r"\(.*?\)", "", token).strip().rstrip(".").strip()
+                if token:
+                    named.add(token)
+            missing = sorted(skill_names - named)
+            invented = sorted(named - skill_names)
+            require(not missing,
+                    f"{mp.name} 'full collection' description omits {missing}; it must "
+                    f"enumerate all {len(skill_names)} skills")
+            require(not invented,
+                    f"{mp.name} 'full collection' description names {invented}, which "
+                    "is not a skill directory")
+    # Non-vacuity: if no description matched, the check verified nothing. Two
+    # manifests carry this claim; both must be reached.
+    require(len(enumerating) == 2,
+            "marketplace enumeration check is vacuous: expected two 'full collection' "
+            f"descriptions to check, reached {enumerating}")
 
 
 def main() -> int:
@@ -319,6 +382,7 @@ def main() -> int:
     skill_dirs = [p.parent for p in (PACKAGE_ROOT / "skills").glob("*/SKILL.md")]
     require(len(skill_dirs) == _n, f"expected {_n} skill directories, found {len(skill_dirs)}")
     check_live_surface_counts(len(skill_dirs))
+    check_marketplace_enumeration({d.name for d in skill_dirs})
     for directory in skill_dirs:
         require((directory / "SKILL.md").is_file(), f"missing SKILL.md: {directory.name}")
 


### PR DESCRIPTION
Mints the v6.0.0 final release candidate. **Merge with a merge commit, not a squash** — a squash attributes the commit to the merger, making any sign-off trailer a false attestation (OAI-P1-01).

The merge commit produced by this PR is the candidate named in `docs/release/PRE-AUTHORIZATION-6.0.0.md`.

## What this changes

**RG1-01 — a false statement in the release note, and it was the implementing lineage's own.** `docs/release/RELEASE-6.0.0.md` claimed the *only* change between `92b3ca6c` and the commit carrying its evidence table was the table. At `48009fef` that delta was ten files, +690/−124, across ten commits — and it elided the emptying of `blocking_claims` and an amendment to `RELEASING.md`, the two changes a reader scoping a re-check would most need. The paragraph is deleted and the device retired: exact-SHA run IDs now live in the annotated tag object, where step 4 already said they belong.

**Ships as an exception release, labelled as one.** Four independent publication reviews across three model families, four NO-GOs, no GO at any candidate. The owner elects the exception `RELEASING.md` § "Independent judgment gate" provides, with all five required disclosures present in the committed note *before* tag creation (D24). The exception reaches RG-8 and nothing else — RG-1, RG-4, RG-5 and RG-6 are met on their own terms.

**Verdict lineage completed.** Run 8 (operator-dispatched, cross-family, OpenAI) brought in-tree unaltered. Run 9 (this lineage's own panel) recorded with its structural limit stated: a panel the implementer seats can block a release and cannot clear one. Run 9's dispute with D20 — that dispatch controls *selection*, so ratifying a GO is not the same as having dispatched the review — is recorded unresolved rather than settled in this release's favour.

**Three oracle repairs, each mutation-tested in both directions.**

| Oracle | Defect | Now |
|---|---|---|
| README mermaid count | selector keyed on `"router and"`, a phrase the README stopped using — matched zero lines, passing vacuously | structural selector + two non-vacuity controls |
| marketplace enumeration (PG-15) | no oracle at all; both manifests shipped 14 of 15 names for a release cycle | expected set derived from the skills directory, enumeration parsed structurally; omission and invention both fail |
| `apply_v6_updates.py` | could be aimed at this repository, or run before the tag exists and rewrite working links into 404s | `--check-paths` + fail-closed tag guard, both self-tested |

**Pre-authorization reissued.** Its predecessor could not fire on either branch — condition 2 wanted a GO that will not come, condition 4 wanted an acceptance whose own procedure excludes the only available channel. Replaced by a documented exception rather than quietly relaxed.

**Precision fix.** The macOS red is a full-Unicode case fold (`straße.txt`/`strasse.txt` resolving to one physical file), not the ASCII case-insensitivity two earlier editions asserted. The contract's own comparison is correct and is not folding.

## Gate status

Full local CI: **PASS** (54 of 55 workflow python steps replicated; 1 skipped for GitHub event env). Public-content gate green, 8 patterns, 39 digest-verified allowlist entries.

Per amended step 4, every gating workflow will be **explicitly dispatched** at the merge commit — path-filtered workflows do not fire on a docs-only diff, and a missing run is not a passing run.

## What this PR does not do

No tag, no Release, no ruleset change. `protect-version-tags` carries `creation` with no bypass actors; disarming it is the authorization act and is the operator's alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSTJZfecEUH49KVszKpgMq)_