### PR TITLE
fix(readme): keep the private fleet repo name out of the public estate banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Obligation:** `best effort` · **Stage:** `building` · **Load-bearing:** `unknown — not yet observed`
 > **Purpose:** `governance_method`
 > **Canonical for:** epistemic-agent-skill-package
-> Estate authority: `ZMS-Labs/zms-homelab/governance/estate.yaml`.
+> Estate authority: the ZMS fleet governance registry (private), `governance/estate.yaml`.
 
 <!-- ZMS-ESTATE:END -->
 


### PR DESCRIPTION
`main` is red on both `stdlib-checks` and `contract`. Both failures have one cause.

`.github/scripts/check_public_content.py` carries a `private-fleet-repo-name` pattern, `\bzms-homelab\b`. The estate banner re-projection in e7e485e2 wrote that private repository's name into `README.md` line 8 of this **public** repo, so the gate rejects it. The `contract` job's clean-room replication runs the same script as one of its 55 workflow steps, which is why it reports `pass=51 fail=1` with `check_public_content.py` as the single failure. One edit clears both jobs.

The banner keeps its meaning. It still names `governance/estate.yaml` as the authority and marks the holding repository private; it just does not name it.

Verified locally on this branch:

```
$ python .github/scripts/check_public_content.py
public-content gate ok: 8 patterns, 38 allowlisted exact files digest-verified (0 dormant entries name files absent from this branch)
```

**Follow-up, not fixed here.** The banner is a generated projection. The generator lives in the private fleet governance repo and will reintroduce the name on the next re-projection unless it is taught that the destination repo is public. Filed as #238.

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: python .github/scripts/check_public_content.py exits 0 on this branch; the stdlib-checks and contract jobs both go green on this PR
rollback_or_return_path: git revert of the single commit on this branch
-->

🤖 Generated with Claude Code

https://claude.ai/code/session_015CX5rBwjwhJZhsJY692MtT
