### PR TITLE
perf(custody): make scope close linear in receipts

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/census_missions.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/census_missions.py
@@ -212,13 +212,24 @@ def _receipts(mission: Mission, store: MissionStore,
     the per-id lookup about every id rescans from revision 1 each time, so a
     mission with one effect per revision made this quadratic -- an estate
     walk over thousands of revisions, millions of parses.
+
+    AND THAT ONE PASS IS HANDED TO THE LOADER. Building the index here and
+    then letting `_load_receipt_checked` reach for its own put the rescan
+    straight back: the loader consults the index for every id, and once that
+    cache is keyed to checkpoint CONTENT a hit costs a full SHA-256 pass over
+    the whole cumulative chain rather than a directory listing. Measured on a
+    300-receipt mission, the census went from 303 checkpoint reads / 1.9 MiB
+    to 91,205 reads / 578 MiB. Forwarding the mapping is the same repair
+    `scope_consistency` already makes for its own fallback loads.
     """
     paths: list[str] = []
     problems: list[str] = []
+    index_built = True
     try:
         index = mission._effect_path_index()
     except (OSError, ValueError, KeyError, TypeError) as exc:
         index = {}
+        index_built = False
         problems.append(f"chain index unreadable: {type(exc).__name__}: {exc}")
     for rid in _lget(latest, "receipt_ids"):
         if not isinstance(rid, str):
@@ -231,7 +242,18 @@ def _receipts(mission: Mission, store: MissionStore,
             # RECEIPT-MISSING for a receipt that is present, intact and merely
             # newer -- telling the operator the opposite of what `resume` now
             # says about the same file.
-            receipt, _refusal, opaque = mission._load_receipt_checked(rid)
+            #
+            # ONLY A MAPPING THAT WAS ACTUALLY BUILT is forwarded. The empty
+            # dict above is a failure marker, not an answer: handing it over
+            # would tell the loader that NO id has a chained path and silently
+            # retire its own artifact_path comparison -- a forged receipt would
+            # then read as ordinary coverage on exactly the run that already
+            # could not read the chain. When the build failed the loader is
+            # called as before, raises the same error, and every id is still
+            # reported.
+            receipt, _refusal, opaque = (
+                mission._load_receipt_checked(rid, effect_paths=index)
+                if index_built else mission._load_receipt_checked(rid))
         except (OSError, ValueError) as exc:
             receipt = None
             problems.append(f"{rid}: receipt unreadable: {type(exc).__name__}")

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -1394,31 +1394,35 @@ class Mission:
         # must not leave an authority-sensitive path index stale. Reading each
         # file once to fingerprint it preserves a linear scan and lets a cache
         # hit avoid reparsing while still observing that supported boundary.
+        # Retain only the digest from that pass: checkpoint records are
+        # cumulative, so retaining every payload at once makes peak memory
+        # quadratic in the number of receipts. A cache miss deliberately
+        # rereads one checkpoint at a time for parsing.
         paths = self.store.checkpoint_paths()
-        raw_records: list[bytes] = []
-        identity: list[tuple[str, str]] = []
-        for cp_path in paths:
-            data = cp_path.read_bytes()
-            identity.append((cp_path.name, sha256_bytes(data)))
-            raw_records.append(data)
-        fingerprint = tuple(identity)
+        fingerprint = tuple(
+            (cp_path.name, sha256_file(cp_path)) for cp_path in paths
+        )
         if self._effect_index_cache is not None \
                 and self._effect_index_cache[0] == fingerprint:
             return self._effect_index_cache[1]
         index: dict[str, str] = {}
-        prev_ids: list[str] = []
+        known_ids: set[str] = set()
         prev_notes: list[str] = []
-        for data in raw_records:
-            record = json.loads(data)
+        for cp_path in paths:
+            record = json.loads(cp_path.read_text(encoding="utf-8"))
             ids = record["receipt_ids"]
             notes = record["state"]["notes"]
-            fresh = [rid for rid in ids if rid not in prev_ids]
+            # Checkpoints repeat the full cumulative ID list. List membership
+            # makes comparing those cumulative prefixes cubic; request IDs
+            # are never reusable, so one mission-wide set is the exact rule.
+            fresh = [rid for rid in ids if rid not in known_ids]
             if fresh:
                 path = _first_effect_note(notes[len(prev_notes):])
                 if path is not None:
                     for rid in fresh:
                         index.setdefault(rid, path)
-            prev_ids, prev_notes = ids, notes
+                known_ids.update(fresh)
+            prev_notes = notes
         self._effect_index_cache = (fingerprint, index)
         return index
 
@@ -1681,11 +1685,14 @@ class Mission:
         # break across the gap where the retired one honestly sat. That fires
         # on the ordinary sanctioned recovery flow, which would train stewards
         # to ignore the signal on day one.
+        effect_paths = self._effect_path_index()
         by_path: dict[str, list[str]] = {}
         for request_id in self._all_receipt_ids_ever():
-            receipt = self._load_receipt(request_id)
+            receipt = self._load_receipt(
+                request_id, effect_paths=effect_paths
+            )
             rel = (receipt["artifact_path"] if receipt is not None
-                   else self._historical_effect_path(request_id))
+                   else effect_paths.get(request_id))
             if rel is None:
                 continue
             key = _normalize_relpath(rel)
@@ -1695,8 +1702,12 @@ class Mission:
         breaks: list[dict] = []
         for ids in by_path.values():
             for prior_id, next_id in zip(ids, ids[1:]):
-                prior = self._load_receipt(prior_id)
-                nxt = self._load_receipt(next_id)
+                prior = self._load_receipt(
+                    prior_id, effect_paths=effect_paths
+                )
+                nxt = self._load_receipt(
+                    next_id, effect_paths=effect_paths
+                )
                 if prior is None or nxt is None:
                     # A gap we cannot read is not evidence of a break. The
                     # missing receipt is already reported by resume as its own
@@ -1738,8 +1749,11 @@ class Mission:
         current_by_key: dict[str, tuple[str, dict | None, str | None]] = {}
         missing: list[str] = []
         unplaceable_opaque: list[tuple[str, str]] = []
+        effect_paths = self._effect_path_index()
         for request_id in latest["receipt_ids"]:
-            receipt, _refusal, opaque = self._load_receipt_checked(request_id)
+            receipt, _refusal, opaque = self._load_receipt_checked(
+                request_id, effect_paths=effect_paths
+            )
             # KIND, not a boolean. Both opaque kinds behave identically here
             # (present, unverifiable, never "lost"), and differ only in the
             # marker and message the operator is handed.
@@ -1758,7 +1772,7 @@ class Mission:
             # Claiming the slot as an OPAQUE entry supersedes the stale
             # receipt without asserting anything this reader cannot check.
             rel = (receipt["artifact_path"] if receipt is not None
-                   else self._historical_effect_path(request_id))
+                   else effect_paths.get(request_id))
             if rel is None:
                 if kind:
                     # Unattributable but NOT lost: a receipt that is merely

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -879,7 +879,9 @@ class Mission:
         # immutable for the mission's life, so reading it once is sound and
         # keeps receipt loading off a per-call chain read.
         self._mission_id: str | None = None
-        self._effect_index_cache: tuple[int, dict[str, str]] | None = None
+        self._effect_index_cache: tuple[
+            tuple[tuple[str, str], ...], dict[str, str]
+        ] | None = None
 
     # -- construction -----------------------------------------------------
 
@@ -1216,16 +1218,22 @@ class Mission:
                 self._mission_id = None
         return self._mission_id
 
-    def _load_receipt(self, request_id: str) -> dict | None:
+    def _load_receipt(
+            self, request_id: str, *,
+            effect_paths: dict[str, str] | None = None
+    ) -> dict | None:
         """None means UNLOADABLE -- absent, corrupt, schema-invalid, or
         BELONGING TO ANOTHER MISSION alike. A corrupt receipt must degrade to
         drift (RECEIPT-MISSING), never crash resume: crashing the recovery
         path on a mangled receipt is a denial of service by exactly the
         tampering drift detection exists to catch."""
-        return self._load_receipt_checked(request_id)[0]
+        return self._load_receipt_checked(
+            request_id, effect_paths=effect_paths
+        )[0]
 
     def _load_receipt_checked(
-            self, request_id: str
+            self, request_id: str, *,
+            effect_paths: dict[str, str] | None = None
     ) -> tuple[dict | None, str | None, tuple[str, str] | None]:
         """(record, refusal reason, OPAQUE). ONE implementation of the trust rule,
         two callers: `_load_receipt` wants only the verdict, while
@@ -1331,7 +1339,10 @@ class Mission:
         # raises the bar without closing that case; it is the es#118 residue,
         # and the tail anchor closes it. Disclosed in SECURITY.md rather than
         # papered over here.
-        chained = self._effect_path_index().get(request_id)
+        chained = (
+            effect_paths if effect_paths is not None
+            else self._effect_path_index()
+        ).get(request_id)
         if chained is not None and record.get("artifact_path") != chained:
             return None, (
                 f"present receipt claims {record.get('artifact_path')!r}, "
@@ -1377,20 +1388,28 @@ class Mission:
         millions of JSON parses. Callers that want ALL the paths ask once.
         Ids with no derivable path are ABSENT (never mapped to a guess), so
         `.get(rid)` returns None exactly where the per-id method does."""
-        # CACHED against the checkpoint COUNT, not time: the chain is
-        # append-only, so a count that has not moved cannot have new ids in
-        # it, and a count that has moved rebuilds. Without this, binding
-        # `_load_receipt` to the chain (round 7) would have reintroduced the
-        # quadratic walk round 3 removed -- resume() loads every receipt.
+        # Cache against exact checkpoint CONTENT, not merely count. Interior
+        # rewrites are rejected by chain verification, but checkpoint@1's tail
+        # is deliberately unsealed until contract@2; a same-count tail rewrite
+        # must not leave an authority-sensitive path index stale. Reading each
+        # file once to fingerprint it preserves a linear scan and lets a cache
+        # hit avoid reparsing while still observing that supported boundary.
         paths = self.store.checkpoint_paths()
+        raw_records: list[bytes] = []
+        identity: list[tuple[str, str]] = []
+        for cp_path in paths:
+            data = cp_path.read_bytes()
+            identity.append((cp_path.name, sha256_bytes(data)))
+            raw_records.append(data)
+        fingerprint = tuple(identity)
         if self._effect_index_cache is not None \
-                and self._effect_index_cache[0] == len(paths):
+                and self._effect_index_cache[0] == fingerprint:
             return self._effect_index_cache[1]
         index: dict[str, str] = {}
         prev_ids: list[str] = []
         prev_notes: list[str] = []
-        for cp_path in paths:
-            record = json.loads(cp_path.read_text(encoding="utf-8"))
+        for data in raw_records:
+            record = json.loads(data)
             ids = record["receipt_ids"]
             notes = record["state"]["notes"]
             fresh = [rid for rid in ids if rid not in prev_ids]
@@ -1400,7 +1419,7 @@ class Mission:
                     for rid in fresh:
                         index.setdefault(rid, path)
             prev_ids, prev_notes = ids, notes
-        self._effect_index_cache = (len(paths), index)
+        self._effect_index_cache = (fingerprint, index)
         return index
 
     def _all_receipt_ids_ever(self) -> list[str]:
@@ -2165,7 +2184,9 @@ class Mission:
             # as the sounder authority everywhere else in this module.
             rel = effect_paths.get(request_id)
             if rel is None:
-                receipt = self._load_receipt(request_id)
+                receipt = self._load_receipt(
+                    request_id, effect_paths=effect_paths
+                )
                 rel = receipt["artifact_path"] if receipt is not None else None
             if rel is None:
                 continue

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -2155,6 +2155,7 @@ class Mission:
         if not includes and not excludes:
             return []
         findings: list[dict] = []
+        effect_paths = self._effect_path_index()
         for request_id in self._all_receipt_ids_ever():
             # The CHAINED effect note, not the receipt file, decides which
             # artifact an id covers. A receipt is a mutable file: a schema-valid
@@ -2162,7 +2163,7 @@ class Mission:
             # artifact_path would move an out-of-scope write into scope and let
             # PASS through. The chain is tamper-evident and is already treated
             # as the sounder authority everywhere else in this module.
-            rel = self._historical_effect_path(request_id)
+            rel = effect_paths.get(request_id)
             if rel is None:
                 receipt = self._load_receipt(request_id)
                 rel = receipt["artifact_path"] if receipt is not None else None

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1808,6 +1808,39 @@ def test_effect_path_index_matches_per_id(workspace: Path) -> None:
     check("index-covers-reconciled-id", index.get("req-a-again") == "notes/a.md")
 
 
+def test_scope_consistency_reuses_single_effect_index(workspace: Path) -> None:
+    """es#161: closing must not rescan the checkpoint chain per receipt."""
+    m = open_mission(
+        workspace, "m-scope-index", "One indexed scope traversal.",
+        scope_in=["docs/**"],
+    )
+    m.approve()
+    for i in range(40):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    original_index = m._effect_path_index
+    original_per_id = m._historical_effect_path
+    index_calls = 0
+    per_id_calls = 0
+
+    def counted_index():
+        nonlocal index_calls
+        index_calls += 1
+        return original_index()
+
+    def counted_per_id(request_id: str, kind: bool = False):
+        nonlocal per_id_calls
+        per_id_calls += 1
+        return original_per_id(request_id, kind)
+
+    m._effect_path_index = counted_index
+    m._historical_effect_path = counted_per_id
+    findings = m.scope_consistency()
+    check("scope-index-preserves-findings", findings == [])
+    check("scope-index-built-once", index_calls == 1)
+    check("scope-index-never-rescans-per-id", per_id_calls == 0)
+
+
 def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
     """Round-3 finding: a schema-valid receipt planted at the lost id's path
     must not buy continuity. The chain records which artifact the id was
@@ -4711,6 +4744,7 @@ TESTS = [
     test_note_cannot_forge_machine_state,
     test_receipt_ids_always_carry_a_derivable_path,
     test_effect_path_index_matches_per_id,
+    test_scope_consistency_reuses_single_effect_index,
     test_foreign_mission_receipt_is_not_this_missions_receipt,
     test_cross_workspace_receipt_cannot_silence_drift,
     test_backslash_effect_path_still_loads_its_own_receipt,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1808,6 +1808,78 @@ def test_effect_path_index_matches_per_id(workspace: Path) -> None:
     check("index-covers-reconciled-id", index.get("req-a-again") == "notes/a.md")
 
 
+def test_effect_path_index_agrees_after_readmission(workspace: Path) -> None:
+    """The index and the per-id lookup must still agree when an id is admitted
+    with NO effect note, dropped from receipt_ids, and later RE-ADMITTED by a
+    revision that does carry one.
+
+    es#161's linear rewrite replaced the index's adjacent-checkpoint freshness
+    test (`rid not in prev_ids`) with a mission-wide first-admission set
+    (`rid not in known_ids`). That is not only a speed change. On this chain
+    the old shape treated the re-admitting revision as a fresh admission and
+    re-derived `req-x` from ITS note -- answering 'secrets/x.md' -- while
+    `_historical_effect_path` stopped at the first admission and answered
+    None. Measured on 488f252 (this PR's exact base) and on b6c6eef: index
+    'secrets/x.md' vs per-id None. The existing pin
+    (test_effect_path_index_matches_per_id) could not see it, because its
+    noteless id is never dropped and re-admitted -- so the one test that
+    exists to stop these two readers drifting was blind to the case where
+    they had already drifted.
+
+    None is the answer the contract asks for: `_effect_path_index` declares
+    that ids with no derivable path are ABSENT, never mapped to a guess, and
+    that `.get(rid)` returns None exactly where the per-id method does. The
+    consequence is deliberate and belongs in a test rather than a reviewer's
+    memory: with no chained path for such an id, `_load_receipt_checked` has
+    nothing to compare a receipt against, so the receipt file is the only
+    authority. The base's disagreeing index refused that receipt -- an
+    accident of the drift, not a rule anyone wrote down.
+
+    `record_effect` refuses any id already in the mission's history, so only
+    a direct chain write can produce this shape: legacy or hand-written
+    history, which is exactly the class the underivable-id fallback exists
+    for. If a later change deliberately teaches BOTH readers to keep scanning
+    past a noteless first admission, `readmit-index-answers-none` is the
+    check that must be updated with it -- the agreement check above it is the
+    invariant that must not be."""
+    m = open_mission(workspace, "m-readmit", "Re-admitted noteless id.")
+    m.approve()
+    m.record_effect("docs/a.md", "aa", "req-a")
+
+    def bare(note: str, *, add=None, ids=None) -> None:
+        latest, path = m.store.load_latest()
+        m._write_next(
+            latest, path, status=latest["status"], add_receipt_id=add,
+            receipt_ids=ids,
+            unresolved_verdicts=latest["state"]["unresolved_verdicts"],
+            note=note)
+
+    bare("bare progress note with no effect marker", add="req-x")
+    latest, _ = m.store.load_latest()
+    bare("bare removal note",
+         ids=[r for r in latest["receipt_ids"] if r != "req-x"])
+    bare("effect: secrets/x.md", add="req-x")
+
+    # NOT VACUOUS. Without these two the whole test would pass on a chain
+    # where the re-admission never happened -- the failure mode of a
+    # regression test whose scenario silently stops being built.
+    notes = [n for p in m.store.checkpoint_paths()
+             for n in json.loads(p.read_text(encoding="utf-8"))["state"]["notes"]]
+    check("readmit-note-is-really-in-the-chain",
+          "effect: secrets/x.md" in notes)
+    check("readmit-id-is-really-back",
+          "req-x" in m.status()["receipt_ids"]
+          and m._all_receipt_ids_ever() == ["req-a", "req-x"])
+
+    index = m._effect_path_index()
+    check("readmit-index-agrees-with-per-id",
+          index.get("req-x") == m._historical_effect_path("req-x"))
+    check("readmit-index-answers-none", index.get("req-x") is None)
+    check("readmit-first-admission-still-wins-elsewhere",
+          index.get("req-a") == "docs/a.md"
+          and m._historical_effect_path("req-a") == "docs/a.md")
+
+
 def test_scope_consistency_reuses_single_effect_index(workspace: Path) -> None:
     """es#161: closing must not rescan the checkpoint chain per receipt."""
     m = open_mission(
@@ -5036,6 +5108,7 @@ TESTS = [
     test_note_cannot_forge_machine_state,
     test_receipt_ids_always_carry_a_derivable_path,
     test_effect_path_index_matches_per_id,
+    test_effect_path_index_agrees_after_readmission,
     test_scope_consistency_reuses_single_effect_index,
     test_scope_consistency_reuses_index_for_underivable_ids,
     test_effect_path_index_invalidates_on_same_count_tail_rewrite,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1841,6 +1841,68 @@ def test_scope_consistency_reuses_single_effect_index(workspace: Path) -> None:
     check("scope-index-never-rescans-per-id", per_id_calls == 0)
 
 
+def test_scope_consistency_reuses_index_for_underivable_ids(
+        workspace: Path) -> None:
+    """The receipt fallback must not re-enumerate checkpoints for every miss.
+
+    An empty index models a legacy/noteless chain: every valid receipt must
+    supply its own path.  Before the fix, receipt validation called the same
+    index method again for every ID, retaining O(U*C) behavior.
+    """
+    m = open_mission(
+        workspace, "m-scope-index-fallback", "One fallback traversal.",
+        scope_in=["docs/**"],
+    )
+    m.approve()
+    for i in range(40):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    index_calls = 0
+
+    def underivable_index():
+        nonlocal index_calls
+        index_calls += 1
+        return {}
+
+    m._effect_path_index = underivable_index
+    findings = m.scope_consistency()
+    check("scope-fallback-preserves-receipt-findings", findings == [])
+    check("scope-fallback-index-built-once", index_calls == 1)
+
+
+def test_effect_path_index_invalidates_on_same_count_tail_rewrite(
+        workspace: Path) -> None:
+    """An unsealed checkpoint@1 tail rewrite must invalidate cached paths."""
+    m = open_mission(
+        workspace, "m-scope-index-tail", "Observe the current tail.",
+        scope_in=["docs/**"],
+    )
+    m.approve()
+    m.record_effect("docs/a.txt", "x", "req-a")
+    check("scope-tail-cache-warmed",
+          m._effect_path_index().get("req-a") == "docs/a.txt")
+
+    tail = m.store.checkpoint_paths()[-1]
+    checkpoint = json.loads(tail.read_text(encoding="utf-8"))
+    checkpoint["state"]["notes"] = [
+        "effect: secrets/a.txt" if note == "effect: docs/a.txt" else note
+        for note in checkpoint["state"]["notes"]
+    ]
+    tail.write_text(
+        json.dumps(checkpoint, indent=1, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    check("scope-tail-per-id-sees-current-path",
+          m._historical_effect_path("req-a") == "secrets/a.txt")
+    check("scope-tail-index-sees-current-path",
+          m._effect_path_index().get("req-a") == "secrets/a.txt")
+    findings = m.scope_consistency()
+    check("scope-tail-rewrite-is-not-hidden-by-cache",
+          [(f["artifact_path"], f["request_id"]) for f in findings]
+          == [("secrets/a.txt", "req-a")])
+
+
 def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
     """Round-3 finding: a schema-valid receipt planted at the lost id's path
     must not buy continuity. The chain records which artifact the id was
@@ -4745,6 +4807,8 @@ TESTS = [
     test_receipt_ids_always_carry_a_derivable_path,
     test_effect_path_index_matches_per_id,
     test_scope_consistency_reuses_single_effect_index,
+    test_scope_consistency_reuses_index_for_underivable_ids,
+    test_effect_path_index_invalidates_on_same_count_tail_rewrite,
     test_foreign_mission_receipt_is_not_this_missions_receipt,
     test_cross_workspace_receipt_cannot_silence_drift,
     test_backslash_effect_path_still_loads_its_own_receipt,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1903,6 +1903,137 @@ def test_effect_path_index_invalidates_on_same_count_tail_rewrite(
           == [("secrets/a.txt", "req-a")])
 
 
+def test_resume_and_continuity_share_one_effect_index(
+        workspace: Path) -> None:
+    """Bulk readers must fingerprint the checkpoint chain only once each.
+
+    Receipt validation binds a mutable receipt to its chain-recorded path.
+    Calling that validation without passing the already-built path index makes
+    every receipt reload fingerprint every checkpoint, even when the index
+    cache itself hits.  Repeated writes to one artifact also exercise the
+    second receipt-loading loop in ``continuity_breaks``.
+    """
+    m = open_mission(
+        workspace, "m-reader-index", "One index per bulk reader.",
+    )
+    m.approve()
+    for i in range(16):
+        m.record_effect("docs/shared.txt", str(i), f"req-{i}")
+
+    original_index = m._effect_path_index
+    index_calls = 0
+
+    def counted_index():
+        nonlocal index_calls
+        index_calls += 1
+        return original_index()
+
+    m._effect_path_index = counted_index
+    check("resume-index-preserves-clean-result", m.resume() == [])
+    check("resume-index-built-once", index_calls == 1)
+
+    index_calls = 0
+    check("continuity-index-preserves-clean-result",
+          m.continuity_breaks() == [])
+    check("continuity-index-built-once", index_calls == 1)
+
+
+def test_effect_path_index_does_not_retain_checkpoint_bytes(
+        workspace: Path) -> None:
+    """Fingerprinting may hold one checkpoint's bytes, never the whole chain.
+
+    A bytes subclass records the maximum number of checkpoint payloads alive
+    together.  This is a positive memory-shape oracle rather than a timing or
+    source-text assertion: retaining a cumulative ``raw_records`` list makes
+    the peak grow with every checkpoint, while a streaming fingerprint plus
+    cache-miss reread keeps it constant.
+    """
+    m = open_mission(
+        workspace, "m-index-stream", "Stream checkpoint fingerprints.",
+    )
+    m.approve()
+    for i in range(12):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    original_read_bytes = Path.read_bytes
+    checkpoint_dir = m.store.checkpoints_dir
+
+    class TrackedBytes(bytes):
+        live = 0
+        peak = 0
+
+        def __new__(cls, value: bytes):
+            instance = super().__new__(cls, value)
+            cls.live += 1
+            cls.peak = max(cls.peak, cls.live)
+            return instance
+
+        def __del__(self):
+            type(self).live -= 1
+
+    def tracked_read_bytes(path: Path) -> bytes:
+        data = original_read_bytes(path)
+        if path.parent == checkpoint_dir:
+            return TrackedBytes(data)
+        return data
+
+    m._effect_index_cache = None
+    Path.read_bytes = tracked_read_bytes
+    try:
+        index = m._effect_path_index()
+    finally:
+        Path.read_bytes = original_read_bytes
+
+    check("index-stream-preserves-all-paths", len(index) == 12)
+    check("index-stream-bounds-live-checkpoint-bytes", TrackedBytes.peak <= 2)
+    check("index-stream-releases-checkpoint-bytes", TrackedBytes.live == 0)
+
+
+def test_effect_path_index_uses_set_membership(workspace: Path) -> None:
+    """Cumulative receipt-id lists must not trigger cubic comparisons.
+
+    Each checkpoint repeats all prior IDs, so list membership compares every
+    repeated prefix against the previous prefix.  Counting equality calls
+    distinguishes that cubic comparison shape from set membership's linear
+    work in the already-quadratic number of serialized IDs.
+    """
+    effect_count = 18
+    m = open_mission(
+        workspace, "m-index-membership", "Bound ID membership work.",
+    )
+    m.approve()
+    for i in range(effect_count):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    original_loads = json.loads
+
+    class CountingStr(str):
+        comparisons = 0
+        __hash__ = str.__hash__
+
+        def __eq__(self, other: object) -> bool:
+            type(self).comparisons += 1
+            return super().__eq__(other)
+
+    def counted_loads(value, *args, **kwargs):
+        record = original_loads(value, *args, **kwargs)
+        if isinstance(record, dict) and isinstance(record.get("receipt_ids"), list):
+            record["receipt_ids"] = [CountingStr(rid)
+                                     for rid in record["receipt_ids"]]
+        return record
+
+    m._effect_index_cache = None
+    json.loads = counted_loads
+    try:
+        index = m._effect_path_index()
+    finally:
+        json.loads = original_loads
+
+    check("index-membership-preserves-all-paths", len(index) == effect_count)
+    check("index-membership-comparisons-are-not-cubic",
+          CountingStr.comparisons < effect_count * effect_count)
+
+
 def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
     """Round-3 finding: a schema-valid receipt planted at the lost id's path
     must not buy continuity. The chain records which artifact the id was
@@ -4809,6 +4940,9 @@ TESTS = [
     test_scope_consistency_reuses_single_effect_index,
     test_scope_consistency_reuses_index_for_underivable_ids,
     test_effect_path_index_invalidates_on_same_count_tail_rewrite,
+    test_resume_and_continuity_share_one_effect_index,
+    test_effect_path_index_does_not_retain_checkpoint_bytes,
+    test_effect_path_index_uses_set_membership,
     test_foreign_mission_receipt_is_not_this_missions_receipt,
     test_cross_workspace_receipt_cannot_silence_drift,
     test_backslash_effect_path_still_loads_its_own_receipt,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -2034,6 +2034,105 @@ def test_effect_path_index_uses_set_membership(workspace: Path) -> None:
           CountingStr.comparisons < effect_count * effect_count)
 
 
+def _count_checkpoint_reads(fn):
+    """Run `fn`; return (result, reads of files under any `checkpoints/` dir).
+
+    The oracle is FILE READS, not calls to `_effect_path_index`. A counter
+    installed on that method goes green the moment the call moves, whether or
+    not the chain is still being re-read -- and re-reading the chain is the
+    cost, not calling the method. Counting reads measures what the claim is
+    about."""
+    orig_bytes, orig_text = Path.read_bytes, Path.read_text
+    reads = 0
+
+    def counted_bytes(self):
+        nonlocal reads
+        if self.parent.name == "checkpoints":
+            reads += 1
+        return orig_bytes(self)
+
+    def counted_text(self, *args, **kwargs):
+        nonlocal reads
+        if self.parent.name == "checkpoints":
+            reads += 1
+        return orig_text(self, *args, **kwargs)
+
+    Path.read_bytes, Path.read_text = counted_bytes, counted_text
+    try:
+        return fn(), reads
+    finally:
+        Path.read_bytes, Path.read_text = orig_bytes, orig_text
+
+
+def test_census_receipts_does_not_rescan_the_chain_per_receipt(
+        workspace: Path) -> None:
+    """es#161 residue: the ESTATE WALK must not re-read the chain per receipt.
+
+    `census_missions._receipts` builds the chain index once and then calls
+    `_load_receipt_checked` for every id WITHOUT handing that index over, so
+    every receipt re-enters `_effect_path_index`. That was survivable while a
+    cache hit cost one directory listing. Keying the cache to checkpoint
+    CONTENT -- the right fix for the stale-index finding -- turns each hit
+    into a full SHA-256 pass over the whole cumulative chain, so the census
+    goes from O(C) checkpoint reads to O(R x C): measured on a 300-receipt
+    mission, 303 reads / 1.9 MiB before the content key, 91,205 reads /
+    578 MiB after it.
+
+    The same class as the finding it came from, in the sibling module the
+    optimisation exists to serve. Every other control here counts calls on a
+    `Mission` method and none of them runs the census, so none of them sees
+    it."""
+    effect_count = 24
+    m = open_mission(workspace, "m-census-io", "Bounded census chain reads.")
+    m.approve()
+    for i in range(effect_count):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+    latest, _ = m.store.load_latest()
+    checkpoints = len(m.store.checkpoint_paths())
+    m._effect_index_cache = None
+
+    (paths, problems, orphans), reads = _count_checkpoint_reads(
+        lambda: census_missions._receipts(m, m.store, latest))
+
+    check("census-io-preserves-every-path", len(paths) == effect_count)
+    check("census-io-reports-no-problems", not problems and not orphans)
+    # One index build reads each checkpoint at most twice (fingerprint, then
+    # parse). Anything that scales with the RECEIPT count is a per-id rescan.
+    check("census-io-does-not-rescan-per-receipt", reads <= 4 * checkpoints)
+
+
+def test_census_still_reports_receipts_when_the_index_is_unbuildable(
+        workspace: Path) -> None:
+    """The failure mode the rescan fix introduces, pinned.
+
+    Handing the census's prebuilt mapping to `_load_receipt_checked` removes
+    the rescan -- and would also hand it an EMPTY mapping on the path where
+    the index could not be built at all, silently disabling the loader's own
+    chained-path check and turning unreadable receipts into ordinary ones.
+    So the fix forwards only a mapping it actually built; when the build
+    fails the loader is called exactly as before, re-raises, and every id is
+    still reported."""
+    m = open_mission(workspace, "m-census-blind", "Index build fails.")
+    m.approve()
+    m.record_effect("docs/a.txt", "a", "req-a")
+    m.record_effect("docs/b.txt", "b", "req-b")
+    latest, _ = m.store.load_latest()
+
+    def _boom():
+        raise OSError("checkpoints unreadable")
+
+    m._effect_path_index = _boom
+    paths, problems, orphans = census_missions._receipts(m, m.store, latest)
+
+    blob = " ".join(problems)
+    check("census-blind-reports-index-failure",
+          "chain index unreadable" in blob)
+    check("census-blind-still-names-every-id",
+          all(f"{rid}: " in blob for rid in ("req-a", "req-b")))
+    check("census-blind-does-not-report-clean-coverage", paths == [])
+    check("census-blind-no-orphans-invented", orphans == [])
+
+
 def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
     """Round-3 finding: a schema-valid receipt planted at the lost id's path
     must not buy continuity. The chain records which artifact the id was
@@ -4943,6 +5042,8 @@ TESTS = [
     test_resume_and_continuity_share_one_effect_index,
     test_effect_path_index_does_not_retain_checkpoint_bytes,
     test_effect_path_index_uses_set_membership,
+    test_census_receipts_does_not_rescan_the_chain_per_receipt,
+    test_census_still_reports_receipts_when_the_index_is_unbuildable,
     test_foreign_mission_receipt_is_not_this_missions_receipt,
     test_cross_workspace_receipt_cannot_silence_drift,
     test_backslash_effect_path_still_loads_its_own_receipt,


### PR DESCRIPTION
Closes #161

## Summary

- build one chain-derived request-id → effect-path index and thread that exact mapping through `scope_consistency()`, `resume()`, and `continuity_breaks()`
- reuse the mapping during fallback receipt validation, including genuinely underivable legacy/noteless IDs
- key the cache to exact checkpoint filename/content digests while retaining only one checkpoint payload at a time
- use mission-wide set membership for cumulative receipt IDs, eliminating the cubic comparison shape
- preserve the authority/fallback behavior and add focused positive controls for every repaired path

## Seeded RED → GREEN

- exact base performs a per-ID historical chain lookup during scope close; the original 40-receipt control observes 40 per-ID scans
- reviewed head `2c9b982bda7f673b1c35d0e4c95eff55c506c38f` re-enumerates checkpoints for every underivable receipt; the fallback control fails there and proves exactly one call now
- the reviewed count-keyed cache hides a same-count tail rewrite from `docs/a` to `secrets/a`; the tail-rewrite control now invalidates the cache and reports the crossing
- reviewed head `b6c6eeff74297508cf2f9ed8e48f70975901ca89` fingerprints the full checkpoint chain once per receipt in `resume()` and `continuity_breaks()`; the 16-receipt control fails there and now proves exactly one index call per bulk reader
- that head also retains every cumulative checkpoint payload; the bytes-lifetime oracle fails there and now proves bounded live checkpoint bytes plus full release
- its growing-list membership has a cubic comparison shape; the equality-count oracle fails there and now proves set-bounded membership while preserving every indexed path

## Verification

- exact base: `main@488f252647dd9e5b38ac091097bb4a2f65c1e016`
- exact head: `def3ebaf4012a9970bd53203a94d5efb6d720a49`
- exact tree: `27d525cf0174cd5637e650989a5ebd27c69da573`
- exact blobs: `custody_mission.py` = `f8594ea5d894713bf94603826ef2f71da4def4ce`; `test_custody_mission.py` = `2bf4d188090d66577a77b498138143102681bae1`
- ancestry: 3 ahead / 0 behind exact base; only the two named files changed
- `python -m py_compile custody_mission.py test_custody_mission.py`
- all seven mission-custody programs pass locally: semantic/schema, store, mission, CLI, gate, hook, and three-process continuity proof
- `git diff --check` passes
- exact-head hosted workflows completed successfully with real runner steps:
  - epistemic-flexibility: `32671251123`
  - openai-bundles: `32671251199`
  - mission-custody-contract: `32671251144`
  - release-security: `32671251078`
  - commission-watch-contract: `32671251201`
  - wiki-contract: `32671251139`
- all five review findings were reproduced, fixed, replied to, and resolved only after exact-head real-step CI
- exact-head Codex review found no major issues and opened no new threads: [result 5388886236](https://github.com/ZMS-Labs/epistemic-skills/pull/218#issuecomment-5388886236)

## Merge gate

`HOLD_EXTERNAL_SECURITY_REVIEW`: the independent security-review connector returned its usage-limit refusal. Do not merge until a substantive independent security review of the unchanged exact head is available.

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: all seven mission-custody programs and all six real-step hosted workflows pass on exact head
rollback_or_return_path: revert commits def3ebaf, b6c6eef, and 2c9b982
-->