### PR TITLE
fix(contracts): closed-vocabulary membership must answer, never raise

### DIFF
--- a/plugins/epistemic-skills/contracts/epistemic-product-calibration.schema.json
+++ b/plugins/epistemic-skills/contracts/epistemic-product-calibration.schema.json
@@ -240,5 +240,30 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "$comment": "A superseded record must name what superseded it. The bundled stdlib verifier already refuses this with MISSING_SUPERSESSION; the published schema did not, so a producer validating against the schema as instructed got a false PASS and the consumer rejected the same envelope. Two definitions of valid is one definition too many.",
+      "if": {
+        "properties": {
+          "status": {
+            "const": "superseded"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "supersedes"
+        ],
+        "properties": {
+          "supersedes": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/plugins/epistemic-skills/contracts/examples/calibration/invalid-unhashable-status.json
+++ b/plugins/epistemic-skills/contracts/examples/calibration/invalid-unhashable-status.json
@@ -1,0 +1,62 @@
+{
+  "protocol": "epistemic-product-calibration@1",
+  "synthetic": true,
+  "producer": {
+    "repo": "ZMS-Labs/epistemic-calibration",
+    "revision": "1111111111111111111111111111111111111111"
+  },
+  "subject": {
+    "repo": "ZMS-Labs/epistemic-skills",
+    "revision": "3333333333333333333333333333333333333333",
+    "version": "3.0.0",
+    "skill_or_surface": "evidence-locked-uat"
+  },
+  "contract_revision": "uat-seeded-defect@1",
+  "corpus": {
+    "ref": "corpora/uat-seeded-defects",
+    "revision": "4444444444444444444444444444444444444444",
+    "sha256": "5555555555555555555555555555555555555555555555555555555555555555"
+  },
+  "runner": {
+    "ref": "runners/uat-calibration",
+    "revision": "6666666666666666666666666666666666666666",
+    "sha256": "7777777777777777777777777777777777777777777777777777777777777777"
+  },
+  "execution": {
+    "models": [
+      "synthetic-model@1"
+    ],
+    "harnesses": [
+      "synthetic-harness@1"
+    ],
+    "started_at": "2026-07-29T00:00:00Z",
+    "completed_at": "2026-07-29T00:05:00Z"
+  },
+  "sampling_frame": {
+    "population": "Synthetic planted-defect and clean-control cases.",
+    "planned": 4,
+    "observed": 3,
+    "excluded": 0,
+    "missing": 1
+  },
+  "preregistration": {
+    "ref": "plans/uat-pilot.json",
+    "revision": "8888888888888888888888888888888888888888",
+    "sha256": "9999999999999999999999999999999999999999999999999999999999999999"
+  },
+  "result": {
+    "ref": "results/uat-pilot.json",
+    "revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "status": [],
+  "supersedes": null,
+  "limitations": [
+    "Synthetic fixture only; does not establish real-user or cross-provider behavior."
+  ],
+  "never_attests": [
+    "behavioral-merit-by-envelope",
+    "statistical-validity-by-envelope",
+    "release-readiness-by-envelope"
+  ]
+}

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -1272,13 +1272,23 @@ class Mission:
                     continue
                 try:
                     latest, _ = store.load_latest()
-                except (StoreError, ValueError) as exc:
+                except (StoreError, ValueError, TypeError) as exc:
                     # A CORRUPT sibling must not brick discovery of a healthy
                     # mission -- but the skip is loud, and if nothing loads the
                     # skip reasons ride the NoActiveMission error. Environmental
                     # OSErrors (transient locks, permissions) propagate instead:
                     # skipping those would reroute discovery around a mission
                     # that is merely busy, inviting a duplicate open.
+                    #
+                    # TypeError joins the CORRUPT list, not the environmental
+                    # one: it is what a type-invalid record produced when a
+                    # closed vocabulary was tested with `in` (`"status": []`).
+                    # The verifier now answers instead of raising, so this arm
+                    # is belt-and-braces -- kept because a validator reached
+                    # through a hostile file has no business deciding whether
+                    # the WHOLE WORKSPACE can be read, and the next
+                    # type-unsafe expression added there would otherwise
+                    # reopen a workspace-wide denial of service.
                     reason = f"{mission_dir.name}: {type(exc).__name__}: {exc}"
                     skipped.append({"name": mission_dir.name,
                                     "kind": type(exc).__name__,

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_store.py
@@ -149,6 +149,14 @@ class MissionStore:
             return False
         try:
             successor = json.loads(paths[index + 1].read_text(encoding="utf-8"))
+            # A successor that is valid JSON and NOT AN OBJECT proves nothing
+            # and must not crash the diagnosis: `[]` made `.get` raise
+            # AttributeError, which this handler does not catch, so
+            # `load_latest` leaked a raw exception instead of the
+            # ChainBroken/EpochSkew verdict -- taking the census and the gate
+            # down with it. Read defensively means read defensively.
+            if not isinstance(successor, dict):
+                return False
             recorded = successor.get("prev_checkpoint_sha256")
             if not isinstance(recorded, str):
                 return False

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -4924,6 +4924,74 @@ def test_census_does_not_count_unapproved_guards_as_armed(
     check("census-does-not-count-the-unapproved-draft-as-enforcing",
           summary["q3_enforce_mode"] == 0)
 
+def test_typeinvalid_sibling_is_skipped_not_fatal(workspace: Path) -> None:
+    """A sibling checkpoint that is JSON-valid but TYPE-invalid must be a
+    SKIPPED corrupt sibling, not a workspace-wide denial of service.
+
+    `_discover` catches (StoreError, ValueError) and lets everything else
+    propagate, on the reasoning that environmental OSErrors should not reroute
+    discovery. But `validate_checkpoint` reaches `rec["status"] in STATES`,
+    and a list status raises TypeError from set membership -- neither a
+    StoreError nor a ValueError. Measured before the fix: dropping a sibling
+    whose checkpoint carries `"status": []` made EVERY pathless lifecycle
+    command in the workspace raise `TypeError: unhashable type: 'list'`, from
+    a string in a file that no healthy mission references."""
+    m = open_mission(workspace, "m-good", "Do the thing.")
+    m.approve()
+    good = json.loads(
+        (workspace / "missions" / "m-good" / "checkpoints"
+         / "r00000001.json").read_text(encoding="utf-8"))
+    bad_dir = workspace / "missions" / "m-typebad" / "checkpoints"
+    bad_dir.mkdir(parents=True)
+    good["mission_id"] = "m-typebad"
+    good["status"] = []
+    (bad_dir / "r00000001.json").write_text(json.dumps(good), encoding="utf-8")
+    try:
+        loaded = Mission.load(workspace, actor="agent:worker")
+    except TypeError:
+        check("typeinvalid-sibling-no-typeerror", False)
+        return
+    except Exception as exc:  # noqa: BLE001
+        check("typeinvalid-sibling-no-typeerror", True)
+        check("typeinvalid-sibling-loads-the-healthy-one",
+              False)
+        print(f"     (raised {type(exc).__name__}: {exc})")
+        return
+    check("typeinvalid-sibling-no-typeerror", True)
+    check("typeinvalid-sibling-loads-the-healthy-one",
+          loaded.store.mission_dir.name == "m-good")
+
+
+def test_malformed_successor_does_not_crash_chain_load(workspace: Path) -> None:
+    """`_successor_proves_alteration` reads the NEXT checkpoint defensively,
+    but `successor.get(...)` assumes a dict. A successor that is valid JSON
+    and not an object (`[]`) raises AttributeError, which its
+    `except (OSError, ValueError)` does not catch -- so `load_latest` leaks a
+    raw exception instead of the ChainBroken/EpochSkew diagnosis, taking the
+    census and the gate down with it."""
+    m = open_mission(workspace, "m-succ", "Do the thing.")
+    m.approve()
+    m = Mission.load(workspace, actor="agent:worker")
+    m.note("second")
+    cps = sorted((workspace / "missions" / "m-succ" / "checkpoints").glob("*.json"))
+    check("successor-fixture-has-three", len(cps) == 3)
+    # Make the INTERIOR checkpoint fail validation, and the successor a
+    # non-object: the epoch/alteration arbitration must still answer.
+    rec = json.loads(cps[1].read_text(encoding="utf-8"))
+    rec["record"] = "checkpoint@2"
+    cps[1].write_text(json.dumps(rec), encoding="utf-8")
+    cps[2].write_text("[]", encoding="utf-8")
+    try:
+        MissionStore(workspace / "missions" / "m-succ").load_latest()
+    except StoreError:
+        check("malformed-successor-is-storeerror", True)
+    except Exception as exc:  # noqa: BLE001
+        check("malformed-successor-is-storeerror", False)
+        print(f"     (raised {type(exc).__name__}: {exc})")
+    else:
+        check("malformed-successor-is-storeerror", False)
+
+
 TESTS = [
     test_scope_entry_classification_table,
     test_uncompared_scope_entries_are_reported,
@@ -4933,6 +5001,8 @@ TESTS = [
     test_mixed_prose_and_path_scope_in_does_not_flag_everything,
     test_scope_ack_is_the_only_discharge,
     test_every_violating_representation_must_be_acknowledged,
+    test_typeinvalid_sibling_is_skipped_not_fatal,
+    test_malformed_successor_does_not_crash_chain_load,
     test_scope_ack_is_normalised_like_the_findings,
     test_scope_ack_note_cannot_be_forged_by_narrative,
     test_reserved_note_refusal_names_a_working_discharge,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
@@ -253,6 +253,57 @@ def test_unhashable_guard_mode_returns_validation_error() -> None:
     check("guard-unknown-tools-pass", validate_record(rec) == [])
 
 
+def test_closed_vocabularies_never_raise_typeerror() -> None:
+    """Every CLOSED vocabulary must answer a non-string with a validation
+    ERROR, not a TypeError.
+
+    es#137 P2 fixed exactly one of these -- `guard_mode` -- and the class was
+    scoped to that instance. The same `value in SET` shape sits on
+    `checkpoint.status`, `verdict.verdict`, `verdict.assurance_tier`,
+    `manifest.acceptance.required_tier`, and the top-level `record` kind, and
+    every one of them raises `TypeError: unhashable type` on a list or dict.
+    Measured before the fix: `validate_record({... "status": []})` raised
+    TypeError, and a sibling checkpoint carrying `"status": []` took EVERY
+    pathless custody command in the workspace down with it (see
+    test_custody_mission.test_typeinvalid_sibling_is_skipped_not_fatal).
+
+    `validate_record` promises a list of errors. A promise that becomes a
+    traceback on hostile input is a denial of service through the recovery
+    path -- exactly what drift detection exists to survive."""
+    cases = []
+
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    rec["status"] = []
+    cases.append(("checkpoint-status", rec))
+
+    rec = copy.deepcopy(valid_checkpoint_r1())
+    rec["manifest"]["acceptance"]["required_tier"] = {}
+    cases.append(("manifest-required-tier", rec))
+
+    rec = copy.deepcopy(valid_manifest())
+    rec["acceptance"]["required_tier"] = []
+    cases.append(("manifest-required-tier-standalone", rec))
+
+    rec = load("valid-verdict-pass-separated.json")
+    rec["verdict"] = []
+    cases.append(("verdict-verdict", rec))
+
+    rec = load("valid-verdict-pass-separated.json")
+    rec["assurance_tier"] = {"a": 1}
+    cases.append(("verdict-assurance-tier", rec))
+
+    cases.append(("record-kind", {"record": ["checkpoint@1"]}))
+
+    for name, record in cases:
+        try:
+            errors = validate_record(record)
+        except TypeError:
+            check(f"closed-vocab-no-typeerror-{name}", False)
+            continue
+        check(f"closed-vocab-no-typeerror-{name}", True)
+        check(f"closed-vocab-returns-errors-{name}", errors != [])
+
+
 def test_examples_corpus() -> None:
     ex = ROOT / "examples"
     for path in sorted(ex.glob("valid-*.json")):
@@ -289,6 +340,7 @@ def main() -> int:
     test_manifest_guard_empty_guards_list_invalid()
     test_manifest_guard_inert_shapes_rejected()
     test_unhashable_guard_mode_returns_validation_error()
+    test_closed_vocabularies_never_raise_typeerror()
     test_examples_corpus()
     print(f"\n{len(FAILURES)} failures")
     return 1 if FAILURES else 0

--- a/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/verify_mission_custody.py
@@ -209,7 +209,7 @@ def epoch_skew_anywhere(record, expected_family: str) -> str | None:
     # corruption, per validate_record) be reported as EpochSkew, which is the
     # decoy suppression again one level up. A newer outer kind never reaches
     # this line: epoch_skew(record) above already returned for it.
-    if kind not in RECORD_KINDS:
+    if not _in_vocab(kind, RECORD_KINDS):
         return None
     family, _, _ = kind.rpartition("@")
     # ... AND IT MUST BE THE FAMILY THIS SLOT HOLDS. A whole checkpoint@1
@@ -282,6 +282,27 @@ def is_sha256(value: Any) -> bool:
     return isinstance(value, str) and bool(_SHA_RE.match(value))
 
 
+def _in_vocab(value: Any, vocabulary: set) -> bool:
+    """Closed-vocabulary membership that ANSWERS instead of raising.
+
+    `value in SET` is a TypeError the moment `value` is unhashable, and every
+    one of these vocabularies is read straight out of an untrusted JSON file.
+    es#137 P2 fixed exactly one instance (`guard_mode`) with an inline
+    `isinstance` and left the mechanism scoped to it; `status`, `verdict`,
+    `assurance_tier`, `required_tier` and the top-level `record` kind all kept
+    the raising shape, and a sibling checkpoint carrying `"status": []` took
+    every pathless custody command in the workspace down with a TypeError.
+    `validate_record` promises a LIST OF ERRORS: a promise that turns into a
+    traceback on hostile input is a denial of service through the recovery
+    path -- exactly what drift detection exists to survive. One predicate, so
+    the next vocabulary added cannot be forgotten.
+
+    Non-strings are never members: every one of these vocabularies is a set of
+    strings, so "not a string" and "not in the set" are the same verdict, and
+    the caller's existing error message already says the right thing."""
+    return isinstance(value, str) and value in vocabulary
+
+
 def _str_list(value: Any) -> bool:
     return isinstance(value, list) and all(
         isinstance(item, str) and item for item in value)
@@ -345,7 +366,7 @@ def validate_manifest(rec: dict) -> list[str]:
         mode = auth.get("guard_mode")
         guards = auth.get("actuator_guards")
         if mode is not None:
-            _require(errors, isinstance(mode, str) and mode in GUARD_MODES,
+            _require(errors, _in_vocab(mode, GUARD_MODES),
                      "authority.guard_mode", "must be 'audit' or 'enforce'")
             _require(errors, isinstance(guards, list) and bool(guards),
                      "authority.guard_mode",
@@ -441,7 +462,7 @@ def validate_manifest(rec: dict) -> list[str]:
 
     acc = rec["acceptance"]
     ok = isinstance(acc, dict) and set(acc) == {"required_tier", "acceptor_ref"} \
-        and acc.get("required_tier") in TIERS \
+        and _in_vocab(acc.get("required_tier"), TIERS) \
         and (acc.get("acceptor_ref") is None
              or (isinstance(acc.get("acceptor_ref"), str) and acc["acceptor_ref"]))
     _require(errors, ok, "acceptance",
@@ -460,7 +481,7 @@ def validate_record(record: Any) -> list[str]:
     if not isinstance(record, dict):
         return ["record: JSON object required"]
     kind = record.get("record")
-    if kind not in RECORD_KINDS:
+    if not _in_vocab(kind, RECORD_KINDS):
         return [f"record: unknown kind {kind!r}"]
     if kind == "mission-manifest@1":
         return validate_manifest(record)
@@ -478,7 +499,7 @@ def validate_checkpoint(rec: dict) -> list[str]:
         return errors
     _require(errors, isinstance(rec["revision"], int) and rec["revision"] >= 1,
              "revision", "integer >= 1 required")
-    _require(errors, rec["status"] in STATES, "status",
+    _require(errors, _in_vocab(rec["status"], STATES), "status",
              f"one of {sorted(STATES)} required")
     prev = rec["prev_checkpoint_sha256"]
     if rec.get("revision") == 1:
@@ -538,9 +559,9 @@ def validate_acceptance_verdict(rec: dict) -> list[str]:
         return errors
     _require(errors, isinstance(rec["revision"], int) and rec["revision"] >= 1,
              "revision", "integer >= 1 required")
-    _require(errors, rec["verdict"] in VERDICTS, "verdict",
+    _require(errors, _in_vocab(rec["verdict"], VERDICTS), "verdict",
              f"one of {sorted(VERDICTS)} required")
-    _require(errors, rec["assurance_tier"] in TIERS, "assurance_tier",
+    _require(errors, _in_vocab(rec["assurance_tier"], TIERS), "assurance_tier",
              f"one of {sorted(TIERS)} required")
     _require(errors, isinstance(rec["mission_id"], str)
              and bool(_ID_RE.match(rec["mission_id"])),

--- a/plugins/epistemic-skills/contracts/verify_calibration.py
+++ b/plugins/epistemic-skills/contracts/verify_calibration.py
@@ -151,7 +151,11 @@ def validate(value: object) -> None:
     if frame["observed"] + frame["excluded"] + frame["missing"] != frame["planned"]:
         fail("POPULATION_MISMATCH", "observed + excluded + missing must equal planned")
 
-    if record["status"] not in STATUSES:
+    # isinstance FIRST: `STATUSES` is a set of strings, so an unhashable
+    # status ({} or []) is not a member -- but `in` RAISES on it instead of
+    # answering, and this verifier's contract is a named failure, never a
+    # traceback.
+    if not isinstance(record["status"], str) or record["status"] not in STATUSES:
         fail("UNKNOWN_STATUS", f"status must be one of {sorted(STATUSES)}")
     supersedes = record.get("supersedes")
     if supersedes is not None and (not isinstance(supersedes, str) or not SHA256.fullmatch(supersedes)):
@@ -188,6 +192,11 @@ def self_test() -> None:
         "invalid-missing-never-attests.json": "MISSING_NEVER_ATTESTS",
         "invalid-floating-revision.json": "BAD_REVISION",
         "invalid-nonrfc3339-timestamp.json": "SCHEMA_VIOLATION",
+        # A CLOSED vocabulary tested with `in` raises TypeError on an
+        # unhashable value, so an inbound envelope carrying `"status": []`
+        # produced a traceback instead of the promised named failure --
+        # the same shape es#137 P2 fixed once, in one place, for one field.
+        "invalid-unhashable-status.json": "UNKNOWN_STATUS",
     }
     for name, expected in cases.items():
         try:
@@ -199,7 +208,34 @@ def self_test() -> None:
         else:
             if expected is not None:
                 raise AssertionError(f"{name}: expected {expected}, got pass")
-    print(f"calibration contract self-test: PASS ({len(cases)}/{len(cases)})")
+    # SCHEMA/VERIFIER PARITY. A producer is told to validate against the
+    # published JSON Schema; a consumer runs this verifier. Where the two
+    # disagree the producer gets a false PASS and the consumer refuses the
+    # same bytes. This asserts the schema DECLARES the status-dependent
+    # supersession requirement this verifier enforces.
+    #
+    # HONEST SCOPE OF THIS ORACLE: it reads the schema document, so it
+    # establishes that the constraint is DECLARED -- not that any JSON Schema
+    # implementation enforces it. There is no stdlib JSON Schema validator, so
+    # enforcement cannot be exercised here; a structural pin is what this
+    # repository can actually check, and saying so is the point.
+    schema = json.loads(
+        (Path(__file__).parent / "epistemic-product-calibration.schema.json")
+        .read_text(encoding="utf-8"))
+    conditionals = [
+        rule for rule in schema.get("allOf", [])
+        if rule.get("if", {}).get("properties", {}).get("status", {}).get("const")
+        == "superseded"
+        and "supersedes" in rule.get("then", {}).get("required", [])
+    ]
+    if not conditionals:
+        raise AssertionError(
+            "schema/verifier parity: this verifier raises MISSING_SUPERSESSION "
+            "for status=superseded without `supersedes`, but the published "
+            "schema declares no such conditional -- a producer validating "
+            "against the schema would get a false PASS")
+    print(f"calibration contract self-test: PASS ({len(cases)}/{len(cases)} "
+          "cases + schema/verifier supersession parity)")
 
 
 def main() -> int:


### PR DESCRIPTION
`value in SET` is a TypeError the moment `value` is unhashable, and every one
of these vocabularies is read straight out of an untrusted JSON file.
es#137 P2 fixed exactly ONE instance of this shape -- `guard_mode` -- with an
inline isinstance, and left the mechanism scoped to its instance. Five more
sites kept the raising form.

Measured on main before this change:

  validate_record({... "status": []})        -> TypeError: unhashable type
  validate_record({... "verdict": []})       -> TypeError
  validate_record({... "assurance_tier": {}}) -> TypeError
  validate_record({"record": ["checkpoint@1"]}) -> TypeError
  manifest.acceptance.required_tier = {}      -> TypeError

and the consequence is not cosmetic: a SIBLING mission directory whose
checkpoint carries `"status": []` took EVERY pathless custody command in the
workspace down with `TypeError: unhashable type: 'list'`, because
`Mission._discover` catches (StoreError, ValueError) and TypeError is neither.
`validate_record` promises a list of errors; a promise that becomes a
traceback on hostile input is a denial of service through the recovery path --
exactly what drift detection exists to survive.

Two more instances of "read defensively, but not quite":

- `custody_store._successor_proves_alteration` called `successor.get(...)` on
  whatever JSON the next checkpoint holds. `[]` raised AttributeError, which
  its `except (OSError, ValueError)` does not catch, so `load_latest` leaked a
  raw exception instead of its ChainBroken/EpochSkew verdict.
- `verify_calibration.validate` tested `record["status"] not in STATUSES`
  with no isinstance guard, so an inbound envelope carrying `"status": []`
  produced a traceback instead of the promised named `UNKNOWN_STATUS`.

And one producer/consumer disagreement of the same family: the published
`epistemic-product-calibration@1` schema had no conditional requiring
`supersedes` when `status` is `superseded`, while the bundled verifier refuses
that record with MISSING_SUPERSESSION. A producer validating against the
schema as instructed got a false PASS and the consumer rejected the same
envelope.

Closes these outstanding agent-review findings:

- #113 verify_mission_custody.py:160 "Type-check enum fields before set
  membership" (r3758069895)
- #119 custody_mission.py:140 "Treat validator type errors as corrupt
  siblings" (r3762996839)
- #175 custody_store.py:152 "Guard malformed successors before reading their
  hash pointer" (r3781271761)
- #76 verify_calibration.py:155 "Validate the status type before set
  membership" (r3708661644)
- #54 epistemic-product-calibration.schema.json:57 "Require supersession
  pointers in the published schema" (r3670960044)

Red-then-green evidence
-----------------------

RED (before the fix, tests added first):

  $ python plugins/epistemic-skills/contracts/mission-custody/test_mission_custody.py
  FAIL closed-vocab-no-typeerror-checkpoint-status
  FAIL closed-vocab-no-typeerror-manifest-required-tier
  FAIL closed-vocab-no-typeerror-manifest-required-tier-standalone
  FAIL closed-vocab-no-typeerror-verdict-verdict
  FAIL closed-vocab-no-typeerror-verdict-assurance-tier
  FAIL closed-vocab-no-typeerror-record-kind
  6 failures

  $ python plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
  FAIL typeinvalid-sibling-no-typeerror
  FAIL malformed-successor-is-storeerror
       (raised AttributeError: 'list' object has no attribute 'get')

  $ python plugins/epistemic-skills/contracts/verify_calibration.py --self-test
  TypeError: unhashable type: 'list'   (invalid-unhashable-status.json)

  $ (schema conditional reverted) python .../verify_calibration.py --self-test
  AssertionError: schema/verifier parity: this verifier raises
  MISSING_SUPERSESSION ... but the published schema declares no such
  conditional -- a producer validating against the schema would get a false PASS

GREEN (after):

  test_mission_custody.py            0 failures
  test_custody_mission.py            0 failures
  test_custody_cli.py rc=0  test_custody_gate.py rc=0  test_es173_cases.py rc=0
  test_custody_store.py rc=0  test_custody_hook.py rc=0
  test_custody_process_proof.py rc=0
  verify_calibration.py --self-test  PASS (6/6 cases + schema/verifier
                                     supersession parity)
  check_json_artifacts.py rc=0       (284 JSON artifacts)

What the oracles actually exercise
----------------------------------

- The vocabulary tests call `validate_record` -- the public entry point -- not
  the per-kind validators, so the dispatch path is covered too.
- The sibling test drives `Mission.load` against a REAL workspace with a real
  corrupt sibling on disk. It establishes runtime behaviour, not source shape.
- The schema parity check READS the schema document. It establishes that the
  constraint is DECLARED, NOT that any JSON Schema implementation enforces it:
  there is no stdlib JSON Schema validator here, so enforcement cannot be
  exercised, and the check's own comment says so.

Failure mode this correction introduces
---------------------------------------

`_in_vocab` makes "not a string" and "not a member" the same verdict, so a
future vocabulary of non-string members (integers, say) would be silently
rejected wholesale rather than validated. That is why the helper says so in
its docstring and why every vocabulary in this module is a set of strings
today. The pin is `test_constants`, which asserts the exact contents of
STATES/TIERS/VERDICTS/RECORD_KINDS: adding a non-string member there fails
that test before it can reach `_in_vocab`.

The TypeError arm added to `_discover` is deliberately belt-and-braces now
that the verifier answers instead of raising. It is kept because a validator
reached through a hostile file has no business deciding whether the WHOLE
WORKSPACE can be read, and the next type-unsafe expression added there would
otherwise silently reopen a workspace-wide denial of service.

Local gate
----------

`bash .github/scripts/run_local_ci.sh` reports pass=52 fail=2 with this
change. The SAME two steps fail identically on unmodified main in this
environment (measured by stashing the change and rerunning cleanroom_ci.sh:
pass=52 fail=2, same two names). Both are Windows-host artifacts, not
regressions:
  - `sync_skill_surfaces.py --self-test` -> PermissionError reading the
    `skills` symlink inside its temp copy (Windows symlink permissions);
  - `test_live_runner.py` PASSES when run directly
    ("formal-rigor live runner: PASS") and fails only inside the cleanroom
    copy.
CI is dark on this repo, so this local gate plus the suites above is the
evidence; these are committed changes, not observed CI runs.

Signed-off-by: SternOne <maintainer@example.org>

> Privacy edit (2026-09-18): personal identifiers and local coordinates in this historical text are redacted. Synthetic example values do not reproduce the original bytes. Findings and outcomes are unchanged.