### PR TITLE
feat(es173): concurrent missions — adjudicated design implementation

### DIFF
--- a/.github/workflows/mission-custody-contract.yml
+++ b/.github/workflows/mission-custody-contract.yml
@@ -57,6 +57,8 @@ jobs:
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
       - name: Custody gate unit tests
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
+      - name: es#173 concurrent-missions case-table spec
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
       # The Stage-C enforcement hook's own suite was NOT run by any workflow.
       # Its platform-aware assertions are written to discriminate on POSIX --
       # `native = "c:/ok" if os.name == "nt" else "/c:/ok"` -- so on a Windows
@@ -108,6 +110,8 @@ jobs:
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
       - name: Custody gate unit tests
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
+      - name: es#173 concurrent-missions case-table spec
+        run: python plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
       - name: Custody enforcement hook tests
         run: python plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
       - name: Three-subprocess kill/resume/repair continuity proof

--- a/plugins/epistemic-skills/contracts/mission-custody/census_missions.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/census_missions.py
@@ -679,10 +679,11 @@ def summarize(reports: list[dict]) -> dict:
     no_active = []
     for r in reports:
         act = [m["mission"] for m in r["missions"] if m["active"]]
-        if len(act) > 1:
-            fail_open.append({"root": r["root"], "cause": "multiple active",
-                              "missions": act})
-        elif not act:
+        # es#173: plurality is LEGAL and the gate evaluates the UNION of all
+        # approved missions' guards, so N>1 active is no longer a fail-open
+        # cause -- reporting it as one would be the inverse of the
+        # cry-fail-open defect this file has already paid for three times.
+        if not act:
             # NOT a disarmed guard -- there is nothing here to arm. But
             # `Mission.load` raises NoActiveMission and the gate is inert, so
             # a Q1 that says nothing about this root leaves the summary line

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -532,10 +532,17 @@ def dispatch(args: argparse.Namespace) -> int:
             acknowledge_unreadable=args.acknowledge_unreadable)
         _print_status(receipt)
     elif args.command == "resume":
-        drift = mission.resume()
-        for relpath in drift:
-            print(_ascii_safe(relpath))
-        if not drift:
+        findings = mission.resume()
+        for marker in findings:
+            print(_ascii_safe(marker))
+        # SIBLING-DISCHARGED is finding-grade but non-blocking (operator
+        # ruling 2026-08-25, loud auto-discharge): it rides stdout like
+        # every finding -- a resume that discharged a transient sibling
+        # crossing must NEVER print "clean" -- but it leaves nothing
+        # unresolved, so it does not contribute to the drift exit code.
+        drift = [m for m in findings
+                 if not m.startswith("SIBLING-DISCHARGED:")]
+        if not findings:
             n = len(set(mission.status()["receipt_ids"]))
             vacuous = " -- vacuously (no effects recorded)" if n == 0 else ""
             print(f"resume: clean; {n} receipt id(s) on record{vacuous}",

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -483,8 +483,13 @@ def dispatch(args: argparse.Namespace) -> int:
 
     if args.command == "gate":
         from custody_gate import run_gate
+        # OD-4 refined ("Self-arm at open, union at approve", operator
+        # ruling 2026-08-25): the session binding self-arms the bound
+        # mission's own guards. Exposure only grows -- the union of
+        # approved missions is evaluated with or without a binding.
         verdict = run_gate(workspace, _read_tool_call(args), actor=args.actor,
-                           session_id="", harness="cli")
+                           session_id="", harness="cli",
+                           bound_mission=_session_binding(args))
         _print_status(verdict)
         return 2 if verdict["decision"] == "block" else 0
 

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -6,8 +6,13 @@ revision number for lifecycle mutations, the receipt JSON for effect and
 reconcile, the checkpoint JSON for status.
 
 Discovery is pathless by contract: no subcommand other than `open` accepts a
---mission-path or --mission-id flag. `Mission.load()` finds the single active
-mission under --workspace on every other command.
+--mission-path or --mission-id flag. Under es#173 concurrent missions a
+session declares which mission it acts under through exactly two channels --
+`--mission <id>` (per-call, wins) and the `ZMS_MISSION_ID` environment
+variable (session default); flag > env > unbound. Unbound, `Mission.load()`
+resolves the single active mission (unchanged), refuses `BindingRequired`
+when several are active, and a stale binding refuses `BindingInvalid` --
+it never falls through to discovery.
 
 Exit codes: 0 success; 2 usage/refusal (argparse prints usage; a CustodyError
 subclass prints its class name + message to stderr); 3 drift detected on
@@ -23,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -57,7 +63,23 @@ def _common_parser() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--workspace", required=True)
     common.add_argument("--actor", required=True)
+    # es#173 session->mission binding, channel 1 of 2 (channel 2 is the
+    # ZMS_MISSION_ID environment variable; the flag wins). Deliberately
+    # named --mission, NOT --mission-id/--mission-path: those flags remain
+    # banned outside `open` (pathless-discovery contract) -- this one names
+    # which mission's AUTHORITY the verb acts under, never a path.
+    common.add_argument("--mission", default=None)
     return common
+
+
+def _session_binding(args: argparse.Namespace) -> str | None:
+    """flag > env > unbound. An empty or whitespace env value is unset --
+    `export ZMS_MISSION_ID=` must not manufacture a binding."""
+    flag = getattr(args, "mission", None)
+    if flag:
+        return flag
+    env = os.environ.get("ZMS_MISSION_ID", "").strip()
+    return env or None
 
 
 def _add_content_flags(parser: argparse.ArgumentParser) -> None:
@@ -149,6 +171,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_open.add_argument("--guards-file", dest="guards_file")
     p_open.add_argument("--guard-mode", dest="guard_mode",
                         choices=["audit", "enforce"])
+    # es#173: quarantine an unreadable sibling mission dir, recorded in the
+    # opening checkpoint; open refuses otherwise (case row B17).
+    p_open.add_argument("--acknowledge-unreadable", action="append",
+                        default=[], dest="acknowledge_unreadable",
+                        metavar="DIR")
 
     sub.add_parser("approve", parents=[common])
 
@@ -176,6 +203,21 @@ def build_parser() -> argparse.ArgumentParser:
     p_effect.add_argument("--path", required=True)
     _add_content_flags(p_effect)
     p_effect.add_argument("--request-id", required=True)
+    # es#173 case row B23: effect under an unreadable active sibling refuses
+    # UnionDegraded until repaired or explicitly acknowledged (the
+    # acknowledgement is recorded in the acting mission's chain and
+    # persists).
+    p_effect.add_argument("--acknowledge-unreadable", action="append",
+                          default=[], dest="acknowledge_unreadable",
+                          metavar="DIR")
+
+    # es#173: plurality needs an enumeration verb.
+    sub.add_parser("missions", parents=[common],
+                   help="READ-ONLY list of every mission dir: id, status, "
+                        "approved?, steward, frontier")
+
+    p_ack_sib = sub.add_parser("acknowledge-sibling", parents=[common])
+    p_ack_sib.add_argument("--path", required=True)
 
     sub.add_parser("resume", parents=[common])
 
@@ -381,6 +423,12 @@ def dispatch(args: argparse.Namespace) -> int:
             raise CustodyError("--guard-mode requires --guards-file")
         guards = (_read_guards_file(args.guards_file)
                   if args.guards_file else None)
+        binding = _session_binding(args)
+        if binding is not None:
+            # Case row B4/B9: a present binding is validated on EVERY verb --
+            # a stale ZMS_MISSION_ID must refuse loudly, never be silently
+            # ignored. A valid binding does not otherwise affect `open`.
+            Mission.load(workspace, actor=args.actor, mission_id=binding)
         Mission.open(
             workspace, mission_id=args.mission_id,
             instruction=_read_text(args, "instruction"),
@@ -390,8 +438,47 @@ def dispatch(args: argparse.Namespace) -> int:
             permissions=args.permission, protected_state=args.protected,
             hold_if=args.hold_if, stop_if=args.stop_if, escalate_if=args.escalate_if,
             acceptable_costs=args.acceptable_costs,
-            guard_mode=args.guard_mode, actuator_guards=guards)
+            guard_mode=args.guard_mode, actuator_guards=guards,
+            acknowledge_unreadable=args.acknowledge_unreadable)
         print(1)  # Mission.open always writes revision 1
+        # The binding line for the shell: printed, NOT set -- a child
+        # process cannot set its parent's environment, and pretending
+        # otherwise would manufacture the "bound, actually unbound" decoy
+        # (es#173 section 1). stderr, so stdout keeps its one-value contract.
+        print(f"bind: export ZMS_MISSION_ID={_ascii_safe(args.mission_id)}",
+              file=sys.stderr)
+        return 0
+
+    if args.command == "missions":
+        rows = []
+        missions_root = workspace / "missions"
+        if missions_root.is_dir():
+            from custody_mission import _approved_by_chain
+            from custody_store import MissionStore
+            for mission_dir in sorted(missions_root.iterdir()):
+                if not mission_dir.is_dir():
+                    continue
+                store = MissionStore(mission_dir)
+                if not store.checkpoint_paths():
+                    continue
+                row = {"mission": mission_dir.name}
+                try:
+                    latest, _ = store.load_latest()
+                except (StoreError, ValueError) as exc:
+                    row.update({"status": "unreadable",
+                                "error": f"{type(exc).__name__}: {exc}",
+                                "approved": None, "steward_ref": None,
+                                "frontier": None})
+                else:
+                    row.update({
+                        "status": latest["status"],
+                        "approved": _approved_by_chain(store),
+                        "steward_ref": latest["manifest"]["steward_ref"],
+                        "frontier": latest["state"]["frontier"],
+                        "revision": latest["revision"],
+                    })
+                rows.append(row)
+        _print_status(rows)
         return 0
 
     if args.command == "gate":
@@ -401,7 +488,8 @@ def dispatch(args: argparse.Namespace) -> int:
         _print_status(verdict)
         return 2 if verdict["decision"] == "block" else 0
 
-    mission = Mission.load(workspace, actor=args.actor)
+    mission = Mission.load(workspace, actor=args.actor,
+                           mission_id=_session_binding(args))
 
     if args.command == "approve":
         print(mission.approve())
@@ -469,6 +557,8 @@ def dispatch(args: argparse.Namespace) -> int:
         _print_status(receipt)
     elif args.command == "acknowledge-loss":
         print(mission.acknowledge_receipt_loss(args.request_id))
+    elif args.command == "acknowledge-sibling":
+        print(mission.acknowledge_sibling(args.path))
     elif args.command == "verify":
         # READ-ONLY (es#138): never a lifecycle write. Exit 0 = chain intact,
         # exit 4 = chain break reported. Either way nothing was written.

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -522,8 +522,9 @@ def dispatch(args: argparse.Namespace) -> int:
     elif args.command == "frontier":
         print(mission.set_frontier(_read_text(args, "text")))
     elif args.command == "effect":
-        receipt = mission.record_effect(args.path, _read_content(args),
-                                         args.request_id)
+        receipt = mission.record_effect(
+            args.path, _read_content(args), args.request_id,
+            acknowledge_unreadable=args.acknowledge_unreadable)
         _print_status(receipt)
     elif args.command == "resume":
         drift = mission.resume()

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
@@ -335,6 +335,46 @@ def evaluate_union(entries: list[dict], tool_call: dict) -> list[dict]:
     return matches
 
 
