### PR TITLE
chore(deps): group Dependabot updates, move routine cadence to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,8 @@ updates:
       - "pin-gardening"
     # Grouped updates (Phase 3, ZMS-Labs/zms-homelab#1719): collapse many
     # single-dependency PRs into one PR per severity band, cutting the
-    # downstream CI fan-out. Majors ride in their own PR so a breaking
-    # action bump is never merged alongside routine patch re-pins.
+    # downstream CI fan-out. Only minor/patch re-pins are grouped; majors
+    # stay ungrouped so each breaking action bump gets its own PR.
     groups:
       github-actions-minor-patch:
         patterns:
@@ -24,8 +24,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-      github-actions-major:
-        patterns:
-          - "*"
-        update-types:
-          - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,23 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels:
       - "pin-gardening"
+    # Grouped updates (Phase 3, ZMS-Labs/zms-homelab#1719): collapse many
+    # single-dependency PRs into one PR per severity band, cutting the
+    # downstream CI fan-out. Majors ride in their own PR so a breaking
+    # action bump is never merged alongside routine patch re-pins.
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "pin-gardening"
-    # Grouped updates (Phase 3, ZMS-Labs/zms-homelab#1719): collapse many
+    # Grouped updates (fleet CI fan-out reduction, Phase 3): collapse many
     # single-dependency PRs into one PR per severity band, cutting the
     # downstream CI fan-out. Only minor/patch re-pins are grouped; majors
     # stay ungrouped so each breaking action bump gets its own PR.


### PR DESCRIPTION
Applies Dependabot's documented `groups` mechanism to this repo's single `github-actions` update entry, so a cycle's action SHA re-pins arrive as one grouped pull request per severity band instead of one PR per action. Only `github-actions-minor-patch` (`update-types: minor, patch`) is grouped. Major bumps are deliberately left unmatched, so Dependabot keeps its default of one PR per dependency for them and a breaking action bump is never merged alongside routine patch re-pins, nor alongside another major. With `open-pull-requests-limit: 5` unchanged, a cycle that previously opened up to five single-dependency PRs, each triggering its own full CI run, now opens one PR for the routine band plus at most one per major.

Dependabot **security** updates are not affected by this interval change: they are raised when a Dependabot alert fires on advisory publication, not on `schedule.interval`, and GitHub's version-updates docs state the version-update cooldown "does not apply to security updates." The pin-gardening header comment, `directory`, `open-pull-requests-limit`, and `labels` are preserved byte-for-byte; this repo has no `ignore:` blocks to preserve.

This is a public repository, so the tracking reference in the config comment names the phase rather than the private fleet repo; `check_public_content.py` rejects that name.

An earlier revision of this branch also defined a `github-actions-major` group matching `"*"`. That would have collapsed every major in a cycle into one PR, which is the opposite of the isolation claimed. It was removed in b7b836818187e0805e3e0d434e72b009633fa54f.

Note: `stdlib-checks` and `contract` stay red on this branch until #239 lands. Both fail on a pre-existing private-repo-name leak in `README.md` that this branch does not touch.

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: yaml.safe_load passes and updates[0].groups has exactly one key, github-actions-minor-patch; diff contains only groups: additions and the schedule interval change; every pre-existing comment, directory, open-pull-requests-limit and labels entry preserved byte-for-byte
rollback_or_return_path: git revert of the commits on this branch
-->

🤖 Generated with Claude Code

https://claude.ai/code/session_015CX5rBwjwhJZhsJY692MtT
