### PR TITLE
fix: non-custody tooling findings shard (wiki retired-seat rule, authority-sim bindings, 3 eval scorers)

### DIFF
--- a/.github/scripts/simulate_authority_sequence.py
+++ b/.github/scripts/simulate_authority_sequence.py
@@ -16,6 +16,7 @@ only ever passes proves nothing about the defect it claims to cure.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import tempfile
@@ -80,8 +81,17 @@ def amended(repo: Path, *, drop: tuple[str, ...] = ()) -> tuple[str, dict[str, s
     # the AMENDED-TAMPERED scenario above went red only when this binding
     # started reading the annotation. A missing or wrong field now yields a
     # subject that is not the candidate, and the scenario fails as it must.
-    bound["authorization"] = tag_fields(repo, "v1.0.0").get("authorized-sha", "")
-    bound["evidence_record"] = candidate   # in the tag object, not a commit
+    fields = tag_fields(repo, "v1.0.0")
+    bound["authorization"] = fields.get("authorized-sha", "")
+    # The evidence binding is read from the same annotation: the
+    # `exact-sha-runs` field must exist and carry the run-id list it claims.
+    # Hard-coded to `candidate`, this value survived the field being removed,
+    # malformed, or attached to the wrong subject -- the
+    # AMENDED-EVIDENCE-TAMPERED scenario stayed green until the binding was
+    # derived from the tag message it asserts about.
+    bound["evidence_record"] = (
+        candidate if re.fullmatch(r"[0-9]+(,[0-9]+)*",
+                                  fields.get("exact-sha-runs", "")) else "")
     bound["tag_target"] = git(repo, "rev-list", "-n", "1", "v1.0.0")
 
     writes_after = []
@@ -109,6 +119,13 @@ def amended_tampered(repo: Path) -> tuple[str, dict[str, str], list[str]]:
     falsifier that hard-codes the authorization subject cannot see this: the
     tag authorizes nothing, yet every bound value still reads candidate."""
     return amended(repo, drop=("authorized-sha",))
+
+
+def amended_evidence_tampered(repo: Path) -> tuple[str, dict[str, str], list[str]]:
+    """The amended sequence with `exact-sha-runs` DROPPED from the tag. The
+    authorization field survives, so only an evidence binding that actually
+    reads the annotation can turn this scenario red."""
+    return amended(repo, drop=("exact-sha-runs",))
 
 
 def superseded(repo: Path) -> tuple[str, dict[str, str], list[str]]:
@@ -180,6 +197,8 @@ def main() -> int:
     ok = run("AMENDED sequence (pre-authorization + tag object)", amended, True)
     ok &= run("AMENDED-TAMPERED sequence (tag omits authorized-sha)",
               amended_tampered, False)
+    ok &= run("AMENDED-EVIDENCE-TAMPERED sequence (tag omits exact-sha-runs)",
+              amended_evidence_tampered, False)
     ok &= run("SUPERSEDED sequence (authorization committed after candidate)",
               superseded, False)
     ok &= run("EVIDENCE-COMMITTED variant (the limb the first cure missed)",

--- a/.github/scripts/simulate_authority_sequence.py
+++ b/.github/scripts/simulate_authority_sequence.py
@@ -50,8 +50,13 @@ def new_repo(root: Path) -> Path:
     return repo
 
 
-def amended(repo: Path) -> tuple[str, dict[str, str], list[str]]:
-    """Pre-authorization BEFORE the candidate; tag object AFTER."""
+def amended(repo: Path, *, drop: tuple[str, ...] = ()) -> tuple[str, dict[str, str], list[str]]:
+    """Pre-authorization BEFORE the candidate; tag object AFTER.
+
+    `drop` omits annotation fields from the created tag, so the tampered
+    variants below exercise THIS scenario's own binding logic: a falsifier
+    that derives nothing from the tag reports PASS over a tag that says
+    nothing."""
     (repo / "PRE-AUTH.md").write_text(
         "I authorize publication of the commit produced by merging the feature "
         "branch, and only that commit, iff the gate returns GO.\n", encoding="utf-8")
@@ -65,10 +70,17 @@ def amended(repo: Path) -> tuple[str, dict[str, str], list[str]]:
     bound["exact_checks"] = git(repo, "rev-parse", "HEAD")      # step 4
     bound["independent_verdict"] = git(repo, "rev-parse", "HEAD")  # step 5
     # Step 7: authorization lives in the tag OBJECT, not a commit.
+    lines = ["verdict: runs/gate GO", f"authorized-sha: {candidate}",
+             "owner: Sim Owner", "exact-sha-runs: 111,222,333,444,555"]
     git(repo, "tag", "-a", "v1.0.0", "-m",
-        f"verdict: runs/gate GO\nauthorized-sha: {candidate}\nowner: Sim Owner\n"
-        f"exact-sha-runs: 111,222,333,444,555")
-    bound["authorization"] = candidate
+        "\n".join(l for l in lines if l.split(":", 1)[0] not in drop))
+    # The authorization subject is what the TAG SAYS, not what this harness
+    # remembers. Hard-coding `candidate` here meant a tag that omitted or
+    # mistyped `authorized-sha` still produced one distinct subject and PASS:
+    # the AMENDED-TAMPERED scenario above went red only when this binding
+    # started reading the annotation. A missing or wrong field now yields a
+    # subject that is not the candidate, and the scenario fails as it must.
+    bound["authorization"] = tag_fields(repo, "v1.0.0").get("authorized-sha", "")
     bound["evidence_record"] = candidate   # in the tag object, not a commit
     bound["tag_target"] = git(repo, "rev-list", "-n", "1", "v1.0.0")
 
@@ -76,6 +88,27 @@ def amended(repo: Path) -> tuple[str, dict[str, str], list[str]]:
     if git(repo, "rev-parse", "HEAD") != candidate:
         writes_after.append("a commit was made after the candidate")
     return candidate, bound, writes_after
+
+
+def tag_fields(repo: Path, tag: str) -> dict[str, str]:
+    """`key: value` lines of the annotated tag OBJECT. The amended sequence
+    keeps its authorization and evidence bindings in this message and nowhere
+    else, so what the tag actually says is the only honest source for either
+    subject."""
+    msg = git(repo, "for-each-ref", f"refs/tags/{tag}", "--format=%(contents)")
+    fields: dict[str, str] = {}
+    for line in msg.splitlines():
+        key, sep, value = line.partition(":")
+        if sep:
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def amended_tampered(repo: Path) -> tuple[str, dict[str, str], list[str]]:
+    """The amended sequence with `authorized-sha` DROPPED from the tag. A
+    falsifier that hard-codes the authorization subject cannot see this: the
+    tag authorizes nothing, yet every bound value still reads candidate."""
+    return amended(repo, drop=("authorized-sha",))
 
 
 def superseded(repo: Path) -> tuple[str, dict[str, str], list[str]]:
@@ -145,6 +178,8 @@ def main() -> int:
     print("Falsifier: one immutable subject across checks, verdict, "
           "authorization, and tag target.")
     ok = run("AMENDED sequence (pre-authorization + tag object)", amended, True)
+    ok &= run("AMENDED-TAMPERED sequence (tag omits authorized-sha)",
+              amended_tampered, False)
     ok &= run("SUPERSEDED sequence (authorization committed after candidate)",
               superseded, False)
     ok &= run("EVIDENCE-COMMITTED variant (the limb the first cure missed)",

--- a/docs/wiki-updates/v6.0.0/check_wiki.py
+++ b/docs/wiki-updates/v6.0.0/check_wiki.py
@@ -163,12 +163,39 @@ def check(wiki: Path, version: str, live: set[str], retired: dict[str, str],
     # way to describe a retired seat, and an earlier form of this rule flagged it
     # -- 9 false positives against 1 true one. A rule that fires on the correct
     # phrasing trains writers to avoid the correct phrasing.
+    #
+    # The rule reads the VISIBLE text -- a Markdown link's label, not its raw
+    # `[text](target)` spelling -- and ignores capitalisation. The raw-text,
+    # case-sensitive form could not see "[Helix](Helix-Central-Passage) is the
+    # central passage", the exact sentence the published Contributing page
+    # carried, so the gate false-greened on the one real defect it had caught
+    # in prose review. Precision is kept by the same constraints as before:
+    # word boundaries, a verb immediately after the name, and the negation
+    # lookahead.
+    #
+    # Two exemptions, both checkable and both in the spirit of STALE-COUNT's
+    # "states its own version on the same line": a line that names a date or a
+    # past version is history recording itself (the design-history table), and
+    # a page that opens with the "**Historical page.**" banner has already
+    # told the reader the seat is not live -- the retired seat's own retained
+    # page is exactly that case.
     RETIRED_PRESENT = re.compile(
         r"\b(" + "|".join(re.escape(k) for k in retired) + r")\b`?\s+"
-        r"(?:is|selects|owns|routes|hands)\b(?!\s+(?:not|no longer|never))")
+        r"(?:is|selects|owns|routes|hands)\b(?!\s+(?:not|no longer|never))",
+        re.IGNORECASE)
+    ANY_LINK = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+    DATED_LINE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
     for p in pages:
-        for m in RETIRED_PRESENT.finditer(p.read_text(encoding="utf-8")):
-            fail.append(f"RETIRED-PRESENT-TENSE: {p.name} -- {m.group(0)!r}")
+        text = p.read_text(encoding="utf-8")
+        if "**Historical page.**" in text:
+            continue
+        for ln in ANY_LINK.sub(r"\1", text).splitlines():
+            if DATED_LINE.search(ln):
+                continue
+            if any(v != version for v in VER_IN_TEXT.findall(ln)):
+                continue
+            for m in RETIRED_PRESENT.finditer(ln):
+                fail.append(f"RETIRED-PRESENT-TENSE: {p.name} -- {m.group(0)!r}")
 
     # RULE 6 -- optional live link resolution.
     if check_links:
@@ -251,8 +278,26 @@ def self_test() -> int:
           + f"\nIt shipped {WORDS[n-1]} skills.\n"}, "STALE-COUNT"),
         ("retired seat in present tense", {"Home.md": good_pages["Home.md"]
                                            + "\n`helix` is the central passage.\n"}, "RETIRED-PRESENT-TENSE"),
+        # The published Contributing page carried exactly this shape --
+        # "[Helix](Helix-Central-Passage) is the central passage ..." -- and the
+        # raw-text, case-sensitive rule could not see it: the gate false-greened
+        # on the one real defect it existed to catch.
+        ("retired seat behind a Markdown link and capitalisation",
+         {"Home.md": good_pages["Home.md"]
+          + "\n[Helix](Helix-Central-Passage) is the central passage.\n"}, "RETIRED-PRESENT-TENSE"),
         ("retired seat correctly negated is NOT flagged", {"Home.md": good_pages["Home.md"]
                                            + "\n`helix` is not a live skill; removed in v5.0.0.\n"}, None),
+        ("negation survives Markdown and capitalisation too", {"Home.md": good_pages["Home.md"]
+          + "\nHistorical [Helix](Helix-Central-Passage) is not a live seat.\n"}, None),
+        ("a dated line is history, not present tense", {"Home.md": good_pages["Home.md"]
+          + "\n| 2026-07-20 | helix design | Helix is the central passage, not the router. |\n"}, None),
+        # The retired seat's own retained page opens with a banner that already
+        # tells the reader the seat is not live; its body legitimately describes
+        # the historical design in the present tense.
+        ("a banner-marked historical page may use present tense",
+         {"Skill-Helix.md": "> **Historical page.** `helix` is not a live skill.\n\n"
+                            "# Helix\n\nHelix is the sole guide to the central passage.\n"},
+         None),
         ("empty wiki is vacuous, not clean", {"__WIPE__": None}, "VACUOUS"),
     ]
     failures = 0

--- a/docs/wiki-updates/v6.0.0/pages/Contributing.md
+++ b/docs/wiki-updates/v6.0.0/pages/Contributing.md
@@ -38,7 +38,7 @@ Use a discipline when the first reads expose a positive trigger:
 | High-stakes or irreversible frozen decision | [Gauntlet](Skill-Gauntlet) |
 | Material user-visible completion claim | [Evidence-Locked UAT](Skill-Evidence-Locked-UAT) |
 
-If a workflow-skill layer is active, [Helix](Helix-Central-Passage) is the central passage that pairs the workflow stage with the positively triggered discipline. It does not require every skill or replace the routine exit.
+If a workflow-skill layer also runs, pairing with it is a [`metacognate`](Skill-Metacognate) Tier 2 judgment made at the moment it is needed. Historical [Helix](Helix-Central-Passage) is not a live seat; there is no pair table.
 
 ## Repository invariants
 

--- a/docs/wiki-updates/v6.0.0/pages/Skill-Context-Audit.md
+++ b/docs/wiki-updates/v6.0.0/pages/Skill-Context-Audit.md
@@ -19,7 +19,7 @@ The prior it operates under: as models strengthen, most accumulated instruction 
 ## Do not use it when
 
 - A single document needs prose editing — that is ordinary editing, not an assembly audit.
-- You are designing a NEW tool or agent-consumed interface — craft doctrine [`agent-interface-design`](Skill-Agent-Interface-Design) owns the outbound channel.
+- You are designing a NEW tool or agent-consumed interface — that is the outbound channel, retained as craft doctrine under [`agent-interface-design`](Skill-Agent-Interface-Design) (a retired seat, no longer routed).
 - You need pre-work recon on a task brief — [`recon`](Skill-Recon) (brief mode) audits the territory; this skill audits the map.
 - You want to tune one prompt for one task's output — that is prompt engineering, not context hygiene.
 

--- a/plugins/epistemic-skills/reference/craft/agent-interface-design-evals/trigger-and-scope/score.py
+++ b/plugins/epistemic-skills/reference/craft/agent-interface-design-evals/trigger-and-scope/score.py
@@ -53,6 +53,13 @@ def score(fixtures: list[dict], responses: list[dict]) -> dict:
             justifications = row.get("example_justifications", [])
             if examples_added and len(justifications) != examples_added:
                 failures.append(f"{fid}: every added example needs a written weaker-consumer justification")
+            elif examples_added and any(not _nonempty(j) for j in justifications):
+                # A COUNT match is not a justification: [""] satisfied the old
+                # check. The example-lint contract requires written prose naming
+                # the weaker-consumer audience, and an empty string names none.
+                failures.append(f"{fid}: an added example's justification must be "
+                                f"written prose naming the weaker-consumer audience, "
+                                f"got {justifications!r}")
         elif expected == "consumer-gate":
             remedy = row.get("remedy")
             if remedy not in GATE_REMEDIES:

--- a/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/score.py
+++ b/plugins/epistemic-skills/skills/context-audit/evals/trigger-and-scope/score.py
@@ -18,7 +18,14 @@ KEEP_CLASSES = {
     "KEEP:GOVERNANCE",
 }
 APPLY_ORDER = ["CONFLICT", "DUPLICATE", "OVER-VERIFY", "OBVIOUS", "MODEL-HANDLES-THIS-NOW"]
-AUDIT_ARTIFACT_FIELDS = ("layers_inventoried", "cross_layer_merge", "report_emitted", "cut_list", "applied")
+AUDIT_ARTIFACT_FIELDS = ("layers_inventoried", "cross_layer_merge", "report_emitted", "cut_list", "applied",
+                         # `cuts_applied` is audit activity too: the report-only
+                         # branch below already forbids it, and a no-fire row
+                         # carrying it is the silent over-firing this battery
+                         # exists to catch. It was omitted here, so a negative
+                         # fixture could declare action no-fire AND applied cuts
+                         # and still pass.
+                         "cuts_applied")
 
 
 def _audit_common(fid: str, row: dict, failures: list[str]) -> None:

--- a/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
+++ b/plugins/epistemic-skills/skills/outsource/tests/run_tests.py
@@ -46,9 +46,16 @@ def check_live_surface_counts(skill_count: int) -> None:
     import re
     disciplines = skill_count - 1  # the entry point is not a discipline
     ok_words = {WORDS[skill_count], WORDS[disciplines]}
+    # The count word must bind to the NOUN it quantifies. Pooling both counts
+    # into one accepted set meant "fifteen disciplines" and "fourteen skills"
+    # both passed -- each naming the other's total. The lookahead captures the
+    # nearest following noun and the comparison is against THAT noun's count.
     count_re = re.compile(
-        r"\b(" + "|".join(WORDS.values()) + r")\b(?=[^.;]{0,60}(?:skill|discipline))",
+        r"\b(" + "|".join(WORDS.values()) + r")\b(?=[^.;]{0,60}?\b(skills?|disciplines?)\b)",
         re.IGNORECASE)
+
+    def want_for(noun: str) -> str:
+        return WORDS[skill_count] if noun.lower().startswith("skill") else WORDS[disciplines]
 
     def strings_of(obj):
         if isinstance(obj, str):
@@ -77,8 +84,10 @@ def check_live_surface_counts(skill_count: int) -> None:
         data = json.loads(read(mp))
         for s in strings_of(data):
             for m in count_re.finditer(s):
-                require(m.group(1).lower() in ok_words,
-                        f"stale count word {m.group(1)!r} on live surface {mp.name}: ...{s[max(0,m.start()-30):m.end()+40]}...")
+                require(m.group(1).lower() == want_for(m.group(2)),
+                        f"stale count word {m.group(1)!r} for {m.group(2)!r} on live surface "
+                        f"{mp.name} (expected {want_for(m.group(2))!r}): "
+                        f"...{s[max(0,m.start()-30):m.end()+40]}...")
     readme = read(REPO_ROOT / "README.md")
     # Select mermaid node lines structurally -- inside a fenced ```mermaid block --
     # rather than by a prose fragment. The previous selector keyed on "router and",
@@ -106,8 +115,9 @@ def check_live_surface_counts(skill_count: int) -> None:
                           f"lines carry no spelled count at all: {mermaid!r}")
     gemini = read(REPO_ROOT / "GEMINI.md")
     for m in count_re.finditer(gemini):
-        require(m.group(1).lower() in ok_words,
-                f"stale count word {m.group(1)!r} in GEMINI.md")
+        require(m.group(1).lower() == want_for(m.group(2)),
+                f"stale count word {m.group(1)!r} for {m.group(2)!r} in GEMINI.md "
+                f"(expected {want_for(m.group(2))!r})")
 
 
 def check_marketplace_enumeration(skill_names: set[str]) -> None:


### PR DESCRIPTION
## What & why

Non-custody tooling shard of the outstanding-findings drain (estate program). 25 findings triaged against current main: **6 fixed here, 9 already fixed (by #222), 7 not actionable (their PR closed unmerged — the file never entered main), 3 real but owned by open PR #231** (routed there, not duplicated here — the estate's no-two-implementations rule).

Fixed on this branch, each red-first:
- `2bed367` — check_wiki.py retired-seat rule was case/Markdown-blind (couldn't see `[Helix](Helix-Central-Passage)`); now reads visible link text case-insensitively, with two checkable exemptions mirroring the existing STALE-COUNT idiom. The honest gate then fired on two real snapshot pages; both repaired in the same commit so the wiki gate stays green.
- `4512467` — simulate_authority_sequence.py: the authorization binding was hard-coded; now parsed from the tag object's `authorized-sha`.
- `11232a2` — same file: evidence binding now requires a well-formed `exact-sha-runs` annotation field.
- `4040c6e` — three eval scorers (agent-interface-design justification check, context-audit cuts_applied no-fire invisibility, outsource count-not-bound-to-noun).

Red-first evidence per fix is in the commit messages and the shard report (planted tampered scenarios each `PASS (expected FAIL)` pre-fix, `FAIL (expected FAIL)` post).

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: the touched tools' own self-tests and eval batteries pass on this branch (check_wiki self-test 18/18 controls, committed 47-page snapshot gate green; simulate_authority_sequence falsifier 5/5; context-audit/agent-interface-design/outsource batteries green); the branch changes take effect only via the tools' next runs
rollback_or_return_path: git revert of this branch's 4 commits; no production state touched
-->