+def effect_rule_matches(rule: dict, artifact_relpath: str) -> bool:
+    """Does an armed guard bind the `effect` verb's write to this path?
+    (es#173, OD-2: effect IS the file write.)
+
+    `tool_names` -- a harness concept -- deliberately does NOT filter here:
+    the effect verb is not a harness tool, and a guard that binds a path
+    must bind the path however the write is spelled, or the custody CLI
+    itself remains the one unmediated writer (the FATAL-2 hole restated).
+    Over-matching is this module's documented safe direction: a false block
+    names its rule and is discharged per-mission by amend. Rules carrying
+    only command_regexes never match an effect -- there is no command."""
+    target = _guard_norm_path(artifact_relpath)
+    return any(_guard_glob_regex(glob).match(target)
+               for glob in rule["path_globs"])
+
+
+def evaluate_effect_union(entries: list[dict], artifact_relpath: str) -> list[dict]:
+    """Every matching (mission, rule) pair for an `effect` write, across
+    the union of APPROVED missions' armed guards -- the OD-2 surface,
+    sharing OD-4 membership with `evaluate_union` (approved contributes,
+    unapproved is subject-only). Entries carry {"name", "authority",
+    "approved"}."""
+    matches: list[dict] = []
+    for entry in entries:
+        if not entry.get("approved"):
+            continue
+        authority = entry["authority"]
+        mode = authority.get("guard_mode")
+        guards = authority.get("actuator_guards")
+        if not mode or not guards:
+            continue
+        for rule in guards:
+            if effect_rule_matches(rule, artifact_relpath):
+                matches.append({"mission": entry["name"],
+                                "rule": rule["name"], "mode": mode,
+                                "decision": ("block" if mode == "enforce"
+                                             else "allow")})
+    return matches
+
+
 def _degraded_disclosure(degraded: list[dict]) -> str:
     names = ", ".join(sorted(d["name"] for d in degraded))
     return (f" UNION DEGRADED: mission dir(s) {names} unreadable -- their "

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
@@ -307,18 +307,27 @@ def _union_entries(workspace: Path, actor: str) -> tuple[list[dict], list[dict]]
     return entries, degraded
 
 
-def evaluate_union(entries: list[dict], tool_call: dict) -> list[dict]:
+def evaluate_union(entries: list[dict], tool_call: dict,
+                   own_mission: str | None = None) -> list[dict]:
     """Every matching (mission, rule) pair across the union of APPROVED
-    missions' armed guards -- ALL matches, not first: the operator
-    discharging a block needs the full bill (es#173 section 2).
+    missions' armed guards, plus the bound mission's OWN guards -- ALL
+    matches, not first: the operator discharging a block needs the full
+    bill (es#173 section 2).
 
-    OD-1 UNION-ALWAYS: callers pass every entry; binding routes authority,
-    never exposure. OD-4 GATE ON APPROVE: an unapproved entry contributes
-    nothing -- checked here, in the one place membership is decided, so a
-    draft mission is subject to the union while arming none of it."""
+    OD-1 UNION-ALWAYS: callers pass every entry; binding routes authority
+    and never REMOVES exposure. OD-4 REFINED (operator ruling 2026-08-25:
+    "Self-arm at open, union at approve"): a mission's armed guards bind
+    its OWN session -- a call bound to it via `own_mission` -- from the
+    moment open arms them, exactly as the pre-union core behaved; they
+    join the fleet-wide union only once the mission is chain-approved.
+    Unbound calls see only the approved union, so an unblessed draft
+    still cannot block OTHER sessions -- membership is decided here, in
+    the one place, and binding can only ADD the bound mission's own
+    guards (the safe direction: a false block names its rule and is
+    discharged by amend)."""
     matches: list[dict] = []
     for entry in entries:
-        if not entry.get("approved"):
+        if not entry.get("approved") and entry["name"] != own_mission:
             continue
         authority = entry["latest"]["manifest"]["authority"]
         mode = authority.get("guard_mode")
@@ -351,15 +360,19 @@ def effect_rule_matches(rule: dict, artifact_relpath: str) -> bool:
                for glob in rule["path_globs"])
 
 
-def evaluate_effect_union(entries: list[dict], artifact_relpath: str) -> list[dict]:
+def evaluate_effect_union(entries: list[dict], artifact_relpath: str,
+                          own_mission: str | None = None) -> list[dict]:
     """Every matching (mission, rule) pair for an `effect` write, across
-    the union of APPROVED missions' armed guards -- the OD-2 surface,
-    sharing OD-4 membership with `evaluate_union` (approved contributes,
-    unapproved is subject-only). Entries carry {"name", "authority",
-    "approved"}."""
+    the union of APPROVED missions' armed guards plus the acting
+    mission's OWN guards -- the OD-2 surface, sharing OD-4 REFINED
+    membership with `evaluate_union` ("Self-arm at open, union at
+    approve", operator ruling 2026-08-25): a draft mission's own effect
+    is checked against its own guards from open, and against the
+    approved union; its guards bind no OTHER mission pre-approve.
+    Entries carry {"name", "authority", "approved"}."""
     matches: list[dict] = []
     for entry in entries:
-        if not entry.get("approved"):
+        if not entry.get("approved") and entry["name"] != own_mission:
             continue
         authority = entry["authority"]
         mode = authority.get("guard_mode")
@@ -419,9 +432,13 @@ def run_gate(workspace: Path, tool_call: dict, *, actor: str,
     missions' armed guards (es#173, OD-1 UNION-ALWAYS): bound or not, every
     gate-routed call sees every approved mission's guards -- if binding to
     mission A exempted a call from mission B's guards, every guard would be
-    voluntary the moment two missions coexist. `bound_mission` is validated
-    for LOGGING only (case row 16): a bad binding is loud on stderr and
-    changes exposure not at all.
+    voluntary the moment two missions coexist. Under OD-4 REFINED
+    ("Self-arm at open, union at approve", operator ruling 2026-08-25)
+    `bound_mission` additionally SELF-ARMS: a call bound to mission M is
+    also checked against M's own guards even before M is approved, so a
+    binding can ADD exposure but never remove any (case row 16 keeps its
+    teeth: a bad binding is loud on stderr, names no active mission, and
+    the approved union is evaluated regardless).
 
     Plurality is legal, so MultipleActiveMissions is gone as an inert
     cause -- the fail-open decoy is removed not by handling the error
@@ -470,7 +487,7 @@ def run_gate(workspace: Path, tool_call: dict, *, actor: str,
             reason += _degraded_disclosure(degraded)
         return {"decision": "allow", "matched": False, "rule": None,
                 "mode": "inert", "reason": reason}
-    matches = evaluate_union(entries, tool_call)
+    matches = evaluate_union(entries, tool_call, own_mission=bound_mission)
     disclosure = ""
     if degraded:
         # An allow that silently dropped a mission's guards would be the
@@ -516,12 +533,14 @@ def run_gate(workspace: Path, tool_call: dict, *, actor: str,
                 "reason": (f"custody guard(s) matched (audit mode): {pairs}"
                            + disclosure)}
     armed = [e for e in entries
-             if e.get("approved")
+             if (e.get("approved") or e["name"] == bound_mission)
              and e["latest"]["manifest"]["authority"].get("guard_mode")
              and e["latest"]["manifest"]["authority"].get("actuator_guards")]
     if not armed:
         # Case row 7: a lone unapproved draft (or unguarded missions only)
-        # contributes nothing -- allow, disclosed as such.
+        # contributes nothing to an UNBOUND call -- allow, disclosed as
+        # such. Its own bound session is self-armed above (OD-4 refined),
+        # so this branch is reached only when no evaluated source exists.
         return {"decision": "allow", "matched": False, "rule": None,
                 "mode": "inert",
                 "reason": "no approved mission guards armed" + disclosure}

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
@@ -20,11 +20,11 @@ import re
 import sys
 from pathlib import Path
 
-from custody_store import EpochSkew
+from custody_store import StoreError
 from custody_mission import (
+    CustodyError,
     Mission,
-    MultipleActiveMissions,
-    NoActiveMission,
+    _approved_by_chain,
     _ascii_case_fold,
     _normalize_relpath,
     now_utc,
@@ -263,98 +263,228 @@ def _append_guard_log(mission_dir: Path, entry: dict) -> None:
         handle.write(json.dumps(entry, sort_keys=True) + "\n")
 
 
-def run_gate(workspace: Path, tool_call: dict, *, actor: str,
-             session_id: str = "", harness: str = "") -> dict:
-    workspace = Path(workspace)
-    try:
-        mission = Mission.load(workspace, actor=actor)
-    except NoActiveMission as exc:
-        # VERSION SKEW IS NOT AN EMPTY WORKSPACE. A store from a newer contract
-        # epoch fails validation, gets skipped, and leaves the workspace looking
-        # missionless -- so an armed mission that BLOCKED reports `allow` with
-        # reason `NoActiveMission` the moment its epoch moves ahead of this
-        # reader (measured). That reason is false and points the operator at the
-        # wrong repair: the mission is fine, the READER is old.
-        #
-        # This is the failure mode the first contract@2 write would hit fleet-
-        # wide (es#118), so it is named on the verdict itself and on stderr,
-        # where the MultipleActiveMissions decoy warning already lives. The
-        # posture is unchanged -- still allow, still inert -- because inverting
-        # it would strand the workspace with no verb to resolve it.
-        detail = str(exc)
-        if "EpochSkew" in getattr(exc, "skipped_kinds", ()):
-            print(f"custody gate: MISSION STORE CLAIMS A NEWER EPOCH THAN "
-                  f"THIS READER under {workspace} -- gate inert and guards NOT "
-                  f"enforced. Read it with an updated custody plugin/CLI to "
-                  f"find out whether the store is genuinely newer or corrupt; "
-                  f"this reader cannot tell. Detail: {detail}", file=sys.stderr)
-            # CLAIMS, matching epoch_skew(). A categorical "is from a newer
-            # epoch" sends the operator to upgrade when the store may in fact
-            # be tampered -- the same over-claim corrected in the helper and
-            # SECURITY.md, left standing in the one string a consumer actually
-            # branches on.
-            return {"decision": "allow", "matched": False, "rule": None,
-                    "mode": "inert",
-                    "reason": ("gate inert: mission store CLAIMS a contract "
-                               "epoch newer than this reader -- guards are NOT "
-                               "enforced here, and this reader cannot tell a "
-                               "genuine newer store from a corrupt or "
-                               f"relabelled one ({detail})")}
-        return {"decision": "allow", "matched": False, "rule": None,
-                "mode": "inert", "reason": f"gate inert: {type(exc).__name__}"}
-    except MultipleActiveMissions as exc:
-        # Fail-open posture stands (a hook must never brick the tool loop on
-        # discovery ambiguity), but a decoy second mission silently disarming
-        # the gate must not pass quietly.
-        print(f"custody gate: MULTIPLE ACTIVE MISSIONS under {workspace} -- "
-              "gate inert, enforcement degraded to convention-held; resolve "
-              "the duplicate mission dirs before relying on guards",
-              file=sys.stderr)
-        return {"decision": "allow", "matched": False, "rule": None,
-                "mode": "inert", "reason": f"gate inert: {type(exc).__name__}"}
-    try:
-        latest = mission.status()
-    except EpochSkew as exc:
-        # THE CHAIN IS READ TWICE. `Mission.load` resolves the mission, then
-        # status() re-reads it -- so a writer publishing the first @2 between
-        # those two reads makes the skew surface HERE, where the handler above
-        # never sees it. Before this, a direct caller got a raw exception and
-        # the hook fell through to its generic error path, both of them missing
-        # the stale-reader verdict this change exists to deliver. That window is
-        # narrow but it is exactly the contract@2 rollout moment.
-        print(f"custody gate: MISSION STORE BEGAN CLAIMING A NEWER EPOCH "
-              f"mid-evaluation under {workspace} -- gate inert and guards NOT "
-              f"enforced. Read it with an updated custody plugin/CLI; this "
-              f"reader cannot tell a genuine newer store from a corrupt one. "
-              f"Detail: {exc}", file=sys.stderr)
-        return {"decision": "allow", "matched": False, "rule": None,
-                "mode": "inert",
-                "reason": ("gate inert: mission store CLAIMS a contract epoch "
-                           "newer than this reader -- guards are NOT enforced "
-                           "here, and this reader cannot tell a genuine newer "
-                           f"store from a corrupt or relabelled one ({exc})")}
-    verdict = evaluate(latest["manifest"]["authority"], tool_call)
-    if verdict["matched"]:
-        command = tool_call.get("command") or ""
+def _union_entries(workspace: Path, actor: str) -> tuple[list[dict], list[dict]]:
+    """Assemble the guard union (es#173 section 2): every ACTIVE mission,
+    chain-verified and manifest-verified, carrying the OD-4 approval flag
+    (`_approved_by_chain` -- the chain test, so a never-approved mission
+    wedged in `reopened` arms nothing).
+
+    A mission that fails to load or verify joins `degraded` instead: its
+    guards CANNOT be trusted, so they are not enforced -- and every caller
+    must SAY so, because a silently shrunken union is the old
+    MultipleActiveMissions fail-open decoy rebuilt one layer down."""
+    active, skipped = Mission._discover(workspace)
+    degraded = [dict(s) for s in skipped]
+    entries: list[dict] = []
+    for e in active:
+        mission = Mission(e["store"], workspace, actor)
+        try:
+            # status() re-reads the chain and verifies the manifest, so the
+            # authority evaluated is the chain-verified latest -- and a
+            # tampered manifest degrades instead of arming. This also covers
+            # the mid-evaluation epoch flip the old two-read gate special-
+            # cased: a writer publishing the first @2 between discovery and
+            # this read surfaces HERE, as a degraded entry.
+            latest = mission.status()
+        except (StoreError, ValueError, CustodyError) as exc:
+            reason = f"{e['name']}: {type(exc).__name__}: {exc}"
+            # Tamper keeps its own distinct, greppable stderr signal: a
+            # session log must be searchable for TAMPER (the hook's contract
+            # since before the union), and the union fold must not silently
+            # retire that marker.
+            print(("custody gate: TAMPER/custody error reading mission "
+                   + e["name"] + " -- its guards are NOT enforced (union "
+                   "degraded): " + reason)
+                  .encode("ascii", "backslashreplace").decode("ascii"),
+                  file=sys.stderr)
+            degraded.append({
+                "name": e["name"], "kind": type(exc).__name__,
+                "reason": reason})
+            continue
+        entries.append({"name": e["name"], "mission": mission,
+                        "latest": latest,
+                        "approved": _approved_by_chain(e["store"])})
+    return entries, degraded
+
+
+def evaluate_union(entries: list[dict], tool_call: dict) -> list[dict]:
+    """Every matching (mission, rule) pair across the union of APPROVED
+    missions' armed guards -- ALL matches, not first: the operator
+    discharging a block needs the full bill (es#173 section 2).
+
+    OD-1 UNION-ALWAYS: callers pass every entry; binding routes authority,
+    never exposure. OD-4 GATE ON APPROVE: an unapproved entry contributes
+    nothing -- checked here, in the one place membership is decided, so a
+    draft mission is subject to the union while arming none of it."""
+    matches: list[dict] = []
+    for entry in entries:
+        if not entry.get("approved"):
+            continue
+        authority = entry["latest"]["manifest"]["authority"]
+        mode = authority.get("guard_mode")
+        guards = authority.get("actuator_guards")
+        if not mode or not guards:
+            continue
+        for rule in guards:
+            if _tool_in(rule, tool_call.get("tool_name", "")) \
+                    and _patterns_match(rule, tool_call):
+                matches.append({"mission": entry["name"],
+                                "rule": rule["name"], "mode": mode,
+                                "decision": ("block" if mode == "enforce"
+                                             else "allow")})
+    return matches
+
+
+def _degraded_disclosure(degraded: list[dict]) -> str:
+    names = ", ".join(sorted(d["name"] for d in degraded))
+    return (f" UNION DEGRADED: mission dir(s) {names} unreadable -- their "
+            "guards are NOT enforced; repair or resolve them before "
+            "relying on the union.")
+
+
+def _log_matches(workspace: Path, matches: list[dict], tool_call: dict, *,
+                 actor: str, session_id: str, harness: str) -> None:
+    """One guard-log append per MATCHING (mission, rule) pair, into that
+    mission's own dir: each mission's audit trail must be complete from its
+    own dir (es#173 section 2). Best-effort exactly as before -- the append
+    is audit, the VERDICT is not, and a log failure must never flip a block
+    into an allow."""
+    command = tool_call.get("command") or ""
+    for row in matches:
         entry = {
             "utc": now_utc(),
             "actor": actor,
             "session_id": session_id,
             "harness": harness,
-            "mode": verdict["mode"],
-            "decision": verdict["decision"],
-            "rule": verdict["rule"],
+            "mode": row["mode"],
+            "decision": row["decision"],
+            "rule": row["rule"],
             "tool_name": tool_call.get("tool_name", ""),
             "command_preview": command[:_PREVIEW],
             "file_path": tool_call.get("file_path"),
         }
         try:
-            _append_guard_log(mission.store.mission_dir, entry)
+            _append_guard_log(workspace / "missions" / row["mission"], entry)
         except Exception as exc:
-            # The audit append is best-effort; the VERDICT is not. A log
-            # failure must never flip a block into an allow.
-            print(f"custody gate: guard-log append failed "
-                  f"({type(exc).__name__}: {exc}); verdict "
-                  f"{verdict['decision']} stands but was not logged",
+            print(f"custody gate: guard-log append failed for "
+                  f"{row['mission']} ({type(exc).__name__}: {exc}); verdict "
+                  f"{row['decision']} stands but was not logged",
                   file=sys.stderr)
-    return verdict
+
+
+def run_gate(workspace: Path, tool_call: dict, *, actor: str,
+             session_id: str = "", harness: str = "",
+             bound_mission: str | None = None) -> dict:
+    """Evaluate a harness tool call against the UNION of all approved
+    missions' armed guards (es#173, OD-1 UNION-ALWAYS): bound or not, every
+    gate-routed call sees every approved mission's guards -- if binding to
+    mission A exempted a call from mission B's guards, every guard would be
+    voluntary the moment two missions coexist. `bound_mission` is validated
+    for LOGGING only (case row 16): a bad binding is loud on stderr and
+    changes exposure not at all.
+
+    Plurality is legal, so MultipleActiveMissions is gone as an inert
+    cause -- the fail-open decoy is removed not by handling the error
+    better but by making the state legal. The hook path stays fail-open for
+    corrupt or epoch-skewed stores (a hook must never brick the tool loop),
+    but an allow that dropped a mission's guards must SAY so, in the
+    verdict reason and on stderr (case rows 22, B22)."""
+    workspace = Path(workspace)
+    if bound_mission:
+        try:
+            Mission.load(workspace, actor=actor, mission_id=bound_mission)
+        except (CustodyError, StoreError) as exc:
+            print(f"custody gate: session binding invalid "
+                  f"({type(exc).__name__}: {exc}) -- exposure unaffected: "
+                  "the union is evaluated regardless of binding",
+                  file=sys.stderr)
+    entries, degraded = _union_entries(workspace, actor)
+    if not entries:
+        skew = [d for d in degraded if d["kind"] == "EpochSkew"]
+        if skew:
+            # VERSION SKEW IS NOT AN EMPTY WORKSPACE. A store from a newer
+            # contract epoch fails validation, gets skipped, and leaves the
+            # workspace looking missionless -- so an armed mission that
+            # BLOCKED reports `allow` the moment its epoch moves ahead of
+            # this reader. Named on the verdict and on stderr; the posture
+            # stays allow/inert because inverting it would strand the
+            # workspace with no verb to resolve it. CLAIMS, not "is": this
+            # reader cannot tell a genuine newer store from a corrupt or
+            # relabelled one.
+            detail = "; ".join(d["reason"] for d in skew)
+            print(f"custody gate: MISSION STORE CLAIMS A NEWER EPOCH THAN "
+                  f"THIS READER under {workspace} -- gate inert and guards "
+                  f"NOT enforced. Read it with an updated custody "
+                  f"plugin/CLI to find out whether the store is genuinely "
+                  f"newer or corrupt; this reader cannot tell. "
+                  f"Detail: {detail}", file=sys.stderr)
+            return {"decision": "allow", "matched": False, "rule": None,
+                    "mode": "inert",
+                    "reason": ("gate inert: mission store CLAIMS a contract "
+                               "epoch newer than this reader -- guards are "
+                               "NOT enforced here, and this reader cannot "
+                               "tell a genuine newer store from a corrupt "
+                               f"or relabelled one ({detail})")}
+        reason = "gate inert: NoActiveMission"
+        if degraded:
+            reason += _degraded_disclosure(degraded)
+        return {"decision": "allow", "matched": False, "rule": None,
+                "mode": "inert", "reason": reason}
+    matches = evaluate_union(entries, tool_call)
+    disclosure = ""
+    if degraded:
+        # An allow that silently dropped a mission's guards would be the
+        # section-0 decoy rebuilt one layer down: disclose in BOTH channels.
+        disclosure = _degraded_disclosure(degraded)
+        print("custody gate:" + disclosure, file=sys.stderr)
+    if matches:
+        _log_matches(workspace, matches, tool_call, actor=actor,
+                     session_id=session_id, harness=harness)
+    blocking = [m for m in matches if m["decision"] == "block"]
+    if blocking:
+        pairs = "; ".join(f"mission={m['mission']} rule={m['rule']}"
+                          for m in blocking)
+        return {
+            "decision": "block", "matched": True,
+            "rule": blocking[0]["rule"], "mode": "enforce",
+            "matches": matches,
+            "reason": (
+                f"custody guard(s) matched this call: {pairs}. No mission "
+                "envelope discharges them. This gate reads ONLY guard_mode "
+                "and actuator_guards -- recording amendment TEXT does not "
+                "discharge a block, however clearly it grants the work. "
+                "Discharge is PER-MISSION: an amend recorded in one "
+                "mission discharges that mission's rule only, so a call "
+                "blocked by several missions needs each one's amend. The "
+                "exits, per matching mission (bind with --mission <id>): "
+                "change the rule that matched via `amend --guards-file`, "
+                "or `amend --guard-mode audit` to retire that mission's "
+                "guard set, or stop. Both amend forms are recorded, "
+                "chained and comparable; narrating a grant is not. NOTE: "
+                "if a rule covers the shell itself, the amend command is "
+                "blocked by the same rule -- run it OUT OF BAND (a session "
+                "or terminal this hook does not gate). The gate "
+                "deliberately has no self-repair exemption: a rule that "
+                "exempted its own discharge command would be a hole shaped "
+                "exactly like the thing it guards." + disclosure)}
+    if matches:
+        pairs = "; ".join(f"mission={m['mission']} rule={m['rule']}"
+                          for m in matches)
+        return {"decision": "allow", "matched": True,
+                "rule": matches[0]["rule"], "mode": matches[0]["mode"],
+                "matches": matches,
+                "reason": (f"custody guard(s) matched (audit mode): {pairs}"
+                           + disclosure)}
+    armed = [e for e in entries
+             if e.get("approved")
+             and e["latest"]["manifest"]["authority"].get("guard_mode")
+             and e["latest"]["manifest"]["authority"].get("actuator_guards")]
+    if not armed:
+        # Case row 7: a lone unapproved draft (or unguarded missions only)
+        # contributes nothing -- allow, disclosed as such.
+        return {"decision": "allow", "matched": False, "rule": None,
+                "mode": "inert",
+                "reason": "no approved mission guards armed" + disclosure}
+    return {"decision": "allow", "matched": False, "rule": None,
+            "mode": armed[0]["latest"]["manifest"]["authority"]["guard_mode"],
+            "reason": "no guard matched" + disclosure}

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_hook.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
@@ -276,6 +277,13 @@ def main(argv: list[str]) -> int:
                      "command": call.get("command"),
                      "file_path": call.get("file_path"),
                      "tool_input": call.get("tool_input")}
+        # The session's binding channel, best-effort: the harness process
+        # env is what this hook inherits. Under OD-4 refined ("Self-arm at
+        # open, union at approve") the binding SELF-ARMS the named
+        # mission's own guards; it can only ADD exposure (a name matching
+        # no mission dir changes nothing), so the lower-provenance env
+        # never widens what a session may do -- only what it may not.
+        bound = os.environ.get("ZMS_MISSION_ID", "").strip() or None
         # ANY candidate blocking blocks the call. A custody error on one
         # candidate must not skip the rest: an unreadable mission in the first
         # workspace would otherwise suppress a real block from the second,
@@ -284,7 +292,8 @@ def main(argv: list[str]) -> int:
             try:
                 verdict = run_gate(
                     workspace, tool_call, actor="hook:custody-gate",
-                    session_id=call.get("session_id", ""), harness=args.harness)
+                    session_id=call.get("session_id", ""),
+                    harness=args.harness, bound_mission=bound)
             except CustodyError as exc:
                 # Tamper keeps its own distinct, greppable signal: a session log
                 # must be searchable for TAMPER, and folding it into the generic

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -41,6 +41,9 @@ _RETIRED_NOTE = "receipt loss acknowledged: "
 _RESERVED_NOTE_PREFIXES = (
     "effect: ", "reconciled: ", "drift detected: ", "receipt restored: ",
     "authority amended: ", _RETIRED_NOTE, "scope-ack by ",
+    # es#173: the quarantine acknowledgement discharges the UnionDegraded
+    # refusal, so narrative able to imitate it would forge the discharge.
+    "unreadable-acknowledged: ",
 )
 
 
@@ -1717,8 +1720,163 @@ class Mission:
         new = self._write_next(latest, path, status="active", note="approved")
         return new["revision"]
 
+    def _acknowledged_unreadable(self, latest: dict) -> set[str]:
+        """Dir names whose union degradation this mission's chain has
+        acknowledged (machine note, reserved prefix -- so narrative cannot
+        forge the discharge). Permanent for the mission's life, like every
+        note: the quarantine judgement was recorded once and holds."""
+        prefix = "unreadable-acknowledged: "
+        return {note[len(prefix):] for note in latest["state"]["notes"]
+                if note.startswith(prefix)}
+
+    def _effect_union_entries(
+            self, latest: dict,
+            acknowledge_unreadable: tuple | list = (),
+    ) -> tuple[list[dict], list[str]]:
+        """Assemble the union for an `effect` (es#173, OD-2) and enforce the
+        B23 degradation rule. Returns (entries, fresh_acknowledgements).
+
+        Every ACTIVE mission joins as {"name", "store", "authority",
+        "approved"} -- including this one: complete mediation has no
+        self-exemption. A sibling whose store cannot be read or whose
+        manifest fails verification is a DEGRADED union: unlike the hook
+        (which must never brick the tool loop), effect CAN refuse without
+        bricking anything, so it does -- UnionDegraded, until the sibling
+        is repaired, completed/cancelled by an updated reader, or
+        explicitly acknowledged (recorded in this mission's chain via the
+        reserved 'unreadable-acknowledged: ' machine note, so the
+        acknowledgement persists and cannot be forged by narrative)."""
+        own_name = self.store.mission_dir.name
+        active, skipped = Mission._discover(self.workspace)
+        degraded = [{"name": s["name"], "reason": s["reason"]}
+                    for s in skipped]
+        entries: list[dict] = []
+        for e in active:
+            if e["name"] == own_name:
+                entries.append({"name": own_name, "store": self.store,
+                                "authority":
+                                    latest["manifest"]["authority"],
+                                "approved":
+                                    _approved_by_chain(self.store)})
+                continue
+            sibling = Mission(e["store"], self.workspace, self.actor)
+            try:
+                sib_latest = sibling.status()
+            except (StoreError, ValueError, CustodyError) as exc:
+                degraded.append({
+                    "name": e["name"],
+                    "reason": f"{type(exc).__name__}: {exc}"})
+                continue
+            entries.append({"name": e["name"], "store": e["store"],
+                            "authority":
+                                sib_latest["manifest"]["authority"],
+                            "approved": _approved_by_chain(e["store"])})
+        acked_chain = self._acknowledged_unreadable(latest)
+        acked_now = {str(name) for name in (acknowledge_unreadable or ())}
+        degraded_names = {d["name"] for d in degraded}
+        unknown = sorted(acked_now - degraded_names - acked_chain)
+        if unknown:
+            raise CustodyError(
+                "acknowledge_unreadable names dir(s) that are not degraded "
+                f"here: {', '.join(unknown)} -- an acknowledgement that "
+                "matches nothing is a typo, not a quarantine")
+        unacked = sorted(d["name"] for d in degraded
+                         if d["name"] not in acked_chain
+                         and d["name"] not in acked_now)
+        if unacked:
+            detail = "; ".join(d["reason"] for d in degraded
+                               if d["name"] in unacked)
+            raise UnionDegraded(
+                "effect refused: sibling mission dir(s) "
+                + ", ".join(unacked) +
+                " cannot be read, so their guards are silently absent from "
+                "the union (case row B23). Repair them, resolve them with "
+                "an updated reader, or acknowledge explicitly "
+                "(--acknowledge-unreadable <dir>; recorded in this "
+                f"mission's chain). Detail: {detail}")
+        fresh = sorted((acked_now & degraded_names) - acked_chain)
+        return entries, fresh
+
+    def _append_sibling_touches(self, entries: list[dict],
+                                artifact_relpath: str, request_id: str,
+                                after_sha256: str) -> None:
+        """The crossing record (es#173 section 4c, FATAL-4): when this
+        effect touches a path an ACTIVE sibling has receipted, append one
+        advisory JSON line to that sibling's sibling-touch.jsonl -- the
+        guard-log analog: append-only, OUTSIDE the chain, chain
+        byte-identity preserved, never a write into the sibling's chain
+        (binding routes where notes land; this mission's actor holds no
+        authority there). Best-effort exactly like the guard-log append: a
+        failed append never blocks the effect but is loud on stderr. It is
+        ADVISORY: ground truth for detection is the resume-time receipt
+        scan, so a lost or suppressed entry cannot hide a crossing -- it
+        only costs the sibling's next resume the early hint."""
+        own_name = self.store.mission_dir.name
+        rel = artifact_relpath.replace("\\", "/")
+        for entry in entries:
+            if entry["name"] == own_name:
+                continue
+            try:
+                touched = any(
+                    isinstance(r, dict)
+                    and isinstance(r.get("artifact_path"), str)
+                    and _same_artifact(r["artifact_path"], rel)
+                    for r in entry["store"].load_receipts())
+                if not touched:
+                    continue
+                line = json.dumps({
+                    "utc": now_utc(),
+                    "actor": self.actor,
+                    "session_id": "",
+                    "from_mission": own_name,
+                    "receipt_id": request_id,
+                    "artifact_path": rel,
+                    "after_sha256": after_sha256,
+                }, sort_keys=True)
+                with open(entry["store"].mission_dir
+                          / "sibling-touch.jsonl", "a",
+                          encoding="utf-8") as handle:
+                    handle.write(line + "\n")
+            except Exception as exc:  # noqa: BLE001
+                print(("custody: sibling-touch append failed for "
+                       f"{entry['name']} ({type(exc).__name__}: {exc}); "
+                       "the effect stands -- detection falls back to the "
+                       "sibling's resume-time receipt scan")
+                      .encode("ascii", "backslashreplace").decode("ascii"),
+                      file=sys.stderr)
+
+    def _log_effect_matches(self, matches: list[dict],
+                            artifact_relpath: str) -> None:
+        """Guard-log the effect verb's matches into each matching mission's
+        dir, mirroring the gate's audit trail (tool_name 'effect').
+        Best-effort: the audit append is not verdict-bearing."""
+        for row in matches:
+            entry = {
+                "utc": now_utc(),
+                "actor": self.actor,
+                "session_id": "",
+                "harness": "effect",
+                "mode": row["mode"],
+                "decision": row["decision"],
+                "rule": row["rule"],
+                "tool_name": "effect",
+                "command_preview": "",
+                "file_path": artifact_relpath,
+            }
+            target = (self.workspace / "missions" / row["mission"]
+                      / "guard-log.jsonl")
+            try:
+                with open(target, "a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(entry, sort_keys=True) + "\n")
+            except Exception as exc:  # noqa: BLE001
+                print(f"custody: guard-log append failed for "
+                      f"{row['mission']} ({type(exc).__name__}: {exc}); "
+                      f"verdict {row['decision']} stands but was not "
+                      "logged", file=sys.stderr)
+
     def record_effect(self, artifact_relpath: str, content: str,
-                       request_id: str) -> dict:
+                       request_id: str, *,
+                       acknowledge_unreadable: tuple | list = ()) -> dict:
         latest, path = self.store.load_latest()
         self._verify_manifest(latest)
         if latest["status"] not in _EFFECT_STATES:
@@ -1740,6 +1898,41 @@ class Mission:
         # the record ALREADY carries; only genuinely NEW paths are refused.
         if recover is None:
             _refuse_unrecordable_artifact_path(artifact_relpath)
+        # es#173 OD-2: effect IS the file write, so it runs union guard
+        # evaluation BEFORE _write_effect. A block refuses side-effect-free
+        # (nothing written, no receipt minted -- the same
+        # refuse-before-mutate posture as the idempotency guard), naming
+        # every matching (mission_id, rule) pair; audit-mode matches are
+        # allowed and logged. A RECOVER discharge is deliberately NOT
+        # exempt: a blocked recovery discharges through the (unblockable)
+        # amend channel of each matching mission, not through a hole in the
+        # mediation -- amend being unblockable is what keeps this legal.
+        entries, fresh_acks = self._effect_union_entries(
+            latest, acknowledge_unreadable)
+        for name in fresh_acks:
+            # The quarantine judgement becomes chain state BEFORE the write
+            # it licenses, one machine-note checkpoint per dir.
+            self._write_next(latest, path, status=latest["status"],
+                              note=f"unreadable-acknowledged: {name}")
+            latest, path = self.store.load_latest()
+        from custody_gate import evaluate_effect_union
+        matches = evaluate_effect_union(entries, artifact_relpath)
+        if matches:
+            self._log_effect_matches(matches, artifact_relpath)
+        blocking = [m for m in matches if m["decision"] == "block"]
+        if blocking:
+            pairs = "; ".join(f"mission={m['mission']} rule={m['rule']}"
+                              for m in blocking)
+            raise CustodyError(
+                f"effect blocked by custody guard(s): {pairs}. Nothing was "
+                "written and no receipt was minted. Discharge is "
+                "PER-MISSION: an amend recorded in one mission discharges "
+                "that mission's rule only -- bind to each matching mission "
+                "(--mission <id>) and change the rule via `amend "
+                "--guards-file`, or `amend --guard-mode audit` to retire "
+                "that mission's guard set, or stop. `note` and `amend` "
+                "remain unblockable by design (OD-2): record the "
+                "escalation there.")
         receipt = self._write_effect(latest, artifact_relpath, content, request_id)
         if recover is not None:
             remaining = [m for m in unresolved if m != recover]
@@ -1748,6 +1941,8 @@ class Mission:
         self._write_next(latest, path, status=status, add_receipt_id=request_id,
                           unresolved_verdicts=remaining,
                           note=f"effect: {artifact_relpath}")
+        self._append_sibling_touches(entries, artifact_relpath, request_id,
+                                     receipt["after_sha256"])
         return receipt
 
     def amend_authority(self, text: str, *, guard_mode=_UNSET,

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -1961,8 +1961,10 @@ class Mission:
             pairs = "; ".join(f"mission={m['mission']} rule={m['rule']}"
                               for m in blocking)
             raise CustodyError(
-                f"effect blocked by custody guard(s): {pairs}. Nothing was "
-                "written and no receipt was minted. Discharge is "
+                f"effect blocked by custody guard(s): {pairs}. No artifact "
+                "bytes were written, no receipt was minted, and no chain "
+                "checkpoint landed; each matching mission's guard-log.jsonl "
+                "records the refusal (intended audit). Discharge is "
                 "PER-MISSION: an amend recorded in one mission discharges "
                 "that mission's rule only -- bind to each matching mission "
                 "(--mission <id>) and change the rule via `amend "
@@ -1973,11 +1975,13 @@ class Mission:
         # Only now -- with the union verdict in hand -- does anything touch
         # the chain. The fresh-quarantine checkpoints used to land BEFORE
         # evaluation, so a blocked effect mutated the chain while its
-        # refusal claimed "Nothing was written" (PR #220 refuter, finding
+        # refusal claimed nothing was written (PR #220 refuter, finding
         # 4: checkpoint count 2 -> 3 on a block, measured). Evaluation is a
         # pure read over `entries`, so ordering it first costs nothing; the
         # quarantine judgement still becomes chain state BEFORE the write
-        # it licenses, one machine-note checkpoint per dir.
+        # it licenses, one machine-note checkpoint per dir. The guard-log
+        # append above is deliberate and outside the chain -- the refusal
+        # is audit, and the message says so rather than claiming silence.
         for name in fresh_acks:
             self._write_next(latest, path, status=latest["status"],
                               note=f"unreadable-acknowledged: {name}")
@@ -2381,13 +2385,20 @@ class Mission:
                       if k] + unplaceable_opaque
         mismatched: list[str] = []
         current_sha_by_rel: dict[str, str] = {}
-        for request_id, receipt, kind in current_by_key.values():
+        # Per-key dispositions this run established, kept so a stale
+        # DRIFT-SIBLING marker (below) can say truthfully what became of
+        # its path: verified clean, receipt lost, or receipt opaque.
+        verified_keys: set[str] = set()
+        missing_by_key: dict[str, str] = {}
+        opaque_by_key: dict[str, tuple[str, str]] = {}
+        for key, (request_id, receipt, kind) in current_by_key.items():
             if kind:
                 # Unverifiable, and honestly so: without the receipt's hash
                 # this reader cannot say the artifact drifted OR that it is
                 # clean. RECEIPT-NEWER-EPOCH already carries that, and NOT
                 # emitting RECONCILIATION here is what keeps `reconcile`
                 # unavailable for this path -- it refuses without a marker.
+                opaque_by_key[key] = (kind, request_id)
                 continue
             if receipt is None:
                 # An unloadable receipt is drift, not a skip: the artifact it
@@ -2395,6 +2406,7 @@ class Mission:
                 # false "clean" for exactly the file most likely tampered.
                 if request_id not in missing:
                     missing.append(request_id)
+                missing_by_key[key] = request_id
                 continue
             rel = receipt["artifact_path"]
             target = self.workspace / rel
@@ -2403,6 +2415,8 @@ class Mission:
                 mismatched.append(rel)
                 if actual is not None:
                     current_sha_by_rel[rel] = actual
+            else:
+                verified_keys.add(key)
         mismatched.sort()
         missing.sort()
         opaque_ids.sort()
@@ -2451,13 +2465,77 @@ class Mission:
         # CURRENT severity: a still-attributable path keeps its marker, a
         # no-longer-attributable one becomes a plain RECONCILIATION
         # finding (the mismatched loop below raises it), and a path whose
-        # content now verifies drops the marker entirely.
+        # content now verifies drops the marker.
+        #
+        # LOUD AUTO-DISCHARGE (operator ruling 2026-08-25, fix-refuter
+        # F-A): the drop stays automatic -- a transient crossing whose
+        # bytes were reverted leaves nothing to reconcile -- but it is a
+        # finding-grade event, never silence: resume RETURNS a
+        # SIBLING-DISCHARGED:<path> marker (non-blocking -- it is not an
+        # unresolved verdict and the status still transitions), and the
+        # discharge note carries the sibling attribution recorded at the
+        # original detection, so the crossing survives in the record even
+        # though its bytes no longer show it.
         live_sibling = {f"DRIFT-SIBLING:{rel}" for rel in sibling_class}
         stale_sibling = [m for m in latest["state"]["unresolved_verdicts"]
                          if m.startswith("DRIFT-SIBLING:")
                          and m not in live_sibling]
         if not findings and not stale_skew and not stale_sibling:
             return []
+
+        def _marker_key(rel: str) -> str:
+            key = _normalize_relpath(rel)
+            return _ascii_case_fold(key) if os.name == "nt" else key
+
+        def _sibling_attribution(rel: str) -> str:
+            # The attribution the ORIGINAL detection recorded ("sibling
+            # receipt: <rel> matches <mission> receipt <id>") -- read from
+            # the chain's own notes, newest first, because the bytes that
+            # proved it may no longer exist.
+            # The detection writes the attribution as a clause INSIDE the
+            # composite drift note, so search within each note and take
+            # the clause up to the next ';'.
+            needle = f"sibling receipt: {rel} matches "
+            for n in reversed(latest["state"]["notes"]):
+                if isinstance(n, str) and needle in n:
+                    tail = n[n.index(needle) + len(needle):]
+                    return tail.split(";", 1)[0].strip()
+            return "an unrecorded sibling"
+
+        mismatched_keys = {_marker_key(r) for r in mismatched}
+        discharged: list[str] = []
+        stale_sibling_notes: list[str] = []
+        for m in stale_sibling:
+            rel = m[len("DRIFT-SIBLING:"):]
+            key = _marker_key(rel)
+            attribution = _sibling_attribution(rel)
+            if key in mismatched_keys:
+                stale_sibling_notes.append(
+                    f"stale sibling marker superseded: {m} re-classified "
+                    f"at current severity (was attributed to {attribution})")
+            elif key in missing_by_key:
+                # The obligation TRANSFERS to receipt-loss (fix-refuter
+                # F-B): nothing was re-classified -- the receipt that
+                # would prove either reading is gone, and RECEIPT-MISSING
+                # now carries the path's obligation.
+                stale_sibling_notes.append(
+                    "stale sibling marker superseded by "
+                    f"RECEIPT-MISSING:{missing_by_key[key]}: {m} (was "
+                    f"attributed to {attribution})")
+            elif key in opaque_by_key:
+                kind, rid = opaque_by_key[key]
+                stale_sibling_notes.append(
+                    "stale sibling marker superseded by "
+                    f"RECEIPT-{kind}:{rid}: {m} (was attributed to "
+                    f"{attribution})")
+            else:
+                verdict = ("content verifies against this mission's own "
+                           "receipt" if key in verified_keys
+                           else "the path is no longer attributable")
+                discharged.append(f"SIBLING-DISCHARGED:{rel}")
+                stale_sibling_notes.append(
+                    f"transient sibling crossing discharged: {rel} -- "
+                    f"{verdict}; was attributed to {attribution}")
         unresolved = [m for m in latest["state"]["unresolved_verdicts"]
                       if m not in stale_skew and m not in stale_sibling]
         for rel in mismatched:
@@ -2487,9 +2565,8 @@ class Mission:
                          f"{hit['mission']} receipt {hit['receipt_id']}")
             for line in sibling_evidence:
                 note += f"; sibling receipt evidence: {line}"
-            for m in stale_sibling:
-                note += (f"; stale sibling marker superseded: {m} "
-                         "re-classified at current severity")
+            for line in stale_sibling_notes:
+                note += f"; {line}"
         else:
             status = ("reopened" if unresolved
                       else self._resumption_status())
@@ -2498,14 +2575,14 @@ class Mission:
                 cleared.append(
                     "previously unverifiable receipt(s) now readable: "
                     + ", ".join(m.split(":", 1)[1] for m in stale_skew))
-            if stale_sibling:
-                cleared.append(
-                    "stale sibling marker(s) discharged, content verifies: "
-                    + ", ".join(m.split(":", 1)[1] for m in stale_sibling))
+            cleared.extend(stale_sibling_notes)
             note = "; ".join(cleared)
         self._write_next(latest, path, status=status,
                           unresolved_verdicts=unresolved, note=note)
-        return findings
+        # The discharge markers ride the RETURN, not unresolved_verdicts:
+        # callers (and the CLI) must see the event, but nothing is left to
+        # reconcile and the status has already transitioned.
+        return findings + discharged
 
     def reconcile(self, artifact_relpath: str, content: str, request_id: str) -> dict:
         latest, path = self.store.load_latest()

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -44,6 +44,10 @@ _RESERVED_NOTE_PREFIXES = (
     # es#173: the quarantine acknowledgement discharges the UnionDegraded
     # refusal, so narrative able to imitate it would forge the discharge.
     "unreadable-acknowledged: ",
+    # es#173 section 4: the machine acknowledgement that reconciles
+    # DRIFT-SIBLING -- caller narrative must not be able to imitate the
+    # record that downgrades a drift finding (gauntlet major).
+    "sibling-touched: ",
 )
 
 
@@ -2121,6 +2125,138 @@ class Mission:
         breaks.sort(key=lambda b: (b["artifact_path"], b["request_id"]))
         return breaks
 
+    def _scan_sibling_receipts(self, rel: str, current_sha: str) -> list[dict]:
+        """receipt@1 records in OTHER mission stores whose artifact_path
+        names this artifact and whose after_sha256 equals the CURRENT
+        content hash -- the es#173 section 4(a) detection scan. Every field
+        it needs already exists on receipt@1; nothing is minted at effect
+        time that the schema must carry (OD-3: zero schema change).
+
+        ANY status, not only active -- the verification-report correction
+        to the design's section 4(a) wording: the adjudication's
+        "resume-time scan of sibling receipt stores" carries no active-only
+        narrowing, and a sibling that completed or was cancelled between
+        its write and this resume must still explain the drift. Best-effort
+        per store: an unreadable sibling contributes no evidence, never a
+        crash -- the recovery path must not be killable (the
+        _load_receipt doctrine, applied to foreign stores)."""
+        own_name = self.store.mission_dir.name
+        missions_root = self.workspace / "missions"
+        found: list[dict] = []
+        if not missions_root.is_dir():
+            return found
+        for mission_dir in sorted(missions_root.iterdir()):
+            if not mission_dir.is_dir() or mission_dir.name == own_name:
+                continue
+            store = MissionStore(mission_dir)
+            try:
+                receipts = store.load_receipts()
+            except Exception as exc:  # noqa: BLE001
+                print(("custody: sibling receipt scan skipped "
+                       f"{mission_dir.name} ({type(exc).__name__}: {exc})")
+                      .encode("ascii", "backslashreplace").decode("ascii"),
+                      file=sys.stderr)
+                continue
+            for record in receipts:
+                if not isinstance(record, dict) or validate_record(record):
+                    continue  # only well-formed receipt@1 counts
+                if _same_artifact(str(record.get("artifact_path")), rel)                         and record.get("after_sha256") == current_sha:
+                    found.append({"mission": mission_dir.name,
+                                  "receipt_id": record.get("request_id"),
+                                  "record": record})
+        return found
+
+    def _classify_sibling_drift(
+            self, latest: dict, rel: str, current_sha: str,
+    ) -> tuple[dict | None, list[str]]:
+        """The FATAL-3 authorization discriminator (es#173 section 4b).
+
+        Hash-match alone is a self-serve audit-downgrade: open() takes
+        unverified refs, so whoever caused unauthorized drift could open a
+        throwaway sibling, effect the tampered bytes, and self-mint the
+        laundering receipt. DRIFT-SIBLING therefore requires ALL of:
+        (1) a sibling receipt@1 hash match (the scan);
+        (2) the sibling operator-approved BY THE CHAIN TEST
+            (_approved_by_chain) -- never latest-status, so a
+            never-approved mission wedged in `reopened` launders nothing;
+        (3) an explicit cross-mission authorization amendment in THIS
+            mission's own chain, naming the sibling mission id and the
+            path or a pattern covering it (_amendment_names).
+
+        Any leg missing -> (None, evidence): plain drift at today's
+        severity with the sibling receipt reported as evidence. The
+        discriminator gates the severity downgrade, never the information
+        -- resume always says what it found."""
+        candidates = self._scan_sibling_receipts(rel, current_sha)
+        evidence: list[str] = []
+        amendments = latest["manifest"]["authority"]["amendments"]
+        for candidate in candidates:
+            mission_name = candidate["mission"]
+            approved = _approved_by_chain(
+                MissionStore(self.workspace / "missions" / mission_name))
+            authorized = any(
+                isinstance(a, dict) and isinstance(a.get("text"), str)
+                and mission_name in a["text"]
+                and _amendment_names(a["text"], rel)
+                for a in amendments)
+            if approved and authorized:
+                return candidate, []
+            legs = []
+            if not approved:
+                legs.append("sibling not operator-approved (chain test)")
+            if not authorized:
+                legs.append("no cross-mission authorization amendment "
+                            "in this mission's chain")
+            evidence.append(
+                f"{rel} matches sibling {mission_name} receipt "
+                f"{candidate['receipt_id']} -- NOT reclassified: "
+                + "; ".join(legs))
+        return None, evidence
+
+    def acknowledge_sibling(self, artifact_relpath: str) -> int:
+        """The only exit for a DRIFT-SIBLING marker (es#173 section 4):
+        acknowledge a sanctioned sibling write, recorded in THIS mission's
+        chain by this mission's own bound session as the reserved machine
+        note `sibling-touched: <path> by <mission> receipt <id>`. Not
+        `acknowledge_loss` -- nothing was lost -- and not `reconcile` --
+        nothing needs rewriting.
+
+        The three discriminator legs are RE-VERIFIED here, at the moment
+        the downgrade is consummated: a marker raised by an earlier resume
+        must not discharge against a store that has since changed."""
+        latest, path = self.store.load_latest()
+        self._verify_manifest(latest)
+        if latest["status"] != "reopened":
+            raise IllegalTransition(
+                f"cannot acknowledge_sibling: status is "
+                f"{latest['status']!r}, expected 'reopened'")
+        norm = artifact_relpath.replace("\\", "/")
+        unresolved = latest["state"]["unresolved_verdicts"]
+        marker = _find_marker(unresolved, "DRIFT-SIBLING:", norm)
+        if marker is None:
+            raise CustodyError(
+                f"no DRIFT-SIBLING marker for {artifact_relpath!r}")
+        rel = marker[len("DRIFT-SIBLING:"):]
+        target = self.workspace / rel
+        current_sha = sha256_file(target) if target.exists() else None
+        hit = None
+        if current_sha is not None:
+            hit, _evidence = self._classify_sibling_drift(
+                latest, rel, current_sha)
+        if hit is None:
+            raise CustodyError(
+                "sibling attribution no longer verifies for "
+                f"{rel!r} (content moved on, the sibling receipt vanished, "
+                "or a discriminator leg no longer holds) -- re-run resume "
+                "and handle the finding at its current severity")
+        remaining = [m for m in unresolved if m != marker]
+        status = "reopened" if remaining else self._resumption_status()
+        new = self._write_next(
+            latest, path, status=status, unresolved_verdicts=remaining,
+            note=(f"sibling-touched: {rel} by {hit['mission']} receipt "
+                  f"{hit['receipt_id']}"))
+        return new["revision"]
+
     def resume(self) -> list[str]:
         latest, path = self.store.load_latest()
         self._verify_manifest(latest)
@@ -2193,6 +2329,7 @@ class Mission:
         opaque_ids = [(rid, k) for rid, _r, k in current_by_key.values()
                       if k] + unplaceable_opaque
         mismatched: list[str] = []
+        current_sha_by_rel: dict[str, str] = {}
         for request_id, receipt, kind in current_by_key.values():
             if kind:
                 # Unverifiable, and honestly so: without the receipt's hash
@@ -2213,10 +2350,31 @@ class Mission:
             actual = sha256_file(target) if target.exists() else None
             if actual != receipt["after_sha256"]:
                 mismatched.append(rel)
+                if actual is not None:
+                    current_sha_by_rel[rel] = actual
         mismatched.sort()
         missing.sort()
         opaque_ids.sort()
-        findings = (mismatched
+        # es#173 section 4: a drifted artifact whose CURRENT bytes match a
+        # sibling receipt@1 is either a sanctioned crossing (all three
+        # discriminator legs -> DRIFT-SIBLING, reconciled by
+        # acknowledge_sibling) or plain drift WITH the sibling receipt
+        # reported as evidence (any leg missing). The discriminator gates
+        # the severity downgrade, never the information.
+        sibling_class: dict[str, dict] = {}
+        sibling_evidence: list[str] = []
+        for rel in mismatched:
+            current_sha = current_sha_by_rel.get(rel)
+            if current_sha is None:
+                continue
+            hit, evidence = self._classify_sibling_drift(
+                latest, rel, current_sha)
+            if hit is not None:
+                sibling_class[rel] = hit
+            else:
+                sibling_evidence.extend(evidence)
+        findings = ([f"DRIFT-SIBLING:{rel}" if rel in sibling_class else rel
+                     for rel in mismatched]
                     + [f"RECEIPT-MISSING:{rid}" for rid in missing]
                     + [f"RECEIPT-{k}:{rid}" for rid, k in opaque_ids])
         # THE SKEW MARKER'S EXIT LIVES HERE. Its remedy is "update the reader
@@ -2237,7 +2395,8 @@ class Mission:
         unresolved = [m for m in latest["state"]["unresolved_verdicts"]
                       if m not in stale_skew]
         for rel in mismatched:
-            marker = f"RECONCILIATION:{rel}"
+            marker = (f"DRIFT-SIBLING:{rel}" if rel in sibling_class
+                      else f"RECONCILIATION:{rel}")
             if marker not in unresolved:
                 unresolved.append(marker)
         for rid in missing:
@@ -2257,6 +2416,11 @@ class Mission:
         # update that fixed the receipt would leave it reopened forever.
         if findings:
             status, note = "reopened", f"drift detected: {', '.join(findings)}"
+            for rel, hit in sorted(sibling_class.items()):
+                note += (f"; sibling receipt: {rel} matches "
+                         f"{hit['mission']} receipt {hit['receipt_id']}")
+            for line in sibling_evidence:
+                note += f"; sibling receipt evidence: {line}"
         else:
             status = ("reopened" if unresolved
                       else self._resumption_status())

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -16,7 +16,7 @@ from custody_store import (
     MissionStore, StoreError, atomic_write_json, sha256_bytes, sha256_file,
 )
 from verify_mission_custody import (
-    TIERS, VERDICTS, epoch_skew_anywhere, validate_record,
+    TIERS, VERDICTS, _ID_RE, epoch_skew_anywhere, validate_record,
 )
 
 _OPEN_STATES = {"draft", "active", "reopened", "verifying"}
@@ -708,6 +708,23 @@ def _amendment_names(text: str, rel_path: str) -> bool:
     return False
 
 
+def _amendment_names_mission(text: str, mission_id: str) -> bool:
+    """Does this amendment NAME `mission_id` as a whole token?
+
+    The id leg of the FATAL-3 discriminator, held to the standard
+    `_amendment_names` sets for the path leg: never a raw substring. A
+    substring test let mission `m-al` ride on an amendment authorizing
+    `m-alpine`, and a mission named `test` ride on the word `latest` --
+    the false-ALLOW direction, an audit-severity downgrade self-served by
+    choosing a convenient id (PR #220 refuter, finding 1). Tokenized
+    exactly like `_amendment_names` so the two legs cannot drift apart."""
+    for segment in text.replace("\\", "/").splitlines():
+        for raw in segment.split():
+            if raw.strip(_TOKEN_TRIM).rstrip(".") == mission_id:
+                return True
+    return False
+
+
 def _display_path(path: str) -> str:
     """A path the acceptor can SEE, in a spelling that survives being typed.
 
@@ -1216,6 +1233,23 @@ class Mission:
         binding channels. It never guesses."""
         workspace = Path(workspace)
         if mission_id is not None:
+            # The binding channels (--mission / ZMS_MISSION_ID) are
+            # lower-provenance input: env-derived text must never steer
+            # which store this session acts under beyond naming ONE id in
+            # THIS workspace. Without this check a traversal id
+            # (`../../ws2/missions/m-remote`) bound across workspaces --
+            # the effect wrote its artifact here while the receipt landed
+            # in the foreign store, a split brain neither workspace's
+            # resume could explain (PR #220 refuter, finding 3). Same
+            # _ID_RE the schema enforces on every manifest at open: an id
+            # is a single kebab-case segment, never a path.
+            if not _ID_RE.match(mission_id):
+                raise BindingInvalid(
+                    f"binding names {mission_id!r}, which is not a legal "
+                    "mission id (single kebab-case segment, the rule "
+                    "open's schema enforces) -- a binding is an "
+                    "identifier, never a path. Fix or unset it "
+                    "(--mission / ZMS_MISSION_ID)")
             mission_dir = workspace / "missions" / mission_id
             store = MissionStore(mission_dir)
             if not store.checkpoint_paths():
@@ -1913,12 +1947,6 @@ class Mission:
         # mediation -- amend being unblockable is what keeps this legal.
         entries, fresh_acks = self._effect_union_entries(
             latest, acknowledge_unreadable)
-        for name in fresh_acks:
-            # The quarantine judgement becomes chain state BEFORE the write
-            # it licenses, one machine-note checkpoint per dir.
-            self._write_next(latest, path, status=latest["status"],
-                              note=f"unreadable-acknowledged: {name}")
-            latest, path = self.store.load_latest()
         from custody_gate import evaluate_effect_union
         matches = evaluate_effect_union(entries, artifact_relpath)
         if matches:
@@ -1937,6 +1965,18 @@ class Mission:
                 "that mission's guard set, or stop. `note` and `amend` "
                 "remain unblockable by design (OD-2): record the "
                 "escalation there.")
+        # Only now -- with the union verdict in hand -- does anything touch
+        # the chain. The fresh-quarantine checkpoints used to land BEFORE
+        # evaluation, so a blocked effect mutated the chain while its
+        # refusal claimed "Nothing was written" (PR #220 refuter, finding
+        # 4: checkpoint count 2 -> 3 on a block, measured). Evaluation is a
+        # pure read over `entries`, so ordering it first costs nothing; the
+        # quarantine judgement still becomes chain state BEFORE the write
+        # it licenses, one machine-note checkpoint per dir.
+        for name in fresh_acks:
+            self._write_next(latest, path, status=latest["status"],
+                              note=f"unreadable-acknowledged: {name}")
+            latest, path = self.store.load_latest()
         receipt = self._write_effect(latest, artifact_relpath, content, request_id)
         if recover is not None:
             remaining = [m for m in unresolved if m != recover]
@@ -2180,8 +2220,10 @@ class Mission:
             (_approved_by_chain) -- never latest-status, so a
             never-approved mission wedged in `reopened` launders nothing;
         (3) an explicit cross-mission authorization amendment in THIS
-            mission's own chain, naming the sibling mission id and the
-            path or a pattern covering it (_amendment_names).
+            mission's own chain, naming the sibling mission id as a
+            whole token (_amendment_names_mission -- never a raw
+            substring) and the path or a pattern covering it
+            (_amendment_names).
 
         Any leg missing -> (None, evidence): plain drift at today's
         severity with the sibling receipt reported as evidence. The
@@ -2196,7 +2238,7 @@ class Mission:
                 MissionStore(self.workspace / "missions" / mission_name))
             authorized = any(
                 isinstance(a, dict) and isinstance(a.get("text"), str)
-                and mission_name in a["text"]
+                and _amendment_names_mission(a["text"], mission_name)
                 and _amendment_names(a["text"], rel)
                 for a in amendments)
             if approved and authorized:
@@ -2247,8 +2289,12 @@ class Mission:
             raise CustodyError(
                 "sibling attribution no longer verifies for "
                 f"{rel!r} (content moved on, the sibling receipt vanished, "
-                "or a discriminator leg no longer holds) -- re-run resume "
-                "and handle the finding at its current severity")
+                "or a discriminator leg no longer holds) -- re-run resume: "
+                "it re-classifies the path at its current severity, "
+                "replacing this stale DRIFT-SIBLING marker (a "
+                "no-longer-attributable path becomes a plain "
+                "RECONCILIATION finding for `reconcile`; content that now "
+                "verifies drops the marker)")
         remaining = [m for m in unresolved if m != marker]
         status = "reopened" if remaining else self._resumption_status()
         new = self._write_next(
@@ -2390,10 +2436,25 @@ class Mission:
                       if (m.startswith("RECEIPT-NEWER-EPOCH:")
                           or m.startswith("RECEIPT-UNREADABLE:"))
                       and m not in live_opaque]
-        if not findings and not stale_skew:
+        # THE STALE SIBLING MARKER'S EXIT LIVES HERE (PR #220 refuter,
+        # finding 2). acknowledge_sibling re-verifies attribution against
+        # CURRENT bytes, so a DRIFT-SIBLING marker whose path had since
+        # moved on (operator edit, reconcile) could never discharge: ack
+        # refused forever, reconcile cleared only RECONCILIATION, and the
+        # mission wedged in `reopened` with begin_verification refusing
+        # (measured). Resume therefore re-classifies the path at its
+        # CURRENT severity: a still-attributable path keeps its marker, a
+        # no-longer-attributable one becomes a plain RECONCILIATION
+        # finding (the mismatched loop below raises it), and a path whose
+        # content now verifies drops the marker entirely.
+        live_sibling = {f"DRIFT-SIBLING:{rel}" for rel in sibling_class}
+        stale_sibling = [m for m in latest["state"]["unresolved_verdicts"]
+                         if m.startswith("DRIFT-SIBLING:")
+                         and m not in live_sibling]
+        if not findings and not stale_skew and not stale_sibling:
             return []
         unresolved = [m for m in latest["state"]["unresolved_verdicts"]
-                      if m not in stale_skew]
+                      if m not in stale_skew and m not in stale_sibling]
         for rel in mismatched:
             marker = (f"DRIFT-SIBLING:{rel}" if rel in sibling_class
                       else f"RECONCILIATION:{rel}")
