### PR TITLE
Record the v6.0.0 publication and discharge its post-tag debts

### DIFF
--- a/.kimi-plugin/marketplace.json
+++ b/.kimi-plugin/marketplace.json
@@ -4,7 +4,7 @@
     {
       "id": "epistemic-skills",
       "displayName": "Epistemic Skills",
-      "source": "https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0"
+      "source": "https://github.com/ZMS-Labs/epistemic-skills/tree/v6.0.0"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The Wiki is unversioned navigation over versioned sources. If a handbook summary
 For a harness without a native package surface, the complete generic install is:
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v6.0.0/plugins/epistemic-skills/skills
 ```
 
 Do not run that command on top of a native plugin install. The [installation handbook](https://github.com/ZMS-Labs/epistemic-skills/wiki/Installation-and-Harness-Compatibility) includes verification and recovery details for every packaged harness.
@@ -98,7 +98,7 @@ For unfamiliar but routine-looking work, perform **two-read micro-recon**: inspe
 
 Routine work produces no entry-point record, blindspot report, formal record, ledger entry, UAT packet, or proof that other triggers were absent. Escalate only when the reads expose an observed mismatch, hidden coupling, unresolved scope, material fan-out risk, or another positive trigger.
 
-See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v5.1.0/plugins/epistemic-skills/skills/metacognate/reference/routine-fast-path.md).
+See the [routine-work guide](https://github.com/ZMS-Labs/epistemic-skills/wiki/Routine-Work-and-Proportionality) and the [released normative reference](https://github.com/ZMS-Labs/epistemic-skills/blob/v6.0.0/plugins/epistemic-skills/skills/metacognate/reference/routine-fast-path.md).
 
 ## metacognate: the single entry point
 
@@ -311,7 +311,7 @@ Use one of native `agy plugin install`, Gemini extension link, or `agy plugin im
 ### Kimi Code
 
 ```text
-/plugins install https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0
+/plugins install https://github.com/ZMS-Labs/epistemic-skills/tree/v6.0.0
 # Local development only, from a clone:
 /plugins install /path/to/epistemic-skills
 ```
@@ -321,7 +321,7 @@ Run `/reload` or start a new session. `.kimi-plugin/plugin.json` points to the c
 ### Generic harness
 
 ```bash
-npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v5.1.0/plugins/epistemic-skills/skills
+npx skills add https://github.com/ZMS-Labs/epistemic-skills/tree/v6.0.0/plugins/epistemic-skills/skills
 ```
 
 Use this only when the host has no native plugin or extension. Frontmatter `description` is the trigger; the body is the method. Compatibility means the host preserves the selected skill's capability, ordering, isolation, persistence, and fail-closed contracts—not merely that it can display Markdown.

--- a/docs/release/PUBLICATION-RECORD-6.0.0.md
+++ b/docs/release/PUBLICATION-RECORD-6.0.0.md
@@ -1,0 +1,94 @@
+# Publication record — v6.0.0
+
+Written **after** the tag existed, which is the only time it can be written.
+`docs/release/RELEASE-6.0.0.md` is immutable inside `v6.0.0` and is not edited by
+this file; everything here is a post-publication fact that no pre-tag document
+could have contained.
+
+## What was published
+
+| Coordinate | Value |
+|---|---|
+| Tag | `v6.0.0`, **annotated**, object `b4bc8dff0d07a7535c24905af7fb97cc85e01037` |
+| Peeled target | `9a37a21faeee9f44bd63b0e43ec86b56c7f0ab1c` |
+| Release | non-draft, not pre-release, targets the annotated tag |
+| Release published | 2026-08-21T04:08:38Z |
+| Release class | **exception release** — RG-8 overridden under D24; not conforming |
+
+## The disarm/re-arm sitting (RG-9)
+
+`protect-version-tags` (ruleset id **20090781**) carries `creation` on
+`refs/tags/v*` with **no bypass actors**, so no actor can create a version tag
+while it is armed. Disarming it is therefore the authorization act, and the tag
+message records the disarm beside the authorization line. The re-arm is recorded
+here, because a tag cannot contain an event that follows it.
+
+| Event | Time (UTC) |
+|---|---|
+| Disarm — enforcement `active` → `disabled` | 2026-08-21T03:55:43Z |
+| Annotated tag `v6.0.0` written | 2026-08-21T04:00:19Z |
+| **Re-arm — enforcement `disabled` → `active`** | **2026-08-21T04:01:20Z** |
+
+Open window: **5 minutes 37 seconds**, one sitting, no other push accepted in it.
+
+**Re-arm proven by seeded probe, not by reading the config back.** A version-shaped
+tag was pushed at the candidate after re-arming and had to be rejected:
+
+```
+remote: error: GH013: Repository rule violations found for refs/tags/v0.0.0-armprobe.
+remote: - Cannot create ref due to creations being restricted.
+ ! [remote rejected] v0.0.0-armprobe -> v0.0.0-armprobe
+```
+
+`GET /git/ref/tags/v0.0.0-armprobe` returns **404** — the probe never landed.
+Post-state re-read: `enforcement: active`, `bypass_actors: None`, rules
+`[creation, deletion, update]` all intact.
+
+## Step-10 verification, executed
+
+| Check | Result |
+|---|---|
+| Tag exists and is annotated | PASS — object type `tag` |
+| Peeled tag target == candidate SHA | PASS — `9a37a21faeee` |
+| Release targets that tag | PASS — `tag_name=v6.0.0` |
+| Release is non-draft | PASS |
+| **Committed note body == Release body** | PASS — sha256 `3468a86b845fee91…` on both sides, 35,102 chars, compared after CRLF normalization |
+| `main` contains the release commit | PASS — `main` *is* the candidate |
+
+## Post-tag commits this release owed, and why they are commits rather than gaps
+
+The tagged tree deliberately shipped two things it could not correctly contain.
+Both are discharged by the commit carrying this file.
+
+1. **Install-ref pin.** The tagged tree pins install recipes at `v5.1.0`, because
+   at tag time that was still the newest *published* tag and pinning an
+   unpublished one ships dead links — publication-gate finding **PG-18**. Now
+   that `v6.0.0` exists, the pin and all five live URL surfaces move to it. The
+   move was gated on measurement, not on the tag's existence alone: all four
+   install/reference URLs were re-probed and returned **HTTP 200** before any
+   ref was rewritten. Prose references to `v5.1.0` (rollback guidance,
+   "supersedes") are untouched — only URL-shaped refs moved.
+
+2. **Wiki handbook — ERRATUM, window missed.** The release note set the revisit
+   trigger as "the window between tag creation and the GitHub Release" and said
+   plainly that if the window were missed this becomes a shipped documentation
+   defect rather than a pending task. **The window was 04:00:19Z to 04:08:38Z
+   and it was not used.** Recording that as an erratum under `RELEASING.md`
+   step 11 rather than restyling it as an open intention, because the note's
+   own text forbids the restyling and because "we will fix it after the tag"
+   now has a 0-for-2 record in this repository.
+
+   What is true and useful: the applier is no longer *blocked*. Its tag-existence
+   guard was the reason it refused to run before, and `v6.0.0` now exists, so
+   `apply_v6_updates.py <wiki-clone> --check-paths` then `--apply` will run. The
+   defect is that the public handbook advertised a v5.0.0-era package at the
+   moment 6.0.0 published, and no later fix un-ships that.
+
+## Obligations that survive publication
+
+- **D8 cross-family consult** — owed, undischarged, carried to 6.1.0 as a
+  blocking obligation. Publishing 6.1.0 under a second RG-8 exception without
+  first discharging D8 would convert an exception into a practice.
+- **`KL-SELF-GO`** — unretired.
+- **Four NO-GO verdicts** — none discharged by publication. The owner overrode
+  the gate; overriding is not answering.

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -14,10 +14,12 @@ PACKAGE_ROOT = HERE.parents[3]
 REPO_ROOT = HERE.parents[5]
 EXPECTED_VERSION = "6.0.0"
 
-# The newest tag an install recipe may point at. Deliberately NOT
-# EXPECTED_VERSION: this tree is 6.0.0 while the newest PUBLISHED tag is
-# v5.1.0, and pinning a tag that does not exist ships dead install links.
-INSTALL_REF_PIN = "v5.1.0"
+# The newest tag an install recipe may point at. It tracks the newest PUBLISHED
+# tag, not EXPECTED_VERSION: pinning a tag that does not exist ships dead install
+# links (PG-18). For most of the 6.0.0 cycle this correctly lagged at v5.1.0
+# because v6.0.0 was unpublished. It moved to v6.0.0 only after the tag existed
+# and all four install URLs were measured at HTTP 200.
+INSTALL_REF_PIN = "v6.0.0"
 _REF = re.compile(r"github\.com/ZMS-Labs/epistemic-skills/(?:tree|blob)/(v[0-9]+\.[0-9]+\.[0-9]+)")
 
 


### PR DESCRIPTION
Post-publication commit. `v6.0.0` is tagged and released; this records what the tag could not contain and discharges the two debts the release note deliberately shipped.

`docs/release/RELEASE-6.0.0.md` is **not edited** — it is immutable inside `v6.0.0` and its bytes equal the Release body. Everything here goes in a separate file.

## The re-arm (RG-9)

A tag cannot carry an event that follows it, so the disarm went in the tag message and the re-arm goes on the branch.

| Event | Time (UTC) |
|---|---|
| Disarm — `active` → `disabled` | 03:55:43Z |
| Annotated tag written | 04:00:19Z |
| **Re-arm — `disabled` → `active`** | **04:01:20Z** |

Open window **5m37s**, one sitting. Proven by seeded probe rather than by reading the config back — a version-shaped tag pushed after re-arming was rejected with `GH013: Cannot create ref due to creations being restricted`, and its ref returns 404.

## Step 10, executed

| Check | Result |
|---|---|
| Tag annotated | PASS — object type `tag`, `b4bc8dff0d07` |
| Peeled target == candidate | PASS — `9a37a21faeee` |
| Release targets the tag, non-draft | PASS |
| **Committed note == Release body** | PASS — sha256 `3468a86b845fee91…` both sides, 35,102 chars, CRLF-normalized |
| `main` contains the release commit | PASS — `main` *is* the candidate |

## Debt 1 — install-ref pin, discharged

The tagged tree pins installs at `v5.1.0` because at tag time that was the newest *published* tag; pinning an unpublished one ships dead links (**PG-18**). The pin and five URL surfaces move to `v6.0.0`.

Gated on measurement, not on the tag's existence: all four install/reference URLs were re-probed at **HTTP 200** before any ref was rewritten. Prose references to `v5.1.0` (rollback guidance, "supersedes") are untouched — only URL-shaped refs moved.

## Debt 2 — wiki handbook, recorded as an ERRATUM

The release note set the trigger as "the window between tag creation and the GitHub Release" and stated that if missed, this becomes a shipped documentation defect rather than a pending task. **The window was 04:00:19Z–04:08:38Z and was not used.**

Recorded as an erratum under step 11 rather than restyled as an open task, because the note's own text forbids the restyling and "we will fix it after the tag" now has a 0-for-2 record here. The applier is no longer *blocked* — its tag-existence guard was the reason it refused — but no later fix un-ships what the public handbook advertised at the moment 6.0.0 published.

## Not discharged

D8 cross-family consult (carries to 6.1.0 as blocking), `KL-SELF-GO`, and the four NO-GO verdicts. Overriding a gate is not answering it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSTJZfecEUH49KVszKpgMq)_