@@ -2421,11 +2482,22 @@ class Mission:
                          f"{hit['mission']} receipt {hit['receipt_id']}")
             for line in sibling_evidence:
                 note += f"; sibling receipt evidence: {line}"
+            for m in stale_sibling:
+                note += (f"; stale sibling marker superseded: {m} "
+                         "re-classified at current severity")
         else:
             status = ("reopened" if unresolved
                       else self._resumption_status())
-            note = ("previously unverifiable receipt(s) now readable: "
+            cleared = []
+            if stale_skew:
+                cleared.append(
+                    "previously unverifiable receipt(s) now readable: "
                     + ", ".join(m.split(":", 1)[1] for m in stale_skew))
+            if stale_sibling:
+                cleared.append(
+                    "stale sibling marker(s) discharged, content verifies: "
+                    + ", ".join(m.split(":", 1)[1] for m in stale_sibling))
+            note = "; ".join(cleared)
         self._write_next(latest, path, status=status,
                           unresolved_verdicts=unresolved, note=note)
         return findings

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -1948,7 +1948,12 @@ class Mission:
         entries, fresh_acks = self._effect_union_entries(
             latest, acknowledge_unreadable)
         from custody_gate import evaluate_effect_union
-        matches = evaluate_effect_union(entries, artifact_relpath)
+        # OD-4 refined ("Self-arm at open, union at approve", operator
+        # ruling 2026-08-25): this mission's own guards bind its own
+        # effect from the moment open arms them, approved or not.
+        matches = evaluate_effect_union(
+            entries, artifact_relpath,
+            own_mission=self.store.mission_dir.name)
         if matches:
             self._log_effect_matches(matches, artifact_relpath)
         blocking = [m for m in matches if m["decision"] == "block"]

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -347,6 +347,25 @@ def _find_marker(unresolved: list[str], prefix: str, artifact_relpath: str) -> s
     return None
 
 
+def _approved_by_chain(store: MissionStore) -> bool:
+    """Has this mission EVER been operator-approved? The chain test, not
+    latest status: a never-approved mission can sit in `reopened` (drift on
+    a draft reopens it), so "latest status != draft" would let store damage
+    arm a draft's guards (OD-4) and let a never-approved sibling launder
+    drift (FATAL-3 leg 2). The core's own `_resumption_status` doctrine,
+    shared here so the union assembler and the resume discriminator cannot
+    disagree with it. Unreadable checkpoints answer False -- damage must
+    never widen authority."""
+    for cp_path in store.checkpoint_paths():
+        try:
+            record = json.loads(cp_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return False
+        if record.get("status") not in ("draft", "reopened"):
+            return True
+    return False
+
+
 class CustodyError(Exception):
     pass
 
@@ -356,7 +375,29 @@ class NoActiveMission(CustodyError):
 
 
 class MultipleActiveMissions(CustodyError):
-    pass
+    """RETIRED as a load-failure class (es#173): plurality is legal, so no
+    verb raises this any more. The class survives for import compatibility
+    and for readers of historical stores/logs that name it."""
+
+
+class BindingRequired(CustodyError):
+    """N>1 active missions and no session binding: the verb refuses rather
+    than guess which mission's authority the work lands under (es#173 §1)."""
+
+
+class BindingInvalid(CustodyError):
+    """The session's binding names a mission this workspace cannot act
+    under -- nonexistent, unreadable, completed, or cancelled. A stale
+    binding NEVER falls through to discovery or to the union: silent
+    fallback is how a session acts under the wrong authority politely
+    (es#173 §1)."""
+
+
+class UnionDegraded(CustodyError):
+    """An active sibling's store is unreadable, so its guards are silently
+    absent from the union. `effect` refuses under this state until the
+    sibling is repaired or the degradation is explicitly acknowledged
+    (es#173 §2, case row B23)."""
 
 
 class IllegalTransition(CustodyError):
@@ -517,6 +558,75 @@ def _is_matchable_pattern(entry: str) -> bool:
         # is both the declared meaning and the safe direction.
         return False
     return ".." not in segments
+
+
+def _seg_intersect(a: str, b: str) -> bool:
+    """Can two single-segment globs ('*'/'?' in-segment, no '/') both match
+    at least one string? Standard two-pattern recursion; memoized."""
+    memo: dict[tuple[int, int], bool] = {}
+
+    def rec(i: int, j: int) -> bool:
+        key = (i, j)
+        if key in memo:
+            return memo[key]
+        out = False
+        if i == len(a) and j == len(b):
+            out = True
+        else:
+            if not out and i < len(a) and a[i] == "*":
+                out = rec(i + 1, j) or (j < len(b) and rec(i, j + 1))
+            if not out and j < len(b) and b[j] == "*":
+                out = rec(i, j + 1) or (i < len(a) and rec(i + 1, j))
+            if not out and i < len(a) and j < len(b) \
+                    and a[i] != "*" and b[j] != "*" \
+                    and (a[i] == "?" or b[j] == "?" or a[i] == b[j]):
+                out = rec(i + 1, j + 1)
+        memo[key] = out
+        return out
+
+    return rec(0, 0)
+
+
+def _globs_intersect(left: str, right: str) -> bool:
+    """Do two scope path patterns admit a common path? (es#173 §3.)
+
+    Decidable for the dialect `_glob_regex` compiles: segments split on '/',
+    a segment containing '**' matches ZERO or more whole segments (which
+    also covers the trailing-'/**' base-path rule: ['x','**'] with '**'
+    consuming zero segments matches the base 'x'), '*'/'?' stay in-segment.
+    Both sides are normalized exactly as the receipt comparison normalizes,
+    including the NT-only A-Z fold, so the disclosure agrees with the
+    machinery it discloses about. Disclosure-only: an over- or under-report
+    here blocks nothing (coexistence on shared paths is the feature)."""
+    def prep(pattern: str) -> list[str]:
+        norm = _normalize_relpath(pattern)
+        if os.name == "nt":
+            norm = _ascii_case_fold(norm)
+        return ["**" if "**" in seg else seg for seg in norm.split("/")]
+
+    pa, pb = prep(left), prep(right)
+    memo: dict[tuple[int, int], bool] = {}
+
+    def rec(i: int, j: int) -> bool:
+        key = (i, j)
+        if key in memo:
+            return memo[key]
+        out = False
+        if i == len(pa) and j == len(pb):
+            out = True
+        else:
+            if not out and i < len(pa) and pa[i] == "**":
+                out = rec(i + 1, j) or (j < len(pb) and rec(i, j + 1))
+            if not out and j < len(pb) and pb[j] == "**":
+                out = rec(i, j + 1) or (i < len(pa) and rec(i + 1, j))
+            if not out and i < len(pa) and j < len(pb) \
+                    and pa[i] != "**" and pb[j] != "**" \
+                    and _seg_intersect(pa[i], pb[j]):
+                out = rec(i + 1, j + 1)
+        memo[key] = out
+        return out
+
+    return rec(0, 0)
 
 
 def _norm_scope_segments(norm: str) -> list[str]:
@@ -894,7 +1004,8 @@ class Mission:
               escalate_if: list[str] | None = None,
               acceptable_costs: list[str] | None = None,
               guard_mode: str | None = None,
-              actuator_guards: list | None = None) -> "Mission":
+              actuator_guards: list | None = None,
+              acknowledge_unreadable: list[str] | None = None) -> "Mission":
         workspace = Path(workspace)
         # ALL THREE identities validate BEFORE the load-probe, so a refused
         # open touches nothing on disk. The actor was missing from this
@@ -909,37 +1020,87 @@ class Mission:
         _refuse_unprintable_identity(actor, "actor")
         _refuse_unprintable_identity(steward_ref, "steward_ref")
         _refuse_unprintable_identity(operator_ref, "operator_ref")
-        # One ACTIVE mission per workspace, enforced at the door: every other
-        # command refuses multiple-active discovery, so open creating that
-        # state would be a decoy-disarm wedge (a second armed-or-unarmed
-        # mission bricks the gate's discovery). Checked BEFORE anything is
-        # written, so a refused open leaves no partial mission dir.
-        try:
-            cls.load(workspace, actor=actor)
-        except NoActiveMission as exc:
-            # "NOTHING ACTIVE" AND "I COULD NOT READ IT" ARE DIFFERENT ANSWERS.
-            # A store this reader must skip for epoch skew may hold an ACTIVE
-            # mission -- an updated reader is exactly the thing that would find
-            # out. Treating the skip as absence let open() write a second @1
-            # mission beside it (reproduced: the workspace ended with both),
-            # and the moment the reader is upgraded discovery sees two active
-            # missions, refuses, and the gate goes inert -- in a state no
-            # duplicate-resolution verb can clear, because this contract has
-            # none. Refusing costs an operator one upgrade; allowing it wedges
-            # the workspace for whoever comes next.
-            if "EpochSkew" in getattr(exc, "skipped_kinds", ()):
-                raise CustodyError(
-                    "a mission store here CLAIMS a newer contract epoch, so "
-                    "this reader cannot tell whether it holds an active "
-                    "mission. Opening beside it risks two active missions "
-                    "once the reader is updated, which wedges the gate. Read "
-                    "this workspace with an updated custody plugin/CLI first."
-                ) from exc
-            pass  # the expected state: nothing active to conflict with
-        else:
+        # PLURALITY IS LEGAL (es#173 §3): open no longer refuses on an
+        # existing active mission -- the fail-open decoy is removed not by
+        # handling MultipleActiveMissions better but by making the state
+        # legal. What open still refuses, checked BEFORE anything is written
+        # so a refused open leaves no partial mission dir:
+        #
+        # 1. a duplicate mission_id (the dir already holds checkpoints);
+        # 2. EpochSkew anywhere in the store -- a store this reader cannot
+        #    read may hold anything, and opening beside it is still blind;
+        # 3. unreadable mission dirs, unless each is explicitly quarantined:
+        #    under concurrent missions a corrupt sibling's guards are
+        #    silently absent from the union, so ignorable-corruption is no
+        #    longer a safe posture (case row B17).
+        if MissionStore(workspace / "missions" / mission_id).checkpoint_paths():
             raise CustodyError(
-                "an active mission already exists under this workspace; "
-                "complete or cancel it before opening another")
+                f"mission {mission_id!r} already exists under this "
+                "workspace; mission ids are permanent -- choose a fresh id")
+        siblings, skipped = cls._discover(workspace)
+        if any(s["kind"] == "EpochSkew" for s in skipped):
+            raise CustodyError(
+                "a mission store here CLAIMS a newer contract epoch, so "
+                "this reader cannot tell whether it holds an active "
+                "mission or what guards it arms. Opening beside it is "
+                "blind. Read this workspace with an updated custody "
+                "plugin/CLI first.")
+        acked = {str(name) for name in (acknowledge_unreadable or [])}
+        unknown = sorted(acked - {s["name"] for s in skipped})
+        if unknown:
+            raise CustodyError(
+                "acknowledge_unreadable names dir(s) that are not "
+                f"unreadable mission dirs here: {', '.join(unknown)} -- an "
+                "acknowledgement that matches nothing is a typo, not a "
+                "quarantine")
+        unacked = sorted(s["name"] for s in skipped if s["name"] not in acked)
+        if unacked:
+            raise CustodyError(
+                "unreadable mission dir(s) under this workspace: "
+                + ", ".join(unacked) +
+                ". Under concurrent missions an unreadable sibling's guards "
+                "are silently absent from the union, so open refuses until "
+                "they are repaired or explicitly quarantined "
+                "(--acknowledge-unreadable <dir>, recorded in the opening "
+                "checkpoint).")
+        opening_notes = [f"unreadable sibling acknowledged: {s['name']}"
+                         for s in sorted(skipped, key=lambda s: s["name"])]
+        # Scope-overlap disclosure (§3): pattern-vs-pattern intersection is
+        # decidable for this glob dialect; prose entries are reported as
+        # incomparable. Disclosure, not refusal -- coexistence on shared
+        # paths is the feature being built. Deterministic: sorted walk over
+        # sorted siblings, so identical inputs disclose identically.
+        new_patterns = sorted(e for e in (scope_in or [])
+                              if _is_matchable_pattern(e))
+        new_prose = sorted(e for e in (scope_in or [])
+                           if not _is_matchable_pattern(e))
+        for entry in sorted(siblings, key=lambda e: e["name"]):
+            sib_in = entry["latest"]["manifest"]["scope"]["in"]
+            sib_patterns = sorted(e for e in sib_in
+                                  if _is_matchable_pattern(e))
+            sib_prose = sorted(e for e in sib_in
+                               if not _is_matchable_pattern(e))
+            for a in new_patterns:
+                for b in sib_patterns:
+                    if _globs_intersect(a, b):
+                        opening_notes.append(
+                            f"scope overlap with {entry['name']}: "
+                            f"{a} ~ {b}")
+            if (scope_in or []) and sib_in:
+                for e in new_prose:
+                    opening_notes.append(
+                        f"scope entry vs {entry['name']} incomparable "
+                        f"(prose): {e}")
+                for e in sib_prose:
+                    opening_notes.append(
+                        f"scope entry of {entry['name']} incomparable "
+                        f"(prose): {e}")
+        for note in opening_notes:
+            # The composed disclosure embeds caller text (scope entries, dir
+            # names); a multi-line entry could smuggle a machine-note line
+            # into the opening checkpoint. Refusing the open is the fail-safe
+            # direction, and the guard's own message names the offending line.
+            _refuse_reserved_note(note)
         store = MissionStore(workspace / "missions" / mission_id)
         created = now_utc()
         manifest = {
@@ -975,7 +1136,7 @@ class Mission:
             "manifest": manifest,
             "state": {
                 "frontier": "await operator approval",
-                "notes": [],
+                "notes": opening_notes,
                 "unresolved_verdicts": [],
             },
             "receipt_ids": [],
@@ -986,12 +1147,19 @@ class Mission:
         return cls(store, workspace, actor)
 
     @classmethod
-    def load(cls, workspace: Path, actor: str) -> "Mission":
+    def _discover(cls, workspace: Path) -> tuple[list[dict], list[dict]]:
+        """Walk missions/ once: every ACTIVE mission and every skip.
+
+        Returns (active, skipped). Each active entry is
+        {"name", "dir", "store", "latest"} -- latest is the chain-verified
+        latest checkpoint. Each skipped entry is {"name", "kind", "reason"}
+        for a dir whose latest checkpoint fails to load. The ONE discovery
+        walk, shared by load, open, the union assembler, and the effect
+        gate, so no two surfaces can disagree about what is active."""
         workspace = Path(workspace)
         missions_root = workspace / "missions"
-        active: list[Path] = []
-        skipped: list[str] = []
-        skipped_kinds: list[str] = []
+        active: list[dict] = []
+        skipped: list[dict] = []
         if missions_root.is_dir():
             for mission_dir in sorted(missions_root.iterdir()):
                 if not mission_dir.is_dir():
@@ -1009,29 +1177,85 @@ class Mission:
                     # skipping those would reroute discovery around a mission
                     # that is merely busy, inviting a duplicate open.
                     reason = f"{mission_dir.name}: {type(exc).__name__}: {exc}"
-                    skipped.append(reason)
-                    skipped_kinds.append(type(exc).__name__)
+                    skipped.append({"name": mission_dir.name,
+                                    "kind": type(exc).__name__,
+                                    "reason": reason})
                     print(("custody: skipping unreadable mission dir " + reason)
                           .encode("ascii", "backslashreplace").decode("ascii"),
                           file=sys.stderr)
                     continue
                 if latest["status"] not in ("completed", "cancelled"):
-                    active.append(mission_dir)
+                    active.append({"name": mission_dir.name,
+                                   "dir": mission_dir, "store": store,
+                                   "latest": latest})
+        return active, skipped
+
+    @classmethod
+    def load(cls, workspace: Path, actor: str,
+             mission_id: str | None = None) -> "Mission":
+        """Resolve the mission this session acts under (es#173 §1).
+
+        Bound (mission_id given): the binding must name a mission directory
+        in THIS workspace whose latest checkpoint status is an open state.
+        Bound-to-nonexistent, bound-to-unreadable, bound-to-completed and
+        bound-to-cancelled are four spellings of the same BindingInvalid
+        refusal -- a stale binding NEVER falls through to discovery or to
+        "the only active mission": silent fallback is how a session acts
+        under the wrong authority politely.
+
+        Unbound: 0 active -> NoActiveMission (unchanged); 1 active ->
+        resolves to it (the single-mission workflow must not grow
+        ceremony); N>1 active -> BindingRequired naming every id and both
+        binding channels. It never guesses."""
+        workspace = Path(workspace)
+        if mission_id is not None:
+            mission_dir = workspace / "missions" / mission_id
+            store = MissionStore(mission_dir)
+            if not store.checkpoint_paths():
+                raise BindingInvalid(
+                    f"binding names mission {mission_id!r}: no such mission "
+                    f"under {workspace / 'missions'}. A binding never falls "
+                    "through to discovery -- fix or unset it (--mission / "
+                    "ZMS_MISSION_ID)")
+            try:
+                latest, _ = store.load_latest()
+            except (StoreError, ValueError) as exc:
+                raise BindingInvalid(
+                    f"binding names mission {mission_id!r}, whose store "
+                    f"cannot be read ({type(exc).__name__}: {exc}). A "
+                    "binding never falls through -- repair the store or "
+                    "unset the binding (--mission / ZMS_MISSION_ID)"
+                ) from exc
+            if latest["status"] not in _OPEN_STATES:
+                raise BindingInvalid(
+                    f"binding names mission {mission_id!r}, whose status is "
+                    f"{latest['status']!r} -- not an open state. Unset the "
+                    "binding (--mission / ZMS_MISSION_ID)")
+            return cls(store, workspace, actor)
+        active, skipped = cls._discover(workspace)
         if not active:
-            detail = f"; skipped unreadable: {'; '.join(skipped)}" if skipped else ""
-            exc = NoActiveMission(f"no active mission under {missions_root}{detail}")
+            reasons = [s["reason"] for s in skipped]
+            detail = (f"; skipped unreadable: {'; '.join(reasons)}"
+                      if skipped else "")
+            exc = NoActiveMission(
+                f"no active mission under {workspace / 'missions'}{detail}")
             # STRUCTURED, not prose. A caller that needs to know WHY discovery
             # came up empty must not have to grep the message: the message
             # contains the workspace path, so a directory literally named
             # `/work/NEWER epoch migration` made a substring test report a
             # newer-epoch store in a workspace holding no stores at all
             # (measured). Callers read this attribute instead.
-            exc.skipped_kinds = tuple(skipped_kinds)
+            exc.skipped_kinds = tuple(s["kind"] for s in skipped)
             raise exc
         if len(active) > 1:
-            names = ", ".join(p.name for p in active)
-            raise MultipleActiveMissions(f"multiple active missions: {names}")
-        return cls(MissionStore(active[0]), workspace, actor)
+            names = ", ".join(e["name"] for e in active)
+            raise BindingRequired(
+                f"{len(active)} active missions under this workspace: "
+                f"{names}. Bind the session to one -- pass --mission <id> "
+                "on the verb, or export ZMS_MISSION_ID=<id> for the "
+                "session. Binding routes authority (where effects and "
+                "notes land), never guard exposure.")
+        return cls(active[0]["store"], workspace, actor)
 
     # -- internal helpers ---------------------------------------------------
 
@@ -1437,12 +1661,10 @@ class Mission:
         The chain is the authority, as everywhere else here: a mission that
         has never been approved has no checkpoint whose status is anything but
         `draft` or `reopened`. Nothing is read from a caller-supplied string.
-        """
-        for cp_path in self.store.checkpoint_paths():
-            record = json.loads(cp_path.read_text(encoding="utf-8"))
-            if record["status"] not in ("draft", "reopened"):
-                return "active"
-        return "draft"
+        ONE implementation (`_approved_by_chain`), shared with the union
+        assembler and the sibling-drift discriminator (es#173), so the three
+        readers of "was this ever approved" cannot drift apart."""
+        return "active" if _approved_by_chain(self.store) else "draft"
 
     def _retired_receipt_ids(self, latest: dict) -> set[str]:
         """Ids whose loss was acknowledged. Retirement is permanent and lives

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
@@ -424,23 +424,26 @@ def test_run_gate_log_failure_keeps_verdict() -> None:
               "guard-log" in buf.getvalue())
 
 
-def test_run_gate_multiple_active_allows_loudly() -> None:
+def test_run_gate_multiple_active_evaluates_the_union() -> None:
+    # es#173: plurality is legal and the old inert-on-plurality fail-open is
+    # DELETED -- a duplicated mission dir arriving out-of-band (sync, copy)
+    # now contributes its guards to the union like any approved mission, and
+    # a block names every matching (mission, rule) pair.
     with tempfile.TemporaryDirectory() as tmp:
         ws = Path(tmp)
         m = Mission.open(ws, "gate-multi", "i", "operator:test", "agent:test",
                          actor="agent:test", guard_mode="enforce",
                          actuator_guards=GUARDS)
         m.approve()
-        # a duplicated mission dir arriving out-of-band (sync, copy) -- the
-        # decoy shape open() now refuses to create itself
         shutil.copytree(m.store.mission_dir, ws / "missions" / "gate-multi-2")
-        buf = io.StringIO()
-        with contextlib.redirect_stderr(buf):
-            v = run_gate(ws, {"tool_name": "Bash", "command": "curl :7878/api",
-                              "file_path": None}, actor="hook:custody-gate")
-        check("run-gate-multi-active-allows", v["decision"] == "allow")
-        check("run-gate-multi-active-warns",
-              "multiple active" in buf.getvalue().lower())
+        v = run_gate(ws, {"tool_name": "Bash", "command": "curl :7878/api",
+                          "file_path": None}, actor="hook:custody-gate")
+        check("run-gate-multi-active-blocks", v["decision"] == "block")
+        check("run-gate-multi-active-names-both-missions",
+              "gate-multi" in v["reason"] and "gate-multi-2" in v["reason"])
+        for name in ("gate-multi", "gate-multi-2"):
+            check(f"run-gate-multi-active-logs-{name}",
+                  (ws / "missions" / name / "guard-log.jsonl").exists())
 
 
 if __name__ == "__main__":

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -161,7 +161,10 @@ def test_cursor_string_tool_input_mcp() -> None:
               run_hook("cursor", payload).returncode == 2)
 
 
-def test_multiple_active_allows_with_warning() -> None:
+def test_multiple_active_evaluates_the_union() -> None:
+    # es#173: the decoy-disarm is dead -- a duplicated mission dir no longer
+    # turns the gate inert; both copies' guards enforce and the hook blocks,
+    # naming every matching (mission, rule) pair in the BLOCKED line.
     with tempfile.TemporaryDirectory() as tmp:
         ws = Path(tmp)
         m = Mission.open(ws, "hook-multi", "i", "operator:t", "agent:t",
@@ -171,9 +174,9 @@ def test_multiple_active_allows_with_warning() -> None:
         shutil.copytree(ws / "missions" / "hook-multi",
                         ws / "missions" / "hook-multi-2")
         res = run_hook("claude", payloads(tmp)["claude"])
-        check("hook-multi-active-allows", res.returncode == 0)
-        check("hook-multi-active-warns",
-              "multiple active" in res.stderr.lower())
+        check("hook-multi-active-blocks", res.returncode == 2)
+        check("hook-multi-active-names-both",
+              "hook-multi" in res.stderr and "hook-multi-2" in res.stderr)
 
 
 def test_fail_open() -> None:

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -70,6 +70,34 @@ def test_block_per_harness() -> None:
                   "no-rm" in (res.stderr + res.stdout))
 
 
+def test_env_bound_draft_self_arms() -> None:
+    """OD-4 refined (operator ruling 2026-08-25: "Self-arm at open, union
+    at approve"): a session whose harness env carries ZMS_MISSION_ID for a
+    draft mission is gated by that draft's OWN guards pre-approve; without
+    the binding the draft arms nothing (union at approve, unchanged)."""
+    def run_with_env(binding: str | None) -> subprocess.CompletedProcess:
+        env = dict(os.environ)
+        env.pop("ZMS_MISSION_ID", None)
+        if binding is not None:
+            env["ZMS_MISSION_ID"] = binding
+        return subprocess.run(
+            [sys.executable, str(HOOK), "--harness", "claude"],
+            input=raw, capture_output=True, text=True, env=env)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        Mission.open(ws, "hook-draft", "i", "operator:t", "agent:t",
+                     actor="agent:t", guard_mode="enforce",
+                     actuator_guards=GUARDS)
+        raw = json.dumps(payloads(tmp)["claude"])
+        check("hook-unbound-draft-allows",
+              run_with_env(None).returncode == 0)
+        res = run_with_env("hook-draft")
+        check("hook-env-bound-draft-blocks", res.returncode == 2)
+        check("hook-env-bound-reason-names-rule",
+              "no-rm" in (res.stderr + res.stdout))
+
+
 def test_allow_paths() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         ws = Path(tmp)

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1149,7 +1149,10 @@ def test_stale_reader_scope_never_claims_enforcement_the_gate_lacks(
     check("stale-scope-control-says-enforces",
           "still enforce" in _stale_reader_scope(healthy, "m-legacy"))
 
-    # DEFECT 1: a duplicate active mission -- Mission.load refuses, gate allows.
+    # DUPLICATE ACTIVE MISSIONS (was DEFECT 1): under es#173 plurality is
+    # legal and the gate evaluates the UNION -- both copies' guards enforce,
+    # so the census must NOT report the root fail-open any more, and the
+    # honest "still enforces" line must apply.
     dupe = workspace / "dupe"
     one = open_mission(dupe, "m-one", "First.",
                        guard_mode="enforce", actuator_guards=guards)
@@ -1157,13 +1160,11 @@ def test_stale_reader_scope_never_claims_enforcement_the_gate_lacks(
     one.record_effect("a.txt", "aa", "req-one")
     shutil.copytree(one.store.mission_dir, dupe / "missions" / "m-two")
     _skew_a_store_into(dupe, "m-legacy")
-    check("stale-scope-duplicate-gate-allows",
-          run_gate(dupe, call, actor="probe")["decision"] == "allow")
+    check("stale-scope-duplicate-gate-blocks",
+          run_gate(dupe, call, actor="probe")["decision"] == "block")
     dupe_scope = _stale_reader_scope(dupe, "m-legacy")
-    check("stale-scope-duplicate-claims-no-enforcement",
-          "still enforce" not in dupe_scope)
-    check("stale-scope-duplicate-names-the-cause",
-          "multiple active" in dupe_scope)
+    check("stale-scope-duplicate-still-enforces",
+          "still enforce" in dupe_scope)
 
     # DEFECT 2: a tampered sole active mission -- status() raises, hook allows.
     tampered = workspace / "tampered"
@@ -1179,12 +1180,15 @@ def test_stale_reader_scope_never_claims_enforcement_the_gate_lacks(
         ["nothing/**"]
     tail.write_text(json.dumps(record, indent=1, sort_keys=True) + "\n",
                     encoding="utf-8")
-    try:
-        run_gate(tampered, call, actor="probe")
-        check("stale-scope-tamper-gate-does-not-enforce", False)
-    except CustodyError:
-        # run_gate propagates; custody_hook catches CustodyError and ALLOWS.
-        check("stale-scope-tamper-gate-does-not-enforce", True)
+    # es#173: run_gate no longer propagates the tamper -- the mission joins
+    # the DEGRADED set (guards NOT enforced, disclosed in the reason and as
+    # a greppable TAMPER line on stderr) and the verdict stays allow.
+    buf_t = io.StringIO()
+    with contextlib.redirect_stderr(buf_t):
+        v_t = run_gate(tampered, call, actor="probe")
+    check("stale-scope-tamper-gate-does-not-enforce",
+          v_t["decision"] == "allow" and "NOT enforced" in v_t["reason"])
+    check("stale-scope-tamper-stderr-greppable", "TAMPER" in buf_t.getvalue())
     check("stale-scope-tamper-claims-no-enforcement",
           "still enforce" not in _stale_reader_scope(tampered, "m-legacy"))
 
@@ -2337,19 +2341,25 @@ def test_tail_guard_tamper_without_amendment_detected(workspace: Path) -> None:
         check("tail-guard-tamper-detected", True)
 
 
-def test_open_refuses_second_active_mission(workspace: Path) -> None:
-    # A second ACTIVE mission under one workspace makes every other command
-    # refuse (MultipleActiveMissions) -- including the gate's discovery -- so
-    # open creating one is a decoy-disarm wedge, not a feature.
+def test_open_beside_active_is_legal_but_duplicate_id_refused(
+        workspace: Path) -> None:
+    # es#173: plurality is legal -- open no longer refuses on an existing
+    # active mission (the decoy-disarm wedge died with the inert-on-
+    # plurality gate branch; the union now enforces across all approved
+    # missions). The door still refuses a DUPLICATE mission id, and the
+    # refused open must not leave a partial mission dir behind.
     open_mission(workspace, "m-first", "First.")
+    second = open_mission(workspace, "m-second", "Concurrent.")
+    check("open-second-active-is-legal",
+          second.store.load_latest()[0]["status"] == "draft")
     try:
-        open_mission(workspace, "m-second", "Decoy.")
-        check("open-refuses-second-active", False)
+        open_mission(workspace, "m-second", "Duplicate id.")
+        check("open-refuses-duplicate-id", False)
     except CustodyError:
-        check("open-refuses-second-active", True)
-    # the refused open must not leave a partial mission dir behind
-    check("open-refused-left-no-dir",
-          not (workspace / "missions" / "m-second").exists())
+        check("open-refuses-duplicate-id", True)
+    cps = sorted((workspace / "missions" / "m-second" / "checkpoints")
+                 .glob("r*.json"))
+    check("open-duplicate-refusal-wrote-nothing", len(cps) == 1)
 
 
 def test_api_disarm_clears_guard_mode_with_guard_list(workspace: Path) -> None:
@@ -4759,7 +4769,7 @@ TESTS = [
     test_amend_arms_guards_legitimately,
     test_api_disarm_clears_guard_mode_with_guard_list,
     test_amend_none_clears_guard_keys,
-    test_open_refuses_second_active_mission,
+    test_open_beside_active_is_legal_but_duplicate_id_refused,
     test_amend_empty_guards_list_refused,
     test_amend_then_tail_guard_strip_detected,
     test_unrelated_amend_then_tail_regex_narrow_detected,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -25,10 +25,10 @@ import census_missions  # noqa: E402
 from custody_mission import (  # noqa: E402
     _same_artifact,
     AcceptanceRefused,
+    BindingRequired,
     CustodyError,
     IllegalTransition,
     Mission,
-    MultipleActiveMissions,
     NoActiveMission,
 )
 
@@ -95,16 +95,21 @@ def test_load_refuses_zero_and_multiple(workspace: Path) -> None:
         check("load-zero-raises", True)
 
     m1 = open_mission(workspace, "m-one", "A.")
-    # open() refuses to CREATE a second active mission in one workspace
-    # (decoy-disarm wedge, es#117 review fix 4); a duplicated mission dir
-    # arriving out-of-band (sync, copy) is exactly the multiple-active state
-    # load() must still refuse, so build it that way.
+    # es#173: plurality is legal, and an UNBOUND lifecycle verb over N>1
+    # active missions refuses BindingRequired (never guesses; the retired
+    # MultipleActiveMissions is raised nowhere) -- the refusal names every
+    # id and both binding channels; a bound load resolves normally.
     shutil.copytree(m1.store.mission_dir, workspace / "missions" / "m-two")
     try:
         Mission.load(workspace, actor="agent:x")
         check("load-multiple-raises", False)
-    except MultipleActiveMissions:
-        check("load-multiple-raises", True)
+    except BindingRequired as exc:
+        check("load-multiple-raises",
+              "m-one" in str(exc) and "m-two" in str(exc)
+              and "ZMS_MISSION_ID" in str(exc))
+    bound = Mission.load(workspace, actor="agent:x", mission_id="m-two")
+    check("load-multiple-bound-resolves",
+          bound.store.mission_dir.name == "m-two")
 
 
 def test_effect_writes_receipt_and_artifact(workspace: Path) -> None:

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -51,13 +51,7 @@ FAILURES: list[str] = []
 
 # Rows not yet implemented. Every name here must FAIL when run; the
 # implementing commits shrink this set to empty.
-XFAIL: set[str] = {
-    "test_b26_never_approved_sibling_never_launders",
-    "test_b27_no_authorization_amendment_no_downgrade",
-    "test_b28_all_three_legs_yield_drift_sibling",
-    "test_scan_covers_non_active_siblings",
-    "test_b29_sibling_touched_prefix_forgery_refused",
-}
+XFAIL: set[str] = set()  # every row implemented -- the set burned down to empty
 
 
 def check(name: str, cond: bool) -> None:

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -958,15 +958,24 @@ def test_refuter_f3_bound_load_validates_mission_id(workspace: Path) -> None:
     m = load_bound(ws1, "m-local")
     check("F3-normal-id-still-loads",
           m.store.mission_dir == ws1 / "missions" / "m-local")
+    # fix-refuter F-D: re's `$` also matches just before a trailing
+    # newline, so "m-x\n" passed the schema's kebab-case check -- the id
+    # rule must anchor with \Z.
+    from verify_mission_custody import _ID_RE
+    check("F3-id-re-rejects-trailing-newline",
+          _ID_RE.match("m-x\n") is None)
+    check("F3-id-re-still-accepts-plain-id",
+          _ID_RE.match("m-x") is not None)
 
 
 def test_refuter_f4_blocked_effect_writes_nothing(workspace: Path) -> None:
-    """Refuter finding 4: a blocked effect's refusal claims "Nothing was
-    written and no receipt was minted" -- so nothing may be. Pre-fix the
-    fresh unreadable-acknowledged checkpoints landed BEFORE union
+    """Refuter finding 4: a blocked effect's refusal claimed "Nothing was
+    written and no receipt was minted" while the fresh
+    unreadable-acknowledged checkpoints had landed BEFORE union
     evaluation could block (measured, PROBE 5: checkpoint count 2 -> 3 on
     a refusal). Refuse-before-mutate: the chain must be byte-identical
-    after a block."""
+    after a block. (The message now names its one deliberate side effect,
+    the guard-log append -- fix-refuter F-C.)"""
     g = [{"name": "no-frozen", "tool_names": ["Write"],
           "command_regexes": [], "path_globs": ["frozen/**"]}]
     open_mission(workspace, "m-guard", guard_mode="enforce",
@@ -1070,6 +1079,88 @@ def test_refuter_f5_post_approve_union_unchanged(workspace: Path) -> None:
         check("F5-post-approve-sibling-effect-blocked", True)
 
 
+def _raise_sibling_marker(ws: Path) -> Mission:
+    """m-alpha receipts shared.txt, authorizes m-beta, m-beta crosses,
+    m-alpha's resume raises DRIFT-SIBLING:shared.txt. Returns bound
+    m-alpha with the marker standing."""
+    a, b = _two_missions_one_artifact(ws)
+    a.amend_authority("operator: mission m-beta is authorized to write "
+                      "shared.txt")
+    b.record_effect("shared.txt", "beta-1", "req-b1")
+    a = load_bound(ws, "m-alpha")
+    assert a.resume() == ["DRIFT-SIBLING:shared.txt"]
+    return a
+
+
+def test_refuter_fa_transient_crossing_discharges_loudly(workspace: Path) -> None:
+    """Fix-refuter F-A (operator ruling 2026-08-25: loud auto-discharge):
+    a transient sibling crossing -- write then revert to the receipted
+    bytes -- self-discharged in SILENCE: resume returned [], the CLI
+    printed "resume: clean", and the discharge note named the path but
+    not the sibling. The discharge stays automatic (nothing is left to
+    reconcile) but is finding-grade: resume RETURNS
+    SIBLING-DISCHARGED:<path> (non-blocking -- status still transitions),
+    the CLI prints it and never "clean", and the note carries the sibling
+    attribution from the original detection."""
+    # Library leg.
+    ws = workspace / "lib"
+    a = _raise_sibling_marker(ws)
+    (ws / "shared.txt").write_text("alpha-1", encoding="utf-8")  # revert
+    findings = a.resume()
+    check("FA-resume-returns-discharge",
+          findings == ["SIBLING-DISCHARGED:shared.txt"])
+    latest = a.store.load_latest()[0]
+    check("FA-status-transitions", latest["status"] == "active")
+    check("FA-nothing-unresolved",
+          latest["state"]["unresolved_verdicts"] == [])
+    check("FA-note-names-sibling-and-receipt",
+          any("discharged" in n and "m-beta" in n and "req-b1" in n
+              for n in latest["state"]["notes"]))
+    try:
+        a.begin_verification()
+        check("FA-verification-reachable-without-ack", True)
+    except IllegalTransition:
+        check("FA-verification-reachable-without-ack", False)
+    # CLI leg: the discharge line reaches stdout, "clean" never prints,
+    # and the exit code stays 0 -- finding-grade, not drift-grade.
+    ws = workspace / "cli"
+    _raise_sibling_marker(ws)
+    (ws / "shared.txt").write_text("alpha-1", encoding="utf-8")
+    r = run_cli(["resume", "--workspace", str(ws),
+                 "--actor", "agent:worker", "--mission", "m-alpha"])
+    check("FA-cli-prints-discharge",
+          "SIBLING-DISCHARGED:shared.txt" in r.stdout)
+    check("FA-cli-never-clean",
+          "resume: clean" not in (r.stdout + r.stderr))
+    check("FA-cli-exit-nonblocking", r.returncode == 0)
+
+
+def test_refuter_fb_marker_transfer_note_truthful(workspace: Path) -> None:
+    """Fix-refuter F-B: when a stale DRIFT-SIBLING marker's obligation
+    transfers to receipt-loss (the covering receipt file vanished), the
+    note claimed "re-classified at current severity" -- false: nothing
+    was re-classified, the receipt that would prove either reading is
+    gone. The note must say the marker was superseded by RECEIPT-MISSING
+    and carry the sibling attribution."""
+    a = _raise_sibling_marker(workspace)
+    a.store.receipt_path("req-a1").unlink()
+    findings = a.resume()
+    check("FB-receipt-missing-raised",
+          "RECEIPT-MISSING:req-a1" in findings)
+    latest = a.store.load_latest()[0]
+    unresolved = latest["state"]["unresolved_verdicts"]
+    check("FB-marker-transferred",
+          "DRIFT-SIBLING:shared.txt" not in unresolved
+          and "RECEIPT-MISSING:req-a1" in unresolved)
+    notes = latest["state"]["notes"]
+    check("FB-note-names-transfer-and-sibling",
+          any("superseded by RECEIPT-MISSING:req-a1" in n
+              and "m-beta" in n and "req-b1" in n for n in notes))
+    check("FB-note-not-falsely-reclassified",
+          not any("re-classified at current severity" in n
+                  for n in notes))
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -1117,6 +1208,8 @@ TESTS = [
     test_refuter_f5_draft_self_arms_own_session,
     test_refuter_f5_draft_guards_invisible_elsewhere,
     test_refuter_f5_post_approve_union_unchanged,
+    test_refuter_fa_transient_crossing_discharges_loudly,
+    test_refuter_fb_marker_transfer_note_truthful,
 ]
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -825,6 +825,175 @@ def test_open_still_refuses_duplicate_mission_id(workspace: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# PR #220 refuter findings -- live-reproduced defects pinned as regressions
+# ---------------------------------------------------------------------------
+
+
+def _seed_receipted_artifact(ws: Path) -> None:
+    """m-alpha approved with a receipt on shared.txt."""
+    a = open_mission(ws, "m-alpha")
+    a.approve()
+    a = load_bound(ws, "m-alpha")
+    a.record_effect("shared.txt", "alpha-1", "req-a1")
+
+
+def test_refuter_f1_substring_id_never_launders(workspace: Path) -> None:
+    """Refuter finding 1: the authorization leg's mission-id test must
+    match the sibling id as a whole token, never a raw substring --
+    `m-al` must not ride on an amendment authorizing `m-alpine`, and a
+    mission named `test` must not ride on the word `latest`.
+    `_amendment_names` already refuses raw substrings for the PATH leg;
+    the id leg is held to the same standard."""
+    # Leg A: adversary id is a substring of the authorized id.
+    ws = workspace / "sub-id"
+    _seed_receipted_artifact(ws)
+    a = load_bound(ws, "m-alpha")
+    a.amend_authority(
+        "operator: mission m-alpine is authorized to write shared.txt")
+    evil = open_mission(ws, "m-al", actor="agent:evil")
+    evil.approve()
+    evil = load_bound(ws, "m-al", actor="agent:evil")
+    evil.record_effect("shared.txt", "tampered-by-m-al", "req-e1")
+    a = load_bound(ws, "m-alpha")
+    check("F1-substring-id-stays-plain-drift", a.resume() == ["shared.txt"])
+    latest = a.store.load_latest()[0]
+    check("F1-substring-id-reconciliation-marker",
+          "RECONCILIATION:shared.txt"
+          in latest["state"]["unresolved_verdicts"])
+    # Leg B: adversary id is an accidental substring of ordinary prose.
+    ws = workspace / "sub-word"
+    _seed_receipted_artifact(ws)
+    a = load_bound(ws, "m-alpha")
+    a.amend_authority(
+        "operator: the latest revision of shared.txt is authorized")
+    evil = open_mission(ws, "test", actor="agent:evil")
+    evil.approve()
+    evil = load_bound(ws, "test", actor="agent:evil")
+    evil.record_effect("shared.txt", "tampered-by-test", "req-e2")
+    a = load_bound(ws, "m-alpha")
+    check("F1-prose-substring-stays-plain-drift",
+          a.resume() == ["shared.txt"])
+    # Positive control: an amendment naming the sibling id as a whole
+    # token still reclassifies -- the fix must not break the sanctioned
+    # crossing.
+    ws = workspace / "exact"
+    _seed_receipted_artifact(ws)
+    a = load_bound(ws, "m-alpha")
+    a.amend_authority(
+        "operator: mission m-al is authorized to write shared.txt")
+    evil = open_mission(ws, "m-al", actor="agent:evil")
+    evil.approve()
+    evil = load_bound(ws, "m-al", actor="agent:evil")
+    evil.record_effect("shared.txt", "sanctioned-by-m-al", "req-e3")
+    a = load_bound(ws, "m-alpha")
+    check("F1-exact-token-still-reclassifies",
+          a.resume() == ["DRIFT-SIBLING:shared.txt"])
+
+
+def test_refuter_f2_stale_sibling_marker_discharges(workspace: Path) -> None:
+    """Refuter finding 2: a DRIFT-SIBLING marker whose path is no longer
+    sibling-attributable (content moved on before acknowledgement) must be
+    dischargeable. Resume re-classifies the path at its CURRENT severity,
+    replacing the stale marker, so the normal reconcile flow applies and
+    the mission can reach begin_verification. Pre-fix the marker had no
+    working exit: acknowledge_sibling refused forever, reconcile cleared
+    only RECONCILIATION, and the mission wedged in `reopened` (measured,
+    probe2 PROBE 2b)."""
+    a, b = _two_missions_one_artifact(workspace)
+    a.amend_authority("operator: mission m-beta is authorized to write "
+                      "shared.txt")
+    b.record_effect("shared.txt", "beta-1", "req-b1")
+    a = load_bound(workspace, "m-alpha")
+    check("F2-sibling-raised", a.resume() == ["DRIFT-SIBLING:shared.txt"])
+    # content moves on before acknowledgement -- attribution is now stale
+    (workspace / "shared.txt").write_text("operator-later-edit",
+                                          encoding="utf-8")
+    try:
+        a.acknowledge_sibling("shared.txt")
+        check("F2-stale-ack-refused", False)
+    except CustodyError as exc:
+        check("F2-stale-ack-refused", True)
+        check("F2-refusal-names-real-remedy", "re-run resume" in str(exc))
+    findings = a.resume()
+    check("F2-reclassified-at-current-severity", findings == ["shared.txt"])
+    unresolved = a.store.load_latest()[0]["state"]["unresolved_verdicts"]
+    check("F2-stale-marker-replaced",
+          "DRIFT-SIBLING:shared.txt" not in unresolved
+          and "RECONCILIATION:shared.txt" in unresolved)
+    a = load_bound(workspace, "m-alpha")
+    a.reconcile("shared.txt", "operator-later-edit", "req-fix")
+    a = load_bound(workspace, "m-alpha")
+    check("F2-resume-clean-after-reconcile", a.resume() == [])
+    latest = a.store.load_latest()[0]
+    check("F2-nothing-unresolved",
+          latest["state"]["unresolved_verdicts"] == [])
+    try:
+        a.begin_verification()
+        check("F2-begin-verification-reachable", True)
+    except IllegalTransition:
+        check("F2-begin-verification-reachable", False)
+
+
+def test_refuter_f3_bound_load_validates_mission_id(workspace: Path) -> None:
+    """Refuter finding 3: the bound-load channel (--mission /
+    ZMS_MISSION_ID, lower-provenance input) must validate mission_id as a
+    single kebab-case segment -- the same rule open's schema enforces. A
+    traversal id must never bind across workspaces: pre-fix the effect
+    wrote the artifact in ws1 while the receipt landed in ws2's store, a
+    split brain neither workspace's resume could explain (measured,
+    PROBE 4)."""
+    ws1 = workspace / "ws1"
+    ws2 = workspace / "ws2"
+    open_mission(ws2, "m-remote").approve()
+    open_mission(ws1, "m-local").approve()
+    for spelling, mid in (
+            ("posix", "../../ws2/missions/m-remote"),
+            ("nt", "..\\..\\ws2\\missions\\m-remote"),
+            ("absolute", str(ws2 / "missions" / "m-remote"))):
+        try:
+            Mission.load(ws1, actor="agent:worker", mission_id=mid)
+            check(f"F3-traversal-refused-{spelling}", False)
+        except CustodyError:
+            check(f"F3-traversal-refused-{spelling}", True)
+    m = load_bound(ws1, "m-local")
+    check("F3-normal-id-still-loads",
+          m.store.mission_dir == ws1 / "missions" / "m-local")
+
+
+def test_refuter_f4_blocked_effect_writes_nothing(workspace: Path) -> None:
+    """Refuter finding 4: a blocked effect's refusal claims "Nothing was
+    written and no receipt was minted" -- so nothing may be. Pre-fix the
+    fresh unreadable-acknowledged checkpoints landed BEFORE union
+    evaluation could block (measured, PROBE 5: checkpoint count 2 -> 3 on
+    a refusal). Refuse-before-mutate: the chain must be byte-identical
+    after a block."""
+    g = [{"name": "no-frozen", "tool_names": ["Write"],
+          "command_regexes": [], "path_globs": ["frozen/**"]}]
+    open_mission(workspace, "m-guard", guard_mode="enforce",
+                 actuator_guards=g).approve()
+    w = open_mission(workspace, "m-writer")
+    w.approve()
+    w = load_bound(workspace, "m-writer")
+    corrupt_dir(workspace, "m-corrupt")
+    before = chain_bytes(workspace, "m-writer")
+    with contextlib.redirect_stderr(io.StringIO()):
+        try:
+            w.record_effect("frozen/f.txt", "x", "req-1",
+                            acknowledge_unreadable=["m-corrupt"])
+            check("F4-effect-blocked", False)
+        except CustodyError as exc:
+            check("F4-effect-blocked",
+                  "blocked by custody guard" in str(exc))
+    check("F4-chain-byte-identical-after-block",
+          chain_bytes(workspace, "m-writer") == before)
+    check("F4-no-artifact-written",
+          not (workspace / "frozen" / "f.txt").exists())
+    receipts = workspace / "missions" / "m-writer" / "receipts"
+    check("F4-no-receipt-minted",
+          not receipts.exists() or not list(receipts.glob("*.json")))
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -864,6 +1033,10 @@ TESTS = [
     test_receipt_at_1_closure_regression,
     test_scope_overlap_disclosure_deterministic,
     test_open_still_refuses_duplicate_mission_id,
+    test_refuter_f1_substring_id_never_launders,
+    test_refuter_f2_stale_sibling_marker_discharges,
+    test_refuter_f3_bound_load_validates_mission_id,
+    test_refuter_f4_blocked_effect_writes_nothing,
 ]
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -54,15 +54,6 @@ FAILURES: list[str] = []
 XFAIL: set[str] = {
     "test_a1_a3_draft_vs_active_union_membership",
     "test_a2_reopened_never_approved_contributes_nothing",
-    "test_a6_a7_terminal_states_binding_invalid",
-    "test_a8_unreadable_dir_binding_invalid",
-    "test_b4_binding_with_nothing_active",
-    "test_b5_b10_open_beside_active_is_legal",
-    "test_b8_bound_resolves_to_bound",
-    "test_b9_b15_stale_binding_never_falls_through",
-    "test_b11_plural_unbound_lifecycle_requires_binding",
-    "test_binding_channels_cli_flag_env_precedence",
-    "test_missions_list_verb",
     "test_b7_lone_unapproved_draft_contributes_nothing",
     "test_b12_union_names_all_matching_pairs",
     "test_b14_b16_binding_never_changes_exposure",
@@ -70,7 +61,6 @@ XFAIL: set[str] = {
     "test_b13_own_guards_gate_own_effect",
     "test_b30_audit_channels_unblockable",
     "test_gate_runs_leave_every_chain_byte_identical",
-    "test_b17_open_refuses_unreadable_sibling",
     "test_b22_gate_degraded_union_is_disclosed",
     "test_b23_effect_refuses_union_degraded",
     "test_b21_crossing_writes_side_channel_never_the_chain",
@@ -79,8 +69,6 @@ XFAIL: set[str] = {
     "test_b28_all_three_legs_yield_drift_sibling",
     "test_scan_covers_non_active_siblings",
     "test_b29_sibling_touched_prefix_forgery_refused",
-    "test_receipt_at_1_closure_regression",
-    "test_scope_overlap_disclosure_deterministic",
 }
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -1,0 +1,945 @@
+#!/usr/bin/env python3
+"""es#173 concurrent missions -- the case tables as an executable spec.
+
+Every test here is one or more rows of the adjudicated design's product
+space (docs/design/2026-08-25-es173-concurrent-missions-design.md, Tables
+A and B in section 7, plus the section 9 test obligations). The tables are
+the spec; this file is the tables made falsifiable. Rows the implementation
+does not yet satisfy are listed in XFAIL below and MUST fail until the
+implementing commit lands -- an XFAIL row that passes is itself a failure
+(the spec would be pinning nothing).
+
+One deliberate departure from the design text, per the verification report
+this implementation was ordered to honor: the resume-time sibling receipt
+scan ranges over ALL readable sibling mission stores, not only the ACTIVE
+ones -- the adjudication ("resume-time scan of sibling receipt stores") and
+the gauntlet repair carry no active-only narrowing, and a sibling that
+completed between its write and A's resume must still explain the drift.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+import custody_mission as cm  # noqa: E402
+from custody_mission import (  # noqa: E402
+    CustodyError, IllegalTransition, Mission, NoActiveMission,
+)
+from custody_gate import run_gate  # noqa: E402
+from custody_store import MissionStore, sha256_file  # noqa: E402
+from verify_mission_custody import validate_record  # noqa: E402
+
+# New names the implementation must provide; resolved lazily so this spec
+# can run (and fail where expected) against the pre-change core.
+BindingRequired = getattr(cm, "BindingRequired", None)
+BindingInvalid = getattr(cm, "BindingInvalid", None)
+UnionDegraded = getattr(cm, "UnionDegraded", None)
+
+CLI = ROOT / "custody_cli.py"
+
+FAILURES: list[str] = []
+
+# Rows not yet implemented. Every name here must FAIL when run; the
+# implementing commits shrink this set to empty.
+XFAIL: set[str] = {
+    "test_a1_a3_draft_vs_active_union_membership",
+    "test_a2_reopened_never_approved_contributes_nothing",
+    "test_a6_a7_terminal_states_binding_invalid",
+    "test_a8_unreadable_dir_binding_invalid",
+    "test_b4_binding_with_nothing_active",
+    "test_b5_b10_open_beside_active_is_legal",
+    "test_b8_bound_resolves_to_bound",
+    "test_b9_b15_stale_binding_never_falls_through",
+    "test_b11_plural_unbound_lifecycle_requires_binding",
+    "test_binding_channels_cli_flag_env_precedence",
+    "test_missions_list_verb",
+    "test_b7_lone_unapproved_draft_contributes_nothing",
+    "test_b12_union_names_all_matching_pairs",
+    "test_b14_b16_binding_never_changes_exposure",
+    "test_b13_effect_union_evaluated_before_write",
+    "test_b13_own_guards_gate_own_effect",
+    "test_b30_audit_channels_unblockable",
+    "test_gate_runs_leave_every_chain_byte_identical",
+    "test_b17_open_refuses_unreadable_sibling",
+    "test_b22_gate_degraded_union_is_disclosed",
+    "test_b23_effect_refuses_union_degraded",
+    "test_b21_crossing_writes_side_channel_never_the_chain",
+    "test_b26_never_approved_sibling_never_launders",
+    "test_b27_no_authorization_amendment_no_downgrade",
+    "test_b28_all_three_legs_yield_drift_sibling",
+    "test_scan_covers_non_active_siblings",
+    "test_b29_sibling_touched_prefix_forgery_refused",
+    "test_receipt_at_1_closure_regression",
+    "test_scope_overlap_disclosure_deterministic",
+}
+
+
+def check(name: str, cond: bool) -> None:
+    if not cond:
+        FAILURES.append(name)
+        print(f"FAIL {name}")
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            raise AssertionError(f"es173 case check failed: {name}")
+    else:
+        print(f"ok   {name}")
+
+
+def open_mission(workspace: Path, mission_id: str, instruction: str = "i",
+                 actor: str = "agent:worker", **kwargs) -> Mission:
+    return Mission.open(
+        workspace, mission_id=mission_id, instruction=instruction,
+        operator_ref="operator:zach", steward_ref="agent:worker",
+        required_tier="declared-role-separation", actor=actor, **kwargs)
+
+
+def load_bound(workspace: Path, mission_id: str,
+               actor: str = "agent:worker") -> Mission:
+    return Mission.load(workspace, actor=actor, mission_id=mission_id)
+
+
+def guard(name: str, globs: list[str], tools: list[str] | None = None,
+          regexes: list[str] | None = None) -> dict:
+    return {"name": name, "tool_names": tools or ["Write"],
+            "command_regexes": regexes or [], "path_globs": globs}
+
+
+def corrupt_dir(workspace: Path, name: str) -> Path:
+    """Plant a mission dir whose latest checkpoint cannot be loaded."""
+    src = None
+    for d in sorted((workspace / "missions").iterdir()):
+        if d.is_dir():
+            src = d
+            break
+    target = workspace / "missions" / name
+    if src is not None and src.name != name:
+        shutil.copytree(src, target)
+    else:
+        (target / "checkpoints").mkdir(parents=True)
+    tail = sorted((target / "checkpoints").glob("r*.json"))
+    if tail:
+        tail[-1].write_text("{not json", encoding="utf-8")
+    else:
+        (target / "checkpoints" / "r00000001.json").write_text(
+            "{not json", encoding="utf-8")
+    return target
+
+
+def chain_bytes(workspace: Path, mission: str) -> list[bytes]:
+    return [p.read_bytes() for p in sorted(
+        (workspace / "missions" / mission / "checkpoints").glob("r*.json"))]
+
+
+def run_cli(args: list[str], *, env_extra: dict | None = None,
+            stdin: str | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("ZMS_MISSION_ID", None)
+    env["PYTHONIOENCODING"] = "utf-8"
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run([sys.executable, str(CLI)] + args, env=env,
+                          input=stdin, capture_output=True, text=True)
+
+
+# ---------------------------------------------------------------------------
+# Table A -- mission status x discovery x binding x union (guard-source)
+# ---------------------------------------------------------------------------
+
+def test_a1_a3_draft_vs_active_union_membership(workspace: Path) -> None:
+    """A1 + A3 + B24/B25 mirror: the SAME armed guard contributes nothing
+    while its mission is a never-approved draft, and blocks the moment
+    approve() lands. Approval is the arming event (OD-4)."""
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    open_mission(workspace, "m-draft", guard_mode="enforce",
+                 actuator_guards=g)
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "secrets/x.env"}
+    v = run_gate(workspace, call, actor="hook:test")
+    check("A1-draft-guards-not-in-union", v["decision"] == "allow")
+    load_bound(workspace, "m-draft").approve()
+    v2 = run_gate(workspace, call, actor="hook:test")
+    check("A3-approved-guards-arm-union", v2["decision"] == "block")
+    check("B25-block-names-mission-and-rule",
+          "m-draft" in v2["reason"] and "no-secrets" in v2["reason"])
+
+
+def test_a2_reopened_never_approved_contributes_nothing(workspace: Path) -> None:
+    """A2: a never-approved mission wedged in `reopened` (drift on a draft)
+    must not arm the union -- the chain test, not latest status, decides
+    (OD-4 / FATAL-3 leg 2 share this discriminator)."""
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    m = open_mission(workspace, "m-re", guard_mode="enforce",
+                     actuator_guards=g)
+    m.record_effect("a.txt", "aa", "req-1")  # legal in draft
+    (workspace / "a.txt").write_text("tampered", encoding="utf-8")
+    m.resume()  # draft -> reopened, never approved
+    check("A2-setup-reopened",
+          m.store.load_latest()[0]["status"] == "reopened")
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "secrets/x.env"}
+    v = run_gate(workspace, call, actor="hook:test")
+    check("A2-never-approved-reopened-not-in-union",
+          v["decision"] == "allow")
+
+
+def test_a4_reopened_approved_lineage_stays_armed(workspace: Path) -> None:
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    m = open_mission(workspace, "m-re-appr", guard_mode="enforce",
+                     actuator_guards=g)
+    m.approve()
+    m.record_effect("a.txt", "aa", "req-1")
+    (workspace / "a.txt").write_text("tampered", encoding="utf-8")
+    m.resume()
+    check("A4-setup-reopened",
+          m.store.load_latest()[0]["status"] == "reopened")
+    v = run_gate(workspace, {"tool_name": "Write", "command": None,
+                             "file_path": "secrets/x.env"},
+                 actor="hook:test")
+    check("A4-approved-reopened-still-armed", v["decision"] == "block")
+
+
+def test_a5_verifying_guards_keep_binding_effect_illegal(workspace: Path) -> None:
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    m = open_mission(workspace, "m-ver", guard_mode="enforce",
+                     actuator_guards=g)
+    m.approve()
+    m.begin_verification()
+    v = run_gate(workspace, {"tool_name": "Write", "command": None,
+                             "file_path": "secrets/x.env"},
+                 actor="hook:test")
+    check("A5-verifying-guards-still-armed", v["decision"] == "block")
+    try:
+        m.record_effect("b.txt", "bb", "req-2")
+        check("A5-effect-illegal-in-verifying", False)
+    except IllegalTransition:
+        check("A5-effect-illegal-in-verifying", True)
+
+
+def test_a6_a7_terminal_states_binding_invalid(workspace: Path) -> None:
+    m = open_mission(workspace, "m-done")
+    m.approve()
+    m.begin_verification()
+    acceptor = Mission.load(workspace, actor="agent:acceptor")
+    acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                            assurance_tier="declared-role-separation",
+                            reason="done")
+    try:
+        load_bound(workspace, "m-done")
+        check("A6-bound-to-completed-refused", False)
+    except Exception as exc:
+        check("A6-bound-to-completed-refused",
+              BindingInvalid is not None and isinstance(exc, BindingInvalid)
+              and "completed" in str(exc))
+    c = open_mission(workspace, "m-gone")
+    c.cancel("abandoned")
+    try:
+        load_bound(workspace, "m-gone")
+        check("A7-bound-to-cancelled-refused", False)
+    except Exception as exc:
+        check("A7-bound-to-cancelled-refused",
+              BindingInvalid is not None and isinstance(exc, BindingInvalid)
+              and "cancelled" in str(exc))
+
+
+def test_a8_unreadable_dir_binding_invalid(workspace: Path) -> None:
+    open_mission(workspace, "m-live").approve()
+    corrupt_dir(workspace, "m-corrupt")
+    try:
+        with contextlib.redirect_stderr(io.StringIO()):
+            load_bound(workspace, "m-corrupt")
+        check("A8-bound-to-unreadable-refused", False)
+    except Exception as exc:
+        check("A8-bound-to-unreadable-refused",
+              BindingInvalid is not None and isinstance(exc, BindingInvalid))
+
+
+def test_b4_binding_with_nothing_active(workspace: Path) -> None:
+    """Row 4: a binding naming a mission in an empty workspace is
+    BindingInvalid -- never silently unbound."""
+    try:
+        load_bound(workspace, "m-ghost")
+        check("B4-binding-nothing-active-refused", False)
+    except Exception as exc:
+        check("B4-binding-nothing-active-refused",
+              BindingInvalid is not None and isinstance(exc, BindingInvalid))
+
+
+# ---------------------------------------------------------------------------
+# Table B -- binding mechanics (rows 1, 2, 5, 6, 8, 9, 10, 11, 15)
+# ---------------------------------------------------------------------------
+
+def test_b1_b2_zero_active_unchanged(workspace: Path) -> None:
+    try:
+        Mission.load(workspace, actor="agent:x")
+        check("B2-zero-active-lifecycle-refuses", False)
+    except NoActiveMission:
+        check("B2-zero-active-lifecycle-refuses", True)
+    m = open_mission(workspace, "m-first")
+    check("B1-open-yields-draft",
+          m.store.load_latest()[0]["status"] == "draft")
+
+
+def test_b5_b10_open_beside_active_is_legal(workspace: Path) -> None:
+    """Rows 5 and 10: plurality is legal -- open no longer refuses on an
+    existing active mission, and the new mission is a union-inert draft."""
+    open_mission(workspace, "m-one").approve()
+    second = open_mission(workspace, "m-two")
+    check("B5-second-open-succeeds",
+          second.store.load_latest()[0]["status"] == "draft")
+    third = open_mission(workspace, "m-three")
+    check("B10-nth-open-succeeds",
+          third.store.load_latest()[0]["status"] == "draft")
+
+
+def test_b6_single_active_unbound_flow_preserved(workspace: Path) -> None:
+    """Row 6: the single-mission workflow must not grow ceremony."""
+    m = open_mission(workspace, "m-solo")
+    m.approve()
+    loaded = Mission.load(workspace, actor="agent:worker")
+    check("B6-unbound-resolves-to-the-one-active",
+          loaded.store.mission_dir.name == "m-solo")
+
+
+def test_b8_bound_resolves_to_bound(workspace: Path) -> None:
+    open_mission(workspace, "m-solo").approve()
+    loaded = load_bound(workspace, "m-solo")
+    check("B8-bound-same-as-unbound-when-ids-coincide",
+          loaded.store.mission_dir.name == "m-solo")
+
+
+def test_b9_b15_stale_binding_never_falls_through(workspace: Path) -> None:
+    open_mission(workspace, "m-one").approve()
+    try:
+        load_bound(workspace, "m-nonexistent")
+        check("B9-stale-binding-no-fallback-to-the-one-active", False)
+    except Exception as exc:
+        check("B9-stale-binding-no-fallback-to-the-one-active",
+              BindingInvalid is not None and isinstance(exc, BindingInvalid))
+    open_mission(workspace, "m-two")
+    try:
+        load_bound(workspace, "m-nonexistent")
+        check("B15-stale-binding-no-fallback-to-union", False)
+    except Exception as exc:
+        check("B15-stale-binding-no-fallback-to-union",
+              BindingInvalid is not None and isinstance(exc, BindingInvalid))
+
+
+def test_b11_plural_unbound_lifecycle_requires_binding(workspace: Path) -> None:
+    open_mission(workspace, "m-one").approve()
+    open_mission(workspace, "m-two")
+    try:
+        Mission.load(workspace, actor="agent:worker")
+        check("B11-plural-unbound-refuses", False)
+    except Exception as exc:
+        ok = (BindingRequired is not None
+              and isinstance(exc, BindingRequired))
+        check("B11-plural-unbound-refuses", ok)
+        if ok:
+            msg = str(exc)
+            check("B11-refusal-lists-ids",
+                  "m-one" in msg and "m-two" in msg)
+            check("B11-refusal-names-channels",
+                  "--mission" in msg and "ZMS_MISSION_ID" in msg)
+
+
+def test_binding_channels_cli_flag_env_precedence(workspace: Path) -> None:
+    """Section 1: flag > env > unbound, on the CLI surface."""
+    ws = str(workspace)
+    r = run_cli(["open", "--workspace", ws, "--actor", "agent:t",
+                 "--mission-id", "m-a", "--instruction", "i",
+                 "--operator", "operator:t", "--steward", "agent:t"])
+    check("cli-open-a", r.returncode == 0)
+    check("cli-open-prints-binding-line", "ZMS_MISSION_ID=m-a" in
+          (r.stdout + r.stderr))
+    r = run_cli(["open", "--workspace", ws, "--actor", "agent:t",
+                 "--mission-id", "m-b", "--instruction", "i",
+                 "--operator", "operator:t", "--steward", "agent:t"])
+    check("cli-open-b", r.returncode == 0)
+    # unbound with two active: refusal
+    r = run_cli(["note", "--workspace", ws, "--actor", "agent:t",
+                 "--text", "x"])
+    check("cli-plural-unbound-note-refuses", r.returncode == 2)
+    # env binds
+    r = run_cli(["note", "--workspace", ws, "--actor", "agent:t",
+                 "--text", "via-env"], env_extra={"ZMS_MISSION_ID": "m-a"})
+    check("cli-env-binding-works", r.returncode == 0)
+    # flag beats env
+    r = run_cli(["note", "--workspace", ws, "--actor", "agent:t",
+                 "--text", "via-flag", "--mission", "m-b"],
+                env_extra={"ZMS_MISSION_ID": "m-a"})
+    check("cli-flag-beats-env", r.returncode == 0)
+    got_a = json.loads(run_cli(
+        ["status", "--workspace", ws, "--actor", "agent:t",
+         "--mission", "m-a"]).stdout)
+    got_b = json.loads(run_cli(
+        ["status", "--workspace", ws, "--actor", "agent:t",
+         "--mission", "m-b"]).stdout)
+    check("cli-notes-landed-by-binding",
+          "via-env" in got_a["state"]["notes"]
+          and "via-flag" in got_b["state"]["notes"]
+          and "via-flag" not in got_a["state"]["notes"])
+
+
+def test_missions_list_verb(workspace: Path) -> None:
+    """Section 6: plurality needs an enumeration verb."""
+    open_mission(workspace, "m-one").approve()
+    open_mission(workspace, "m-two")
+    r = run_cli(["missions", "--workspace", str(workspace),
+                 "--actor", "agent:t"])
+    check("cli-missions-exit-0", r.returncode == 0)
+    if r.returncode == 0:
+        rows = json.loads(r.stdout)
+        by_id = {row["mission"]: row for row in rows}
+        check("cli-missions-lists-both",
+              set(by_id) >= {"m-one", "m-two"})
+        check("cli-missions-approved-flag",
+              by_id.get("m-one", {}).get("approved") is True
+              and by_id.get("m-two", {}).get("approved") is False)
+        check("cli-missions-carries-status-steward-frontier",
+              all(k in by_id.get("m-one", {})
+                  for k in ("status", "steward_ref", "frontier")))
+
+
+# ---------------------------------------------------------------------------
+# Union guard evaluation (rows 7, 12, 13, 14, 16, 24, 25, 30 + section 9)
+# ---------------------------------------------------------------------------
+
+def test_b7_lone_unapproved_draft_contributes_nothing(workspace: Path) -> None:
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    open_mission(workspace, "m-draft", guard_mode="enforce",
+                 actuator_guards=g)
+    v = run_gate(workspace, {"tool_name": "Write", "command": None,
+                             "file_path": "secrets/x.env"},
+                 actor="hook:test")
+    check("B7-lone-draft-allows", v["decision"] == "allow")
+
+
+def test_b12_union_names_all_matching_pairs(workspace: Path) -> None:
+    """Row 12: a call matching guards in TWO approved missions is blocked
+    naming every (mission, rule) pair -- the operator needs the full bill."""
+    open_mission(workspace, "m-a", guard_mode="enforce",
+                 actuator_guards=[guard("rule-a", ["shared/**"],
+                                        tools=["Write"])]).approve()
+    open_mission(workspace, "m-b", guard_mode="enforce",
+                 actuator_guards=[guard("rule-b", ["shared/**"],
+                                        tools=["Write"])]).approve()
+    v = run_gate(workspace, {"tool_name": "Write", "command": None,
+                             "file_path": "shared/f.txt"},
+                 actor="hook:test")
+    check("B12-union-blocks", v["decision"] == "block")
+    check("B12-names-all-pairs",
+          all(t in v["reason"] for t in ("m-a", "rule-a", "m-b", "rule-b")))
+    for mid in ("m-a", "m-b"):
+        log = workspace / "missions" / mid / "guard-log.jsonl"
+        check(f"B12-guard-log-appended-{mid}", log.exists())
+
+
+def test_b14_b16_binding_never_changes_exposure(workspace: Path) -> None:
+    """Rows 14/16 + the section 9 adversarial exposure test: a session bound
+    to mission A attempting an actuator guarded ONLY by approved sibling B
+    MUST be blocked (OD-1); a bad binding still gets the union."""
+    open_mission(workspace, "m-a").approve()
+    open_mission(workspace, "m-b", guard_mode="enforce",
+                 actuator_guards=[guard("b-only", ["frozen/**"],
+                                        tools=["Write"])]).approve()
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "frozen/f.txt"}
+    v = run_gate(workspace, call, actor="hook:test")
+    check("B14-union-regardless-of-binding", v["decision"] == "block")
+    # CLI: gate bound to m-a is still blocked by m-b's guard
+    r = run_cli(["gate", "--workspace", str(workspace), "--actor", "hook:t",
+                 "--mission", "m-a"], stdin=json.dumps(call))
+    check("B14-cli-bound-gate-still-blocked", r.returncode == 2)
+    # bad binding: union still evaluated, block stands (row 16)
+    r = run_cli(["gate", "--workspace", str(workspace), "--actor", "hook:t",
+                 "--mission", "m-ghost"], stdin=json.dumps(call))
+    check("B16-bad-binding-gate-still-union", r.returncode == 2)
+
+
+def test_b13_effect_union_evaluated_before_write(workspace: Path) -> None:
+    """Row 13 + OD-2: effect IS the file write, union-evaluated BEFORE
+    _write_effect; a block is side-effect-free -- no bytes, no receipt."""
+    open_mission(workspace, "m-guard", guard_mode="enforce",
+                 actuator_guards=[guard("no-frozen", ["frozen/**"],
+                                        tools=["Write"])]).approve()
+    b = open_mission(workspace, "m-writer")
+    b.approve()
+    b = load_bound(workspace, "m-writer")
+    try:
+        b.record_effect("frozen/f.txt", "content", "req-1")
+        check("B13-effect-blocked", False)
+    except CustodyError as exc:
+        check("B13-effect-blocked", not isinstance(exc, IllegalTransition))
+        check("B13-block-names-pair",
+              "m-guard" in str(exc) and "no-frozen" in str(exc))
+    check("B13-no-bytes-written",
+          not (workspace / "frozen" / "f.txt").exists())
+    check("B13-no-receipt-minted",
+          not b.store.receipt_path("req-1").exists())
+    check("B13-request-id-still-fresh",
+          "req-1" not in b.store.load_latest()[0]["receipt_ids"])
+
+
+def test_b13_own_guards_gate_own_effect(workspace: Path) -> None:
+    """Union includes the acting mission itself once approved: complete
+    mediation for actuation has no self-exemption."""
+    m = open_mission(workspace, "m-self", guard_mode="enforce",
+                     actuator_guards=[guard("self-frozen", ["frozen/**"],
+                                            tools=["Write"])])
+    m.approve()
+    try:
+        m.record_effect("frozen/own.txt", "x", "req-1")
+        check("B13-own-guard-gates-own-effect", False)
+    except CustodyError:
+        check("B13-own-guard-gates-own-effect", True)
+
+
+def test_b30_audit_channels_unblockable(workspace: Path) -> None:
+    """Row 30 + OD-2 paired test: the same union guard that blocks effect
+    leaves note, amend, and frontier recorded on the same surface."""
+    open_mission(workspace, "m-guard", guard_mode="enforce",
+                 actuator_guards=[guard("no-frozen", ["frozen/**"],
+                                        tools=["Write"])]).approve()
+    b = open_mission(workspace, "m-writer")
+    b.approve()
+    b = load_bound(workspace, "m-writer")
+    try:
+        b.record_effect("frozen/f.txt", "content", "req-1")
+        check("B30-effect-blocked-for-contrast", False)
+    except CustodyError:
+        check("B30-effect-blocked-for-contrast", True)
+    check("B30-note-recorded", isinstance(
+        b.note("blocked on frozen/f.txt; escalating"), int))
+    check("B30-amend-recorded", isinstance(
+        b.amend_authority("operator: granted frozen/f.txt to m-writer"), int))
+    check("B30-frontier-recorded", isinstance(
+        b.set_frontier("await operator on frozen/"), int))
+
+
+def test_gate_runs_leave_every_chain_byte_identical(workspace: Path) -> None:
+    """Section 9: byte-identity of gate runs under N missions."""
+    open_mission(workspace, "m-a", guard_mode="enforce",
+                 actuator_guards=[guard("rule-a", ["shared/**"],
+                                        tools=["Write"])]).approve()
+    open_mission(workspace, "m-b", guard_mode="audit",
+                 actuator_guards=[guard("rule-b", ["shared/**"],
+                                        tools=["Write"])]).approve()
+    before = {m: chain_bytes(workspace, m) for m in ("m-a", "m-b")}
+    run_gate(workspace, {"tool_name": "Write", "command": None,
+                         "file_path": "shared/f.txt"}, actor="hook:test")
+    after = {m: chain_bytes(workspace, m) for m in ("m-a", "m-b")}
+    check("gate-chains-byte-identical", before == after)
+
+
+# ---------------------------------------------------------------------------
+# Degraded stores (rows 17, 18, 22, 23)
+# ---------------------------------------------------------------------------
+
+def test_b17_open_refuses_unreadable_sibling(workspace: Path) -> None:
+    open_mission(workspace, "m-live").approve()
+    corrupt_dir(workspace, "m-corrupt")
+    with contextlib.redirect_stderr(io.StringIO()):
+        try:
+            open_mission(workspace, "m-new")
+            check("B17-open-refuses-unreadable-sibling", False)
+        except CustodyError:
+            check("B17-open-refuses-unreadable-sibling", True)
+        check("B17-refused-open-left-no-dir",
+              not (workspace / "missions" / "m-new").exists())
+        # acknowledged: open proceeds and records the acknowledgement
+        m = open_mission(workspace, "m-new",
+                         acknowledge_unreadable=["m-corrupt"])
+    notes = m.store.load_latest()[0]["state"]["notes"]
+    check("B17-acknowledgement-recorded-in-opening-checkpoint",
+          any("m-corrupt" in n for n in notes))
+
+
+def test_b22_gate_degraded_union_is_disclosed(workspace: Path) -> None:
+    """Row 22: hook path stays fail-open, but the verdict reason AND stderr
+    must name the skipped sibling and say its guards are NOT enforced."""
+    open_mission(workspace, "m-live").approve()
+    corrupt_dir(workspace, "m-corrupt")
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        v = run_gate(workspace, {"tool_name": "Bash", "command": "ls",
+                                 "file_path": None}, actor="hook:test")
+    check("B22-gate-still-allows", v["decision"] == "allow")
+    check("B22-reason-names-degradation",
+          "m-corrupt" in v["reason"] and "NOT enforced" in v["reason"])
+    check("B22-stderr-names-degradation", "m-corrupt" in buf.getvalue())
+
+
+def test_b23_effect_refuses_union_degraded(workspace: Path) -> None:
+    """Row 23: effect CAN refuse without bricking anything, so it does."""
+    m = open_mission(workspace, "m-live")
+    m.approve()
+    corrupt_dir(workspace, "m-corrupt")
+    with contextlib.redirect_stderr(io.StringIO()):
+        try:
+            m.record_effect("a.txt", "aa", "req-1")
+            check("B23-effect-refuses-degraded", False)
+        except Exception as exc:
+            check("B23-effect-refuses-degraded",
+                  UnionDegraded is not None and isinstance(exc, UnionDegraded)
+                  and "m-corrupt" in str(exc))
+        check("B23-refused-effect-wrote-nothing",
+              not (workspace / "a.txt").exists())
+        # recorded acknowledgement lets work continue, and persists
+        m.record_effect("a.txt", "aa", "req-1",
+                        acknowledge_unreadable=["m-corrupt"])
+        check("B23-acknowledged-effect-proceeds",
+              (workspace / "a.txt").exists())
+        m2 = Mission.load(workspace, actor="agent:worker",
+                          mission_id="m-live")
+        m2.record_effect("b.txt", "bb", "req-2")
+        check("B23-acknowledgement-persists-in-chain",
+              (workspace / "b.txt").exists())
+
+
+def test_b18_open_refuses_epoch_skew_sibling(workspace: Path) -> None:
+    m = open_mission(workspace, "m-old")
+    m.approve()
+    m.begin_verification()
+    acceptor = Mission.load(workspace, actor="agent:acceptor")
+    acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                            assurance_tier="declared-role-separation",
+                            reason="done")
+    # relabel the tail to a future epoch: the store CLAIMS a newer contract
+    tail = sorted((workspace / "missions" / "m-old" / "checkpoints")
+                  .glob("r*.json"))[-1]
+    rec = json.loads(tail.read_text(encoding="utf-8"))
+    rec["record"] = "checkpoint@99"
+    tail.write_text(json.dumps(rec), encoding="utf-8")
+    with contextlib.redirect_stderr(io.StringIO()):
+        try:
+            open_mission(workspace, "m-new")
+            check("B18-open-refuses-epoch-skew", False)
+        except CustodyError:
+            check("B18-open-refuses-epoch-skew", True)
+
+
+# ---------------------------------------------------------------------------
+# Sibling crossings (rows 19, 21, 26, 27, 28, 29 + section 9)
+# ---------------------------------------------------------------------------
+
+def _two_missions_one_artifact(workspace: Path) -> tuple[Mission, Mission]:
+    """A receipts shared.txt; returns (A, B) both approved and bound."""
+    a = open_mission(workspace, "m-alpha")
+    a.approve()
+    a = load_bound(workspace, "m-alpha")
+    a.record_effect("shared.txt", "alpha-1", "req-a1")
+    b = open_mission(workspace, "m-beta", actor="agent:other")
+    b.approve()
+    b = load_bound(workspace, "m-beta", actor="agent:other")
+    return a, b
+
+
+def test_b21_crossing_writes_side_channel_never_the_chain(workspace: Path) -> None:
+    """Row 21 + FATAL-4 + section 9 byte-identity: B's effect on a path A
+    receipted appends one advisory JSONL line to A's sibling-touch.jsonl;
+    A's checkpoint chain stays byte-identical."""
+    a, b = _two_missions_one_artifact(workspace)
+    before = chain_bytes(workspace, "m-alpha")
+    receipt = b.record_effect("shared.txt", "beta-1", "req-b1")
+    check("B21-effect-succeeded", receipt["after_sha256"] is not None)
+    check("B21-sibling-chain-byte-identical",
+          chain_bytes(workspace, "m-alpha") == before)
+    side = workspace / "missions" / "m-alpha" / "sibling-touch.jsonl"
+    check("B21-side-channel-written", side.exists())
+    if side.exists():
+        entry = json.loads(side.read_text(encoding="utf-8").splitlines()[-1])
+        check("B21-entry-fields",
+              entry.get("from_mission") == "m-beta"
+              and entry.get("receipt_id") == "req-b1"
+              and entry.get("artifact_path") == "shared.txt"
+              and set(entry) >= {"utc", "actor", "session_id",
+                                 "after_sha256"})
+
+
+def test_b26_never_approved_sibling_never_launders(workspace: Path) -> None:
+    """Row 26 + the FATAL-3 laundering test, never-approved leg: an
+    adversary opens a throwaway sibling, effects the tampered bytes, and A's
+    resume must report plain drift -- no DRIFT-SIBLING."""
+    a, _ = _two_missions_one_artifact(workspace)
+    evil = open_mission(workspace, "m-evil", actor="agent:evil")
+    evil = load_bound(workspace, "m-evil", actor="agent:evil")
+    evil.record_effect("shared.txt", "tampered", "req-e1")  # legal in draft
+    a = load_bound(workspace, "m-alpha")
+    findings = a.resume()
+    check("B26-plain-drift-not-sibling",
+          findings == ["shared.txt"])
+    latest = a.store.load_latest()[0]
+    check("B26-reconciliation-marker",
+          "RECONCILIATION:shared.txt" in latest["state"]["unresolved_verdicts"])
+    check("B26-evidence-reported",
+          any("m-evil" in n and "req-e1" in n
+              for n in latest["state"]["notes"]))
+
+
+def test_b27_no_authorization_amendment_no_downgrade(workspace: Path) -> None:
+    """Row 27: hash match + approved sibling, but no cross-mission
+    authorization amendment in A's own chain -> plain drift + evidence."""
+    a, b = _two_missions_one_artifact(workspace)
+    b.record_effect("shared.txt", "beta-1", "req-b1")
+    a = load_bound(workspace, "m-alpha")
+    findings = a.resume()
+    check("B27-plain-drift-not-sibling", findings == ["shared.txt"])
+    latest = a.store.load_latest()[0]
+    check("B27-evidence-reported",
+          any("m-beta" in n and "req-b1" in n
+              for n in latest["state"]["notes"]))
+
+
+def test_b28_all_three_legs_yield_drift_sibling(workspace: Path) -> None:
+    """Row 28: hash match + approved sibling + authorization amendment in
+    A's chain -> DRIFT-SIBLING, reconciled by acknowledgement with the
+    machine note, written by A's own bound session."""
+    a, b = _two_missions_one_artifact(workspace)
+    a.amend_authority("operator: mission m-beta is authorized to write "
+                      "shared.txt during the overlap")
+    b.record_effect("shared.txt", "beta-1", "req-b1")
+    a = load_bound(workspace, "m-alpha")
+    findings = a.resume()
+    check("B28-drift-sibling-classified",
+          findings == ["DRIFT-SIBLING:shared.txt"])
+    latest = a.store.load_latest()[0]
+    check("B28-marker-raised",
+          "DRIFT-SIBLING:shared.txt" in latest["state"]["unresolved_verdicts"])
+    check("B28-note-names-mission-and-receipt",
+          any("m-beta" in n and "req-b1" in n
+              for n in latest["state"]["notes"]))
+    rev = a.acknowledge_sibling("shared.txt")
+    check("B28-acknowledge-returns-revision", isinstance(rev, int))
+    latest = a.store.load_latest()[0]
+    check("B28-marker-cleared",
+          latest["state"]["unresolved_verdicts"] == [])
+    check("B28-machine-note-written",
+          any(n.startswith("sibling-touched: shared.txt by m-beta receipt "
+                           "req-b1") for n in latest["state"]["notes"]))
+    check("B28-mission-back-to-active", latest["status"] == "active")
+
+
+def test_scan_covers_non_active_siblings(workspace: Path) -> None:
+    """The verification-report correction: a sibling that COMPLETED between
+    its write and A's resume still explains the drift -- the scan ranges
+    over all readable sibling stores, not only active ones."""
+    a, b = _two_missions_one_artifact(workspace)
+    a.amend_authority("operator: mission m-beta is authorized to write "
+                      "shared.txt during the overlap")
+    b.record_effect("shared.txt", "beta-1", "req-b1")
+    b.begin_verification()
+    acceptor = load_bound(workspace, "m-beta", actor="agent:acceptor")
+    acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                            assurance_tier="declared-role-separation",
+                            reason="beta done")
+    a = load_bound(workspace, "m-alpha")
+    findings = a.resume()
+    check("scan-completed-sibling-still-attributes",
+          findings == ["DRIFT-SIBLING:shared.txt"])
+
+
+def test_b29_sibling_touched_prefix_forgery_refused(workspace: Path) -> None:
+    """Row 29 + section 9 forgery test: every documented bypass shape, on
+    every caller-text surface."""
+    m = open_mission(workspace, "m-forge")
+    m.approve()
+    forged = "sibling-touched: shared.txt by m-evil receipt req-x"
+    shapes = {
+        "plain": forged,
+        "leading-space": " " + forged,
+        "capital": "Sibling-touched: shared.txt by m-evil receipt req-x",
+        "leading-newline": "\n" + forged,
+        "second-line": "ordinary narrative\n" + forged,
+        "cf-smuggled": "sibling​-touched: shared.txt by m-evil "
+                       "receipt req-x",
+    }
+    for shape, text in shapes.items():
+        try:
+            m.note(text)
+            check(f"B29-note-refuses-{shape}", False)
+        except CustodyError:
+            check(f"B29-note-refuses-{shape}", True)
+    try:
+        m.amend_authority(forged)
+        check("B29-amend-refuses", False)
+    except CustodyError:
+        check("B29-amend-refuses", True)
+    try:
+        m.set_frontier(forged)
+        check("B29-frontier-refuses", False)
+    except CustodyError:
+        check("B29-frontier-refuses", True)
+    try:
+        m.cancel(forged)
+        check("B29-cancel-refuses", False)
+    except CustodyError:
+        check("B29-cancel-refuses", True)
+    m.begin_verification()
+    acceptor = Mission.load(workspace, actor="agent:acceptor")
+    try:
+        acceptor.record_verdict("PASS", acceptor_id="agent:acceptor",
+                                assurance_tier="declared-role-separation",
+                                reason=forged)
+        check("B29-verdict-reason-refuses", False)
+    except CustodyError:
+        check("B29-verdict-reason-refuses", True)
+
+
+# ---------------------------------------------------------------------------
+# Record closure, disclosure, migration-adjacent invariants
+# ---------------------------------------------------------------------------
+
+def test_receipt_at_1_closure_regression(workspace: Path) -> None:
+    """Section 9: the implementation never attempts a receipt field outside
+    RECEIPT_FIELDS; a receipt minted before the change round-trips."""
+    a, b = _two_missions_one_artifact(workspace)
+    receipt_path = a.store.receipt_path("req-a1")
+    before = receipt_path.read_bytes()
+    b.record_effect("shared.txt", "beta-1", "req-b1")  # the crossing write
+    check("receipt-closure-sibling-receipt-untouched",
+          receipt_path.read_bytes() == before)
+    crossing = json.loads(
+        b.store.receipt_path("req-b1").read_text(encoding="utf-8"))
+    check("receipt-closure-crossing-receipt-validates",
+          validate_record(crossing) == [])
+    check("receipt-closure-no-new-fields",
+          set(crossing) == {"record", "mission_id", "request_id", "actor",
+                            "utc", "artifact_path", "before_sha256",
+                            "after_sha256"})
+
+
+def test_scope_overlap_disclosure_deterministic(workspace: Path) -> None:
+    """Section 3 + section 9: overlapping scope.in patterns are disclosed
+    and recorded at open, deterministically; prose is incomparable."""
+    def build(ws: Path) -> list[str]:
+        open_mission(ws, "m-one", scope_in=["docs/**", "media acquisition"])\
+            .approve()
+        m = open_mission(ws, "m-two", scope_in=["docs/plans/*.md"])
+        return [n for n in m.store.load_latest()[0]["state"]["notes"]
+                if "overlap" in n or "incomparable" in n]
+    ws1 = workspace / "w1"
+    ws2 = workspace / "w2"
+    notes1 = build(ws1)
+    notes2 = build(ws2)
+    check("overlap-disclosed", any("m-one" in n and "docs/**" in n
+                                   for n in notes1))
+    check("overlap-deterministic", notes1 == notes2)
+    ws3 = workspace / "w3"
+    open_mission(ws3, "m-one", scope_in=["src/**"]).approve()
+    m = open_mission(ws3, "m-disjoint", scope_in=["docs/**"])
+    check("no-false-overlap",
+          not any("overlap" in n
+                  for n in m.store.load_latest()[0]["state"]["notes"]))
+
+
+def test_open_still_refuses_duplicate_mission_id(workspace: Path) -> None:
+    open_mission(workspace, "m-dup")
+    try:
+        open_mission(workspace, "m-dup")
+        check("open-refuses-duplicate-id", False)
+    except (CustodyError, Exception):
+        check("open-refuses-duplicate-id", True)
+    # exactly one r1 checkpoint exists
+    cps = sorted((workspace / "missions" / "m-dup" / "checkpoints")
+                 .glob("r*.json"))
+    check("duplicate-open-wrote-nothing", len(cps) == 1)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+TESTS = [
+    test_a1_a3_draft_vs_active_union_membership,
+    test_a2_reopened_never_approved_contributes_nothing,
+    test_a4_reopened_approved_lineage_stays_armed,
+    test_a5_verifying_guards_keep_binding_effect_illegal,
+    test_a6_a7_terminal_states_binding_invalid,
+    test_a8_unreadable_dir_binding_invalid,
+    test_b4_binding_with_nothing_active,
+    test_b1_b2_zero_active_unchanged,
+    test_b5_b10_open_beside_active_is_legal,
+    test_b6_single_active_unbound_flow_preserved,
+    test_b8_bound_resolves_to_bound,
+    test_b9_b15_stale_binding_never_falls_through,
+    test_b11_plural_unbound_lifecycle_requires_binding,
+    test_binding_channels_cli_flag_env_precedence,
+    test_missions_list_verb,
+    test_b7_lone_unapproved_draft_contributes_nothing,
+    test_b12_union_names_all_matching_pairs,
+    test_b14_b16_binding_never_changes_exposure,
+    test_b13_effect_union_evaluated_before_write,
+    test_b13_own_guards_gate_own_effect,
+    test_b30_audit_channels_unblockable,
+    test_gate_runs_leave_every_chain_byte_identical,
+    test_b17_open_refuses_unreadable_sibling,
+    test_b22_gate_degraded_union_is_disclosed,
+    test_b23_effect_refuses_union_degraded,
+    test_b18_open_refuses_epoch_skew_sibling,
+    test_b21_crossing_writes_side_channel_never_the_chain,
+    test_b26_never_approved_sibling_never_launders,
+    test_b27_no_authorization_amendment_no_downgrade,
+    test_b28_all_three_legs_yield_drift_sibling,
+    test_scan_covers_non_active_siblings,
+    test_b29_sibling_touched_prefix_forgery_refused,
+    test_receipt_at_1_closure_regression,
+    test_scope_overlap_disclosure_deterministic,
+    test_open_still_refuses_duplicate_mission_id,
+]
+
+
+def _check_registry_is_complete() -> None:
+    registered = {fn.__name__ for fn in TESTS}
+    defined = {name for name, value in globals().items()
+               if name.startswith("test_") and callable(value)}
+    orphans = sorted(defined - registered)
+    if orphans:
+        FAILURES.append("unregistered")
+        print(f"FAIL registry-complete: defined but never run: {orphans}")
+
+
+def _run(fn) -> None:
+    before = len(FAILURES)
+    err: Exception | None = None
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            fn(Path(td))
+    except Exception as exc:  # noqa: BLE001
+        err = exc
+    failed = len(FAILURES) > before or err is not None
+    if fn.__name__ in XFAIL:
+        # Expected to fail until the implementing commit lands. The recorded
+        # failures are rolled back; an unexpected PASS is itself a failure,
+        # because a green row that is still listed here pins nothing.
+        del FAILURES[before:]
+        if failed:
+            suffix = f" [{type(err).__name__}]" if err else ""
+            print(f"xfail (unimplemented) {fn.__name__}{suffix}")
+        else:
+            FAILURES.append(f"XPASS:{fn.__name__}")
+            print(f"FAIL XPASS {fn.__name__}: passed while marked "
+                  "expectedFailure -- remove it from XFAIL")
+    elif err is not None:
+        FAILURES.append(f"ERROR:{fn.__name__}")
+        print(f"FAIL {fn.__name__}: {type(err).__name__}: {err}")
+
+
+def main() -> int:
+    _check_registry_is_complete()
+    for fn in TESTS:
+        _run(fn)
+    print(f"\n{len(FAILURES)} failures")
+    return 1 if FAILURES else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -52,16 +52,9 @@ FAILURES: list[str] = []
 # Rows not yet implemented. Every name here must FAIL when run; the
 # implementing commits shrink this set to empty.
 XFAIL: set[str] = {
-    "test_a1_a3_draft_vs_active_union_membership",
-    "test_a2_reopened_never_approved_contributes_nothing",
-    "test_b7_lone_unapproved_draft_contributes_nothing",
-    "test_b12_union_names_all_matching_pairs",
-    "test_b14_b16_binding_never_changes_exposure",
     "test_b13_effect_union_evaluated_before_write",
     "test_b13_own_guards_gate_own_effect",
     "test_b30_audit_channels_unblockable",
-    "test_gate_runs_leave_every_chain_byte_identical",
-    "test_b22_gate_degraded_union_is_disclosed",
     "test_b23_effect_refuses_union_degraded",
     "test_b21_crossing_writes_side_channel_never_the_chain",
     "test_b26_never_approved_sibling_never_launders",

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -52,11 +52,6 @@ FAILURES: list[str] = []
 # Rows not yet implemented. Every name here must FAIL when run; the
 # implementing commits shrink this set to empty.
 XFAIL: set[str] = {
-    "test_b13_effect_union_evaluated_before_write",
-    "test_b13_own_guards_gate_own_effect",
-    "test_b30_audit_channels_unblockable",
-    "test_b23_effect_refuses_union_degraded",
-    "test_b21_crossing_writes_side_channel_never_the_chain",
     "test_b26_never_approved_sibling_never_launders",
     "test_b27_no_authorization_amendment_no_downgrade",
     "test_b28_all_three_legs_yield_drift_sibling",

--- a/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_es173_cases.py
@@ -993,6 +993,83 @@ def test_refuter_f4_blocked_effect_writes_nothing(workspace: Path) -> None:
           not receipts.exists() or not list(receipts.glob("*.json")))
 
 
+def test_refuter_f5_draft_self_arms_own_session(workspace: Path) -> None:
+    """Finding 5 (operator ruling 2026-08-25: "Self-arm at open, union at
+    approve"): a mission's armed guards bind its OWN session -- calls
+    bound to it, and its own effect verb -- from the moment open arms
+    them, exactly as the pre-union core behaved. The defect this row
+    pins: on the unrefined branch a draft's guards bound NOBODY until
+    approve, a silent disarm of the shipped core's behaviour."""
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    open_mission(workspace, "m-draft", guard_mode="enforce",
+                 actuator_guards=g)
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "secrets/x.env"}
+    v = run_gate(workspace, call, actor="hook:test",
+                 bound_mission="m-draft")
+    check("F5-own-bound-gate-blocked-pre-approve", v["decision"] == "block")
+    check("F5-block-names-own-pair",
+          "m-draft" in v.get("reason", "")
+          and "no-secrets" in v.get("reason", ""))
+    r = run_cli(["gate", "--workspace", str(workspace), "--actor", "hook:t",
+                 "--mission", "m-draft"], stdin=json.dumps(call))
+    check("F5-cli-bound-gate-blocked-pre-approve", r.returncode == 2)
+    m = load_bound(workspace, "m-draft")
+    try:
+        m.record_effect("secrets/own.env", "x", "req-1")
+        check("F5-own-effect-blocked-pre-approve", False)
+    except CustodyError as exc:
+        check("F5-own-effect-blocked-pre-approve",
+              not isinstance(exc, IllegalTransition)
+              and "no-secrets" in str(exc))
+
+
+def test_refuter_f5_draft_guards_invisible_elsewhere(workspace: Path) -> None:
+    """Finding 5 counterweight (the adjudication's preserved intent): an
+    unblessed draft cannot block OTHER sessions. Its guards stay out of
+    the fleet union for unbound calls, for calls bound to OTHER missions,
+    and for sibling effects, until approve."""
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    open_mission(workspace, "m-draft", guard_mode="enforce",
+                 actuator_guards=g)
+    open_mission(workspace, "m-other", actor="agent:other").approve()
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "secrets/x.env"}
+    v = run_gate(workspace, call, actor="hook:test")
+    check("F5-unbound-gate-unaffected", v["decision"] == "allow")
+    v = run_gate(workspace, call, actor="hook:test",
+                 bound_mission="m-other")
+    check("F5-other-bound-gate-unaffected", v["decision"] == "allow")
+    other = load_bound(workspace, "m-other", actor="agent:other")
+    receipt = other.record_effect("secrets/x.env", "s", "req-o1")
+    check("F5-sibling-effect-unaffected",
+          receipt["after_sha256"] is not None)
+
+
+def test_refuter_f5_post_approve_union_unchanged(workspace: Path) -> None:
+    """Finding 5 leg (c): approval still arms the fleet union exactly as
+    before the refinement -- unbound calls, other-bound calls, and
+    sibling effects are all blocked post-approve."""
+    g = [guard("no-secrets", ["secrets/**"], tools=["Write"])]
+    open_mission(workspace, "m-draft", guard_mode="enforce",
+                 actuator_guards=g)
+    open_mission(workspace, "m-other", actor="agent:other").approve()
+    load_bound(workspace, "m-draft").approve()
+    call = {"tool_name": "Write", "command": None,
+            "file_path": "secrets/x.env"}
+    v = run_gate(workspace, call, actor="hook:test")
+    check("F5-post-approve-unbound-blocked", v["decision"] == "block")
+    v = run_gate(workspace, call, actor="hook:test",
+                 bound_mission="m-other")
+    check("F5-post-approve-other-bound-blocked", v["decision"] == "block")
+    other = load_bound(workspace, "m-other", actor="agent:other")
+    try:
+        other.record_effect("secrets/x.env", "s", "req-o1")
+        check("F5-post-approve-sibling-effect-blocked", False)
+    except CustodyError:
+        check("F5-post-approve-sibling-effect-blocked", True)
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -1037,6 +1114,9 @@ TESTS = [
     test_refuter_f2_stale_sibling_marker_discharges,
     test_refuter_f3_bound_load_validates_mission_id,
     test_refuter_f4_blocked_effect_writes_nothing,
+    test_refuter_f5_draft_self_arms_own_session,
+    test_refuter_f5_draft_guards_invisible_elsewhere,
+    test_refuter_f5_post_approve_union_unchanged,
 ]
 
 

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -230,9 +230,13 @@ def epoch_skew_anywhere(record, expected_family: str) -> str | None:
     return None
 
 
-_ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
-_SHA_RE = re.compile(r"^[0-9a-f]{64}$")
-_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+# \Z, never $: re's $ also matches just before a trailing newline, so
+# "m-x\n" passed as a kebab-case id (fix-refuter F-D, measured). No legal
+# value of any of these carries a newline; the same one-character mechanism
+# is closed for all three rather than only the instance it was caught on.
+_ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
+_SHA_RE = re.compile(r"^[0-9a-f]{64}\Z")
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*\Z")
 
 MANIFEST_FIELDS = {
     "record", "mission_id", "created_utc", "authority", "scope",


### PR DESCRIPTION
Implements the adjudicated es#173 concurrent-missions design in the mission-custody core.

**Design (authoritative):** `docs/design/2026-08-25-es173-concurrent-missions-design.md` @ `53d1607` (branch `feat/es173-concurrent-missions`), as adjudicated on #173 (2026-08-15 model ruling, gauntlet CONDITIONAL, 2026-08-24 four-OD adjudication), with the post-revision verification reports honored — including the OD-3 correction: the resume-time sibling receipt scan ranges over **all readable sibling stores**, not only active ones (the adjudication's "resume-time scan of sibling receipt stores" carries no active-only narrowing).

## Commit → design section map

| Commit | Design section | What it implements |
|---|---|---|
| c87dc16 | §7 Tables A/B + §9 test obligations | The case tables as an executable spec (`test_es173_cases.py`): every row a test, unimplemented rows in an XFAIL set that MUST fail until implemented (an XFAIL row that passes is itself a failure). The set burned down to empty by the final commit. |
| d203bc4 | §1 (binding), §3 (strict no-fallback validation), §6 (open door) | Plurality legalized: `MultipleActiveMissions` removed at its trigger; unbound lifecycle verbs over N>1 active missions refuse `BindingRequired` naming every id and both binding channels (`ZMS_MISSION_ID` env / `--mission` flag); bound loads resolve; `open` beside an active mission is legal, duplicate id still refused with no partial dir. |
| a1fa6dd | §2 (union-always), OD-1 + OD-4 | Every gate-routed call is evaluated against the **union** of all approved missions' armed guards, bound or not — binding routes authority, never guard exposure (OD-1). Union membership is **approve-gated**: a draft/unapproved mission arms nothing but is still subject to the union (OD-4). Blocks name every matching (mission, rule) pair; guard-log lands in each matching mission's dir. The inert-on-plurality fail-open (the decoy disarm) is deleted. |
| 90d0994 | §2(b), OD-2; rows 13, 21, 23, 30 | The effect verb runs union evaluation **before** `_write_effect`; a blocked effect refuses side-effect-free, naming every matching (mission_id, rule) pair. `note`/`amend`/`frontier` stay ungated by design (unblockable audit/discharge channels). |
| 1aab6b1 | §4, OD-3 (as corrected); rows 19, 26–29 | DRIFT-SIBLING: resume-time scan of sibling receipt@1 stores (any status, zero schema change) + the FATAL-3 three-leg discriminator (hash match ∧ sibling approved **by the chain test** ∧ explicit cross-mission authorization amendment in the resuming mission's own chain — any leg missing ⇒ plain drift at today's severity; the discriminator gates the severity downgrade, never the information). Sibling crossings are advisory records to `sibling-touch.jsonl` (guard-log analog, append-only, never the sibling chain). `sibling-touched: ` registered as a reserved machine-note prefix with the forgery test covering every documented bypass shape. |
| 9d41038 | §9 (CI obligation) | `test_es173_cases.py` wired into `.github/workflows/mission-custody-contract.yml`. |

## Test evidence

- Baseline (origin/main @ c539613, clean worktree): **955 pass / 0 fail** across the 7 existing suites.
- This branch: **1059 pass / 0 fail** across 8 suites (`+100` es173 spec, `+2` custody_mission, `+2` custody_gate).
- No existing test weakened. The three modified suites invert only the behaviors the design orders deleted (the old tests pinned the inert-on-plurality fail-open / `MultipleActiveMissions` refusal); each replacement asserts strictly stronger behavior (block instead of allow, both missions named, guard-log written in both).

**Do not merge without operator review** — ES main has no branch protection; the merge gate is the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5d5R7sBuCu95baxhvLnoY
