### PR TITLE
fix(custody): refuse a required text field no reader could ever read

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -194,6 +194,127 @@ def _refuse_store_aliased_target(workspace: Path, target: Path,
                     "writing through it would truncate the record that "
                     "attests the work. Remove the alias and record a fresh "
                     "artifact.")
+# A required text field exists so a human can later READ it, and
+# `not text.strip()` is not that check. `str.strip()` is Unicode-aware over
+# `str.isspace()`, so it already refuses every Z-separator -- U+00A0 included
+# -- but it accepts the code points that render blank WITHOUT being "space":
+# format controls (Cf: zero-width joiners, bidi marks and isolates, soft
+# hyphen, BOM, tag characters), C0/C1 controls (Cc), and a few letters and
+# symbols whose glyph is empty by design. Measured on the build that shipped
+# `not reason.strip()`: 26 distinct code points, over four axes and 35 cases
+# across three call paths (cancel via argv, cancel via --reason-file, and
+# amend), exited 0 -- sealing `cancelled: <invisible>` into a TERMINAL
+# checkpoint, a mission permanently closed with a reason no reader can
+# recover (es#213).
+#
+# The rule is a PREDICATE that fails closed, not a category enumeration -- the
+# same shape `_refuse_unprintable_identity` settled on, for the same reason: an
+# enumeration's blind spot is exactly the class its author did not think of.
+# That reason is not decorative here. The FIRST pass at this class shipped only
+# the first two clauses plus an eight-entry allow-list, and the allow-list's
+# blind spot was measured on the shipped build: 1961 code points -- every Mn
+# and Me assigned in Unicode 14.0.0 -- were still accepted, and nine of them
+# were confirmed live to exit 0 and seal `cancelled: <invisible>` into a
+# terminal checkpoint (U+034F, U+FE00, U+FE0F, U+E0100, U+180B, U+16FE4,
+# U+0301, U+05B0, U+20DD). The third clause below closes that axis by
+# CATEGORY, which is why it is a category test and not 1961 more entries.
+#
+#     ch.isspace()
+#     or not ch.isprintable()
+#     or unicodedata.category(ch) in _ZERO_ADVANCE_MARK_CATEGORIES
+#     or ord(ch) in _BLANK_GLYPH_CODEPOINTS
+#
+# `not isprintable()` is the FIRST closed half. A full-range census
+# (0..0x10FFFF, run on unicodedata 14.0.0 and 15.0.0 -- the local and CI
+# interpreters -- with identical results) shows it covers every member of Cc,
+# Cf, Cn, Co, Cs, Zl and Zp, and 16 of the 17 Zs, with no printable member
+# anywhere in those categories -- so a code point assigned into any of them by
+# a FUTURE Unicode version is refused without editing this file. The
+# `isspace()` clause is redundant today except for U+0020, the one printable
+# space (same census); it stays because it restates the property directly, and
+# it can only ever refuse more, never less.
+#
+# `_ZERO_ADVANCE_MARK_CATEGORIES` is the SECOND closed half, and it is the same
+# kind of guarantee: a nonspacing (Mn) or enclosing (Me) mark has zero advance
+# width BY DEFINITION and composes onto a preceding base character, so a string
+# that is nothing but marks has no base to compose onto and renders as nothing
+# or as a dotted-circle artifact. Future Mn/Me assignments are covered without
+# editing this file. Mc (SPACING combining mark) is deliberately excluded: 445
+# code points that do carry advance width and are visible on their own.
+#
+# `_BLANK_GLYPH_CODEPOINTS` is what is left OPEN, and it is an enumeration:
+# printable Lo/So characters that still render as nothing, which no category
+# predicate reaches without also refusing every CJK ideograph or every emoji.
+# Its blind spot is, by construction, whatever blank-rendering printable Lo/So
+# code point is missing from it. That residual is bounded and disclosed rather
+# than hidden -- every entry is census-proven printable, non-space, and not
+# Mn/Me (an entry a closed half already covers would be dead weight posing as
+# coverage; U+17B4 and U+17B5 were exactly that once Mn was closed, and are
+# removed), and because these are ordinary letters and symbols, a text carrying
+# ANY visible character alongside one still passes.
+# Same posture as the reserved-note guard's disclosed homoglyph residual.
+_ZERO_ADVANCE_MARK_CATEGORIES = frozenset({"Mn", "Me"})
+
+_BLANK_GLYPH_CODEPOINTS = frozenset({
+    0x115F,   # HANGUL CHOSEONG FILLER       (Lo)
+    0x1160,   # HANGUL JUNGSEONG FILLER      (Lo)
+    0x3164,   # HANGUL FILLER                (Lo)
+    0xFFA0,   # HALFWIDTH HANGUL FILLER      (Lo)
+    0x2800,   # BRAILLE PATTERN BLANK        (So)
+    0x1D159,  # MUSICAL SYMBOL NULL NOTEHEAD (So)
+})
+
+_MAX_REPORTED_BLANKS = 8
+
+
+def _require_substantive_text(text, label: str, purpose: str) -> None:
+    """Refuse a required text field that no reader could ever read.
+
+    The test is on the WHOLE string, never on a single character: text that
+    merely CONTAINS a zero-width, bidi, or combining character is still text.
+    Refusing those would be this guard's own defect pointed the other way -- an
+    operator left holding a mission that can no longer be cancelled, which is
+    worse than the blank reason the guard exists to stop. That direction is the
+    failure mode the Mn/Me clause specifically risks, because ordinary
+    well-formed text in several living scripts carries a nonspacing mark and
+    emoji presentation is a base symbol plus U+FE0F; it is pinned by
+    `test_cancel_accepts_substantive_reasons`, whose rows include non-Latin
+    scripts, an emoji ZWJ sequence, Hebrew with niqqud, Thai with a vowel mark,
+    an emoji and a CJK ideograph each followed by a variation selector, and
+    real text carrying an interior ZWSP, RLM, and combining grapheme joiner.
+    """
+    if not isinstance(text, str) or not text:
+        raise CustodyError(f"{label} required ({purpose})")
+    # The accumulator is capped at what the message can print. `--reason-file`
+    # has no size limit, so one entry per character would make the REFUSAL path
+    # allocate in proportion to the file -- measured at ~4.3x the file's bytes
+    # and rising, which turns a documented exit-2 into an OOM for a large blank
+    # file. Only the first `_MAX_REPORTED_BLANKS` DISTINCT code points are ever
+    # shown, so only those are ever held; `len(text)` supplies the count, and
+    # `more_blanks` reproduces the "..." suffix without a full distinct list.
+    shown_blanks: dict = {}
+    more_blanks = False
+    for ch in text:
+        if not (ch.isspace() or not ch.isprintable()
+                or unicodedata.category(ch) in _ZERO_ADVANCE_MARK_CATEGORIES
+                or ord(ch) in _BLANK_GLYPH_CODEPOINTS):
+            return  # at least one character a reader can actually see
+        cp = ord(ch)
+        if cp not in shown_blanks:
+            if len(shown_blanks) < _MAX_REPORTED_BLANKS:
+                shown_blanks[cp] = None
+            else:
+                more_blanks = True
+    # Name the code points in ASCII. Echoing the glyphs would print the very
+    # invisibility being refused, and this module's errors must survive an
+    # ASCII-only console (see custody_cli._ascii_safe).
+    shown = " ".join("U+%04X" % cp for cp in shown_blanks)
+    if more_blanks:
+        shown += " ..."
+    raise CustodyError(
+        f"{label} required ({purpose}); the text supplied is "
+        f"{len(text)} character(s) of non-rendering code points and would "
+        f"record nothing a reader could recover: {shown}")
 
 
 def _refuse_unprintable_identity(value, field: str) -> None:
@@ -2354,8 +2475,8 @@ class Mission:
         if latest["status"] not in _OPEN_STATES:
             raise IllegalTransition(
                 f"cannot amend_authority: status is {latest['status']!r}")
-        if not isinstance(text, str) or not text.strip():
-            raise CustodyError("amendment text required (verbatim operator grant)")
+        _require_substantive_text(
+            text, "amendment text", "verbatim operator grant")
         manifest = json.loads(json.dumps(latest["manifest"]))
         _refuse_reserved_note(text)
         manifest["authority"]["amendments"].append(
@@ -2405,10 +2526,14 @@ class Mission:
         if latest["status"] not in _OPEN_STATES:
             raise IllegalTransition(
                 f"cannot authorize_sibling: status is {latest['status']!r}")
-        if not isinstance(text, str) or not text.strip():
-            raise CustodyError(
-                "amendment text required (the verbatim operator grant this "
-                "authorization records)")
+        # THIRD site of the same class, not a second instance of a fixed one.
+        # `authorize_sibling` landed with es#173 after this branch was cut and
+        # reached for `not text.strip()`, the check es#213 measured as open on
+        # 26 code points. A sibling authorization is an authority record with
+        # the same reader, so it takes the same predicate.
+        _require_substantive_text(
+            text, "amendment text",
+            "the verbatim operator grant this authorization records")
         if not isinstance(mission_id, str) or not _ID_RE.match(mission_id):
             raise CustodyError(
                 f"authorize_sibling names {mission_id!r}, which is not a "
@@ -3789,6 +3914,8 @@ class Mission:
         return new["revision"]
 
     def cancel(self, reason: str) -> int:
+        _require_substantive_text(
+            reason, "cancel reason", "why the mission was abandoned")
         latest, path = self.store.load_latest()
         self._verify_manifest(latest)
         if latest["status"] not in ("draft", "active", "reopened", "verifying"):

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -324,6 +324,383 @@ def test_audit_report_with_orphaned_receipt_validates() -> None:
         check("orphan-report-negative-control", validate_record(bad) != [])
 
 
+def test_cancel_requires_nonempty_reason() -> None:
+    """A terminal cancellation must retain why the mission was abandoned.
+
+    Empty argv text and whitespace-only reason files both refuse without
+    appending a checkpoint, so the still-active mission remains recoverable.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir()
+        reason_file = Path(tmp) / "blank-reason.txt"
+        reason_file.write_text(" \t\n", encoding="utf-8", newline="")
+        open_cli(ws, "cancel-reason", "instruction")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        checkpoints = ws / "missions" / "cancel-reason" / "checkpoints"
+        before = sorted(checkpoints.glob("*.json"))
+
+        cases = (
+            ("empty-argv", ("--reason", "")),
+            ("whitespace-argv", ("--reason", " \t")),
+            ("whitespace-file", ("--reason-file", str(reason_file))),
+        )
+        for name, reason_args in cases:
+            r = run(
+                "cancel",
+                "--workspace",
+                str(ws),
+                "--actor",
+                "agent:worker",
+                *reason_args,
+            )
+            check(f"cancel-{name}-exit-2", r.returncode == 2)
+            check(
+                f"cancel-{name}-names-required-reason",
+                "cancel reason required" in r.stderr,
+            )
+            check(f"cancel-{name}-no-traceback", "Traceback" not in r.stderr)
+            check(
+                f"cancel-{name}-no-checkpoint-write",
+                sorted(checkpoints.glob("*.json")) == before,
+            )
+            status = json.loads(
+                run(
+                    "status",
+                    "--workspace",
+                    str(ws),
+                    "--actor",
+                    "agent:worker",
+                ).stdout
+            )
+            check(
+                f"cancel-{name}-mission-still-active",
+                status["status"] == "active",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Blank-shaped cancel reasons (es#213)
+#
+# A cancelled mission is TERMINAL, and its reason is the only record of why it
+# was abandoned. The first fix wrote `not reason.strip()`. `str.strip()` is
+# Unicode-aware over `str.isspace()`, so it already refuses every Zs/Zl/Zp
+# separator -- U+00A0 included. What it does NOT refuse is the classes that
+# render blank but are not "space": zero-width and bidi format controls (Cf),
+# C0/C1 controls (Cc), and blank-RENDERING letters and symbols (Lo/Mn/So).
+# Measured against the pre-fix build, these rows failed as a set: 26 distinct
+# code points over 35 cases (cancel via argv, cancel via --reason-file, and
+# amend) exited 0 and sealed `cancelled: <invisible>` into the terminal
+# checkpoint. Zero rows on the two whitespace axes failed -- `strip()` already
+# covered those, which is why they stay here as regression pins rather than
+# bug reproductions.
+#
+# The axis is the Unicode general category, not a hand-picked character list:
+# the guard refuses a code point because of its CATEGORY, so one row proves the
+# axis and the remaining rows are regression pins for code points a real shell,
+# editor, or copy-paste actually emits.
+#
+# The `zero-advance-mark` block at the bottom is the SECOND pass. The first one
+# closed Cc/Cf/Cn/Co/Cs/Zl/Zp/Zs with `isspace() or not isprintable()` and left
+# the printable half to an 8-entry allow-list -- which is the shape whose blind
+# spot is whatever its author did not enumerate. Measured on that build, 1961
+# Mn/Me code points (Unicode 14.0.0) were still accepted, and 9 of them are
+# pinned below as having actually sealed a terminal cancellation. Enumeration
+# closed by category, not by adding 1961 more entries.
+_BLANK_REASON_CASES = (
+    # (axis, codepoint, label)
+    ("ascii-whitespace", 0x0020, "SPACE"),
+    ("ascii-whitespace", 0x0009, "TAB"),
+    ("ascii-whitespace", 0x000A, "LINE FEED"),
+    ("ascii-whitespace", 0x000D, "CARRIAGE RETURN"),
+    ("ascii-whitespace", 0x000B, "VERTICAL TAB"),
+    ("unicode-whitespace", 0x00A0, "NO-BREAK SPACE"),
+    ("unicode-whitespace", 0x1680, "OGHAM SPACE MARK"),
+    ("unicode-whitespace", 0x2007, "FIGURE SPACE"),
+    ("unicode-whitespace", 0x202F, "NARROW NO-BREAK SPACE"),
+    ("unicode-whitespace", 0x205F, "MEDIUM MATHEMATICAL SPACE"),
+    ("unicode-whitespace", 0x3000, "IDEOGRAPHIC SPACE"),
+    ("unicode-whitespace", 0x2028, "LINE SEPARATOR"),
+    ("unicode-whitespace", 0x2029, "PARAGRAPH SEPARATOR"),
+    ("unicode-whitespace", 0x0085, "NEXT LINE"),
+    ("zero-width", 0x200B, "ZERO WIDTH SPACE"),
+    ("zero-width", 0x200C, "ZERO WIDTH NON-JOINER"),
+    ("zero-width", 0x200D, "ZERO WIDTH JOINER"),
+    ("zero-width", 0x2060, "WORD JOINER"),
+    ("zero-width", 0xFEFF, "ZERO WIDTH NO-BREAK SPACE (BOM)"),
+    ("zero-width", 0x00AD, "SOFT HYPHEN"),
+    ("zero-width", 0x180E, "MONGOLIAN VOWEL SEPARATOR"),
+    ("zero-width", 0xE0020, "TAG SPACE"),
+    ("rtl-and-bidi", 0x200E, "LEFT-TO-RIGHT MARK"),
+    ("rtl-and-bidi", 0x200F, "RIGHT-TO-LEFT MARK"),
+    ("rtl-and-bidi", 0x202A, "LEFT-TO-RIGHT EMBEDDING"),
+    ("rtl-and-bidi", 0x202E, "RIGHT-TO-LEFT OVERRIDE"),
+    ("rtl-and-bidi", 0x2066, "LEFT-TO-RIGHT ISOLATE"),
+    ("rtl-and-bidi", 0x2069, "POP DIRECTIONAL ISOLATE"),
+    ("control", 0x0001, "START OF HEADING"),
+    ("control", 0x0007, "BELL"),
+    ("control", 0x001B, "ESCAPE"),
+    ("control", 0x007F, "DELETE"),
+    ("blank-glyph", 0x3164, "HANGUL FILLER"),
+    ("blank-glyph", 0x115F, "HANGUL CHOSEONG FILLER"),
+    ("blank-glyph", 0x1160, "HANGUL JUNGSEONG FILLER"),
+    ("blank-glyph", 0xFFA0, "HALFWIDTH HANGUL FILLER"),
+    ("blank-glyph", 0x2800, "BRAILLE PATTERN BLANK"),
+    ("blank-glyph", 0x1D159, "MUSICAL SYMBOL NULL NOTEHEAD"),
+    # Zero-advance marks (Mn/Me) -- the axis the first pass at this class left
+    # open. An Mn/Me code point is PRINTABLE and is not `isspace()`, so neither
+    # half of `isspace() or not isprintable()` reaches it, and the 8-entry
+    # blank-glyph allow-list reached 2 of the 1961 Mn/Me code points assigned
+    # in Unicode 14.0.0. A mark is nonspacing BY DEFINITION -- zero advance
+    # width, composed onto a preceding base -- so a string that is nothing but
+    # marks has no base to compose onto and renders as nothing (or a
+    # dotted-circle artifact). Measured against the build that shipped the
+    # category predicate alone, every row below exited 0 and sealed
+    # `cancelled: <invisible>` into the terminal checkpoint.
+    ("zero-advance-mark", 0x034F, "COMBINING GRAPHEME JOINER"),
+    ("zero-advance-mark", 0xFE0F, "VARIATION SELECTOR-16"),
+    ("zero-advance-mark", 0xFE00, "VARIATION SELECTOR-1"),
+    ("zero-advance-mark", 0xE0100, "VARIATION SELECTOR-17"),
+    ("zero-advance-mark", 0x180B, "MONGOLIAN FREE VARIATION SELECTOR ONE"),
+    ("zero-advance-mark", 0x16FE4, "KHITAN SMALL SCRIPT FILLER"),
+    ("zero-advance-mark", 0x0301, "COMBINING ACUTE ACCENT"),
+    ("zero-advance-mark", 0x05B0, "HEBREW POINT SHEVA"),
+    ("zero-advance-mark", 0x20DD, "COMBINING ENCLOSING CIRCLE"),
+    # Moved down from `blank-glyph`: these two are Mn, so the Mn/Me clause is
+    # what refuses them now. Leaving them labelled as allow-list entries would
+    # misreport which half of the guard is load-bearing for them -- and they
+    # were removed from the allow-list for exactly that reason.
+    ("zero-advance-mark", 0x17B4, "KHMER VOWEL INHERENT AQ"),
+    ("zero-advance-mark", 0x17B5, "KHMER VOWEL INHERENT AA"),
+)
+
+# The guard tests the WHOLE string, so a RUN of blank-shaped characters drawn
+# from DIFFERENT axes has to refuse as well. A per-character predicate that had
+# only ever been shown single-character rows could pass every row above and
+# still admit a mixed run -- which is what a real paste produces, since an
+# operator's "invisible" text is rarely one code point repeated.
+# Written as \u escapes on purpose: a source file that carries the invisible
+# characters literally cannot be reviewed, which is the same unreadability the
+# guard exists to refuse.
+_BLANK_REASON_RUNS = (
+    ("all-marks", "\u0301\u0302\u0303"),
+    ("mixed-axes", "\u200b\u0301\u00a0"),
+    ("mark-after-space", " \u034f"),
+    ("variation-selector-run", "\ufe0f\ufe0f\ufe0f"),
+    ("mark-then-format-control", "\u05b0\u200e"),
+)
+
+# The fix's OWN failure mode is over-rejection. Refusing a reason the operator
+# is entitled to give wedges a mission that can then never be cancelled -- a
+# worse outcome than the blank reason it was meant to stop. Every row here MUST
+# be accepted. The load-bearing ones are the tail: a reason that CONTAINS a
+# zero-width, bidi, or combining code point alongside real text is substantive,
+# and a guard written as "refuse if ANY character is Cf/Mn" would ship exactly
+# the defect this one fixes, pointed the other way. The variation-selector and
+# niqqud rows are the pins for the Mn/Me clause specifically -- ordinary
+# well-formed text in several living scripts carries a nonspacing mark, and
+# emoji presentation is a base symbol plus U+FE0F.
+_SUBSTANTIVE_REASON_CASES = (
+    ("ascii", "superseded by es#214"),
+    ("single-punctuation", "."),
+    ("single-digit", "0"),
+    ("cjk", "\u4efb\u52a1\u5df2\u53d6\u6d88"),
+    ("arabic-rtl", "\u062a\u0645 \u0627\u0644\u0625\u0644\u063a\u0627\u0621"),
+    ("hebrew-rtl", "\u05d1\u05d5\u05d8\u05dc"),
+    ("cyrillic", "\u043e\u0442\u043c\u0435\u043d\u0435\u043d\u043e"),
+    ("devanagari", "\u0930\u0926\u094d\u0926"),
+    ("emoji", "\U0001f525"),
+    ("emoji-zwj-sequence", "\U0001f468\u200d\U0001f469\u200d\U0001f467"),
+    ("combining-mark", "annul\u0065\u0301"),
+    ("real-text-padded-with-nbsp", "\u00a0superseded by es#214\u00a0"),
+    ("real-text-containing-zwsp", "superseded\u200bby es#214"),
+    ("real-text-containing-rlm", "closed\u200f by operator"),
+    ("real-text-containing-cgj", "supersed\u034fed by es#214"),
+    ("emoji-with-variation-selector", "\u2764\ufe0f"),
+    ("cjk-with-variation-selector", "\u845b\ufe00"),
+    ("hebrew-with-niqqud", "\u05d1\u05b0\u05d5\u05d8\u05dc"),
+    ("thai-with-vowel-mark", "\u0e22\u0e01\u0e40\u0e25\u0e34\u0e01"),
+)
+
+
+def _cancel_with(ws_root: Path, mission_id: str, reason_args: tuple) -> tuple:
+    """open -> cancel a fresh mission, returning (result, checkpoint dir)."""
+    ws = ws_root / mission_id
+    ws.mkdir(parents=True)
+    open_cli(ws, mission_id, "instruction")
+    r = run("cancel", "--workspace", str(ws), "--actor", "agent:worker",
+            *reason_args)
+    return r, ws / "missions" / mission_id / "checkpoints"
+
+
+def test_cancel_refuses_every_blank_shaped_reason() -> None:
+    """A reason made only of non-rendering code points is not a reason.
+
+    Refusal must be total across the category axes, not a strip() of the
+    subset Python happens to call whitespace. Each case proves exit 2, an
+    ASCII-only diagnosis naming the code point, no traceback, no checkpoint
+    appended, and a mission left cancellable.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i, (axis, cp, label) in enumerate(_BLANK_REASON_CASES):
+            mid = "blank-%02d" % i
+            r, checkpoints = _cancel_with(root, mid, ("--reason", chr(cp)))
+            tag = "%s-U+%04X" % (axis, cp)
+            check("cancel-blank-%s-exit-2" % tag, r.returncode == 2)
+            check("cancel-blank-%s-names-required-reason" % tag,
+                  "cancel reason required" in r.stderr)
+            check("cancel-blank-%s-no-traceback" % tag,
+                  "Traceback" not in r.stderr)
+            # The diagnosis must be actionable AND ascii-safe: name the
+            # offending code point as U+XXXX, never echo the invisible glyph.
+            check("cancel-blank-%s-names-codepoint" % tag,
+                  ("U+%04X" % cp) in r.stderr)
+            check("cancel-blank-%s-stderr-is-ascii" % tag,
+                  all(ord(c) < 128 for c in r.stderr))
+            check("cancel-blank-%s-no-checkpoint-write" % tag,
+                  len(sorted(checkpoints.glob("*.json"))) == 1)
+            # Read the durable record, not `status`: `status` REFUSES on a
+            # cancelled mission ("no active mission"), so asking it would turn
+            # a successful bypass into a crash instead of a clean assertion.
+            latest = sorted(checkpoints.glob("*.json"))[-1]
+            record = json.loads(latest.read_text(encoding="utf-8"))
+            check("cancel-blank-%s-mission-not-cancelled" % tag,
+                  record["status"] != "cancelled")
+
+
+def test_cancel_refuses_blank_shaped_runs() -> None:
+    """The predicate is per-character but the verdict is on the WHOLE string.
+
+    Every row above is one code point repeated, which a guard could pass by
+    special-casing single characters. These rows mix axes -- mark plus space,
+    mark plus zero-width, mark plus bidi -- because that is what a real paste
+    of "invisible" text actually contains.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i, (label, reason) in enumerate(_BLANK_REASON_RUNS):
+            mid = "blankrun-%02d" % i
+            r, checkpoints = _cancel_with(root, mid, ("--reason", reason))
+            check("cancel-blankrun-%s-exit-2" % label, r.returncode == 2)
+            check("cancel-blankrun-%s-names-required-reason" % label,
+                  "cancel reason required" in r.stderr)
+            check("cancel-blankrun-%s-no-traceback" % label,
+                  "Traceback" not in r.stderr)
+            check("cancel-blankrun-%s-stderr-is-ascii" % label,
+                  all(ord(c) < 128 for c in r.stderr))
+            check("cancel-blankrun-%s-no-checkpoint-write" % label,
+                  len(sorted(checkpoints.glob("*.json"))) == 1)
+            latest = sorted(checkpoints.glob("*.json"))[-1]
+            record = json.loads(latest.read_text(encoding="utf-8"))
+            check("cancel-blankrun-%s-mission-not-cancelled" % label,
+                  record["status"] != "cancelled")
+
+
+def test_cancel_refuses_blank_shaped_reason_files() -> None:
+    """The --reason-file vector reaches code points argv cannot carry.
+
+    Windows CreateProcess rejects an embedded NUL outright, so U+0000 is only
+    reachable through a file. Each payload is DOUBLED because `_read_text`
+    decodes utf-8-sig and strips ONE leading BOM -- a lone U+FEFF file would
+    decode to "" and be caught by the empty check, proving the stripper rather
+    than the survivor.
+    """
+    file_cases = (
+        ("control", 0x0000, "NUL"),
+        ("control", 0x007F, "DELETE"),
+        ("zero-width", 0xFEFF, "ZERO WIDTH NO-BREAK SPACE (BOM)"),
+        ("zero-width", 0x200B, "ZERO WIDTH SPACE"),
+        ("rtl-and-bidi", 0x202E, "RIGHT-TO-LEFT OVERRIDE"),
+        ("blank-glyph", 0x3164, "HANGUL FILLER"),
+        ("unicode-whitespace", 0x00A0, "NO-BREAK SPACE"),
+        ("zero-advance-mark", 0xFE0F, "VARIATION SELECTOR-16"),
+        ("zero-advance-mark", 0x034F, "COMBINING GRAPHEME JOINER"),
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i, (axis, cp, label) in enumerate(file_cases):
+            rf = root / ("reason-%02d.txt" % i)
+            with open(rf, "w", encoding="utf-8", newline="") as handle:
+                handle.write(chr(cp) * 2)
+            mid = "blankfile-%02d" % i
+            r, checkpoints = _cancel_with(root, mid, ("--reason-file", str(rf)))
+            tag = "%s-U+%04X" % (axis, cp)
+            check("cancel-blankfile-%s-exit-2" % tag, r.returncode == 2)
+            check("cancel-blankfile-%s-names-required-reason" % tag,
+                  "cancel reason required" in r.stderr)
+            check("cancel-blankfile-%s-no-traceback" % tag,
+                  "Traceback" not in r.stderr)
+            check("cancel-blankfile-%s-no-checkpoint-write" % tag,
+                  len(sorted(checkpoints.glob("*.json"))) == 1)
+
+
+def test_cancel_accepts_substantive_reasons() -> None:
+    """Over-rejection is this guard's own failure mode -- pin it.
+
+    A refused-but-legitimate reason leaves a mission no one can cancel. Every
+    row must reach the terminal state AND land its reason verbatim in the
+    checkpoint note, including the rows whose text merely CONTAINS an
+    invisible code point.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i, (label, reason) in enumerate(_SUBSTANTIVE_REASON_CASES):
+            mid = "subst-%02d" % i
+            r, checkpoints = _cancel_with(root, mid, ("--reason", reason))
+            check("cancel-substantive-%s-exit-0" % label, r.returncode == 0)
+            latest = sorted(checkpoints.glob("*.json"))[-1]
+            record = json.loads(latest.read_text(encoding="utf-8"))
+            check("cancel-substantive-%s-status-cancelled" % label,
+                  record["status"] == "cancelled")
+            check("cancel-substantive-%s-reason-recorded-verbatim" % label,
+                  ("cancelled: " + reason) in record["state"]["notes"])
+
+
+def test_amend_refuses_blank_shaped_text() -> None:
+    """`amend --text` carries the same guard idiom, so it carries the same hole.
+
+    The amendment text is the operator's VERBATIM grant -- the one string in
+    the contract whose exactness is the point. One row per axis; the full
+    per-code-point table lives on cancel, which is where the class was found.
+    """
+    axis_probe = (
+        ("ascii-whitespace", 0x0020),
+        ("unicode-whitespace", 0x00A0),
+        ("zero-width", 0x200B),
+        ("rtl-and-bidi", 0x202E),
+        ("control", 0x0007),
+        ("blank-glyph", 0x3164),
+        ("zero-advance-mark", 0xFE0F),
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for i, (axis, cp) in enumerate(axis_probe):
+            ws = root / ("amend-%02d" % i)
+            ws.mkdir(parents=True)
+            open_cli(ws, "amend-%02d" % i, "instruction")
+            r = run("amend", "--workspace", str(ws), "--actor", "agent:worker",
+                    "--text", chr(cp))
+            tag = "%s-U+%04X" % (axis, cp)
+            check("amend-blank-%s-exit-2" % tag, r.returncode == 2)
+            check("amend-blank-%s-names-required-text" % tag,
+                  "amendment text required" in r.stderr)
+            check("amend-blank-%s-no-traceback" % tag,
+                  "Traceback" not in r.stderr)
+        # positive control: a real grant, one that merely contains a ZWSP, and
+        # one that merely contains a nonspacing mark -- the over-rejection
+        # direction has to be pinned on this call path too, not only on cancel.
+        for label, text in (("plain", "operator grants scope: docs/"),
+                            ("contains-mark", "grant scope: docs/ \u2764\ufe0f"),
+                            ("contains-zwsp", "grant\u200bscope: docs/")):
+            ws = root / ("amend-ok-" + label)
+            ws.mkdir(parents=True)
+            open_cli(ws, "amend-ok-" + label, "instruction")
+            r = run("amend", "--workspace", str(ws), "--actor", "agent:worker",
+                    "--text", text)
+            check("amend-substantive-%s-exit-0" % label, r.returncode == 0)
+
+
 def test_display_safe_drift_and_error_output() -> None:
     """Non-ASCII content in a drifted relpath or a CustodyError message must
     render with JSON-style ASCII escapes on stdout/stderr -- never a raw
@@ -1214,6 +1591,12 @@ TESTS = [
     test_continuity_warning_is_ascii_safe,
     test_audit_report_kind_is_validatable,
     test_audit_report_with_orphaned_receipt_validates,
+    test_cancel_requires_nonempty_reason,
+    test_cancel_refuses_every_blank_shaped_reason,
+    test_cancel_refuses_blank_shaped_runs,
+    test_cancel_refuses_blank_shaped_reason_files,
+    test_cancel_accepts_substantive_reasons,
+    test_amend_refuses_blank_shaped_text,
     test_open_stop_rules_and_acceptable_costs,
     test_open_without_stop_rules_yields_empty_lists,
     test_success_output_confirms_the_write,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import tracemalloc
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
@@ -25,6 +26,8 @@ from custody_gate import run_gate  # noqa: E402
 import census_missions  # noqa: E402
 from custody_mission import (  # noqa: E402
     _approved_by_chain,
+    _MAX_REPORTED_BLANKS,
+    _require_substantive_text,
     _same_artifact,
     AcceptanceRefused,
     BindingRequired,
@@ -5429,9 +5432,131 @@ def test_census_orphan_probe_failure_is_partial_not_absence(
     clean = census_missions.summarize([census_missions.census(workspace)])
     check("orphan-probe-clean-run-is-not-partial",
           clean["answers_are_partial"] is False)
+def test_blank_text_refusal_accumulator_is_bounded(_ws: Path) -> None:
+    """The REFUSAL path must not allocate in proportion to the input.
+
+    `--reason-file` has no size limit. The first version of this guard appended
+    one entry per character before de-duplicating, so refusing a large blank
+    file allocated ~4.3x the file's bytes and rising -- turning a documented
+    exit-2 refusal into an OOM (chatgpt-codex-connector on es#213). Only the
+    first `_MAX_REPORTED_BLANKS` DISTINCT code points are ever printed, so only
+    those may ever be held.
+
+    The oracle is the allocation the CALL makes: the input string is built
+    before tracing starts, so the traced peak is the guard's own. The old shape
+    peaks at ~8 bytes per character (~16 MB at n=2,000,000); the bound below is
+    two orders of magnitude under that, so it discriminates rather than merely
+    passing.
+    """
+    blanks = "\u0020\u00a0\u200b\u200e\u0007\u3164\u034f\ufe0f" \
+             "\u2060\u202e\u0001\u2800"
+    small = (blanks * ((100_000 // len(blanks)) + 1))[:100_000]
+    large = (blanks * ((2_000_000 // len(blanks)) + 1))[:2_000_000]
+
+    peaks = {}
+    for name, text in (("small", small), ("large", large)):
+        tracemalloc.start()
+        base = tracemalloc.get_traced_memory()[0]
+        raised = False
+        try:
+            _require_substantive_text(text, "cancel reason", "why")
+        except CustodyError:
+            raised = True
+        peaks[name] = tracemalloc.get_traced_memory()[1] - base
+        tracemalloc.stop()
+        check("blank-accumulator-%s-still-refuses" % name, raised)
+
+    check("blank-accumulator-large-input-allocation-bounded",
+          peaks["large"] < 100_000)
+    # 20x the input must not buy 20x the allocation.
+    check("blank-accumulator-allocation-does-not-scale-with-input",
+          peaks["large"] < max(peaks["small"], 1) * 4)
+
+
+def test_blank_text_refusal_message_names_first_distinct_codepoints(_ws: Path) -> None:
+    """Capping the accumulator must not change what the message says.
+
+    The diagnosis names the first `_MAX_REPORTED_BLANKS` DISTINCT code points
+    in order of first appearance, ASCII-only, with a trailing `...` only when a
+    further distinct code point was seen. Repetition is not a further distinct
+    code point, and the 9th distinct one is counted but never named.
+    """
+    twelve = "\u0020\u00a0\u200b\u200e\u0007\u3164\u034f\ufe0f" \
+             "\u2060\u202e\u0001\u2800"
+    exactly_eight = twelve[:8] * 40
+    try:
+        _require_substantive_text(exactly_eight, "cancel reason", "why")
+        check("blank-message-eight-distinct-refuses", False)
+    except CustodyError as exc:
+        msg = str(exc)
+        check("blank-message-eight-distinct-refuses", True)
+        check("blank-message-eight-distinct-no-ellipsis", "..." not in msg)
+        check("blank-message-eight-distinct-names-all-eight",
+              all(("U+%04X" % ord(c)) in msg for c in twelve[:8]))
+        check("blank-message-eight-distinct-counts-characters",
+              "%d character(s)" % len(exactly_eight) in msg)
+        check("blank-message-eight-distinct-is-ascii",
+              all(ord(c) < 128 for c in msg))
+
+    over_cap = twelve * 40
+    try:
+        _require_substantive_text(over_cap, "cancel reason", "why")
+        check("blank-message-over-cap-refuses", False)
+    except CustodyError as exc:
+        msg = str(exc)
+        check("blank-message-over-cap-refuses", True)
+        check("blank-message-over-cap-has-ellipsis", msg.endswith("..."))
+        check("blank-message-over-cap-names-first-eight",
+              all(("U+%04X" % ord(c)) in msg
+                  for c in twelve[:_MAX_REPORTED_BLANKS]))
+        check("blank-message-over-cap-omits-the-ninth",
+              ("U+%04X" % ord(twelve[_MAX_REPORTED_BLANKS])) not in msg)
+        check("blank-message-over-cap-preserves-first-appearance-order",
+              " ".join("U+%04X" % ord(c)
+                       for c in twelve[:_MAX_REPORTED_BLANKS]) in msg)
+        check("blank-message-over-cap-is-ascii",
+              all(ord(c) < 128 for c in msg))
+
+
+def test_authorize_sibling_refuses_blank_shaped_grant(
+        workspace: Path) -> None:
+    """The THIRD site of the blank-text class, not a second instance of a
+    fixed one.
+
+    `authorize_sibling` landed with es#173 after this work was first
+    written, and reached for `not text.strip()` -- the check measured as
+    open on 26 code points. It records an authority grant a human must
+    later read, so it takes the same predicate, and the mission must
+    survive the refusal rather than absorb an unreadable authorization."""
+    rel = "docs/x.txt"
+    a = open_mission(workspace, "a-owner", "own the artifact")
+    a.approve()
+    a.record_effect(rel, "one\n", "req-a1")
+    before = a.status()["revision"]
+    # Built from escapes, never literal characters, so this source file
+    # stays pure ASCII.
+    for label, grant in (("empty", ""), ("space", " "),
+                         ("nbsp", "\u00a0"), ("zwsp", "\u200b"),
+                         ("bom", "\ufeff"), ("vs16", "\ufe0f"),
+                         ("cgj", "\u034f")):
+        try:
+            a.authorize_sibling("b-writer", rel, grant)
+            check("sibling-grant-refuses-%s" % label, False)
+        except CustodyError:
+            check("sibling-grant-refuses-%s" % label, True)
+    check("sibling-grant-refusal-appends-nothing",
+          a.status()["revision"] == before)
+    # Negative control: a real grant still lands, so the guard refuses the
+    # class and not the verb.
+    a.authorize_sibling("b-writer", rel, "operator: b-writer may write it")
+    check("sibling-grant-accepts-real-text",
+          a.status()["revision"] > before)
 
 
 TESTS = [
+    test_blank_text_refusal_accumulator_is_bounded,
+    test_blank_text_refusal_message_names_first_distinct_codepoints,
+    test_authorize_sibling_refuses_blank_shaped_grant,
     test_scope_entry_classification_table,
     test_uncompared_scope_entries_are_reported,
     test_bare_filename_exclusion_is_enforced,


### PR DESCRIPTION
Replaces #213, which cannot merge: its first commit carries no `Signed-off-by` trailer, and the operator declined a history rewrite. This branch is cut from current `main` with signed commits, and carries both the original content and the review thread's conclusion.

## The defect, reproduced on current `main` before anything was written

`cancel` sealed a **terminal** checkpoint with whatever reason it was handed, including nothing at all — there was no check on `main`. `amend_authority` guarded its verbatim operator grant with `not text.strip()`. That is Unicode-aware over `str.isspace()`, so it refuses every Z-separator, but it accepts the code points that render blank without being *space*: format controls, C0/C1 controls, nonspacing and enclosing marks, and a few letters and symbols whose glyph is empty by design.

Driven through the CLI against `origin/main`, with a control that separates a real defect from a broken oracle:

```
case             cancel rc   sealed terminal note
empty                    0   'cancelled: '
space                    0   'cancelled:  '
nbsp                     0   'cancelled: U+00A0'
zwsp                     0   'cancelled: U+200B'
rlm                      0   'cancelled: U+200F'
bom                      0   'cancelled: U+FEFF'
vs16                     0   'cancelled: U+FE0F'
braille-blank            0   'cancelled: U+2800'
hangul-filler            0   'cancelled: U+3164'
cgj                      0   'cancelled: U+034F'
REAL (control)           0   'cancelled: operator abandoned it'
```

Every one exits 0 and permanently closes the mission with a reason no reader can recover. After this change the same ten refuse with exit 2 and append no checkpoint, so the mission stays active and recoverable, while the control still passes.

## The guard

`_require_substantive_text` is a predicate that fails closed, not a category enumeration, because an enumeration's blind spot is exactly the class its author did not think of. It tests the **whole** string: text that merely *contains* a zero-width or combining character is still text, and refusing that would leave an operator holding a mission that can no longer be cancelled — worse than the blank reason the guard exists to stop.

The residual is bounded and disclosed rather than hidden. `_BLANK_GLYPH_CODEPOINTS` is the one open enumeration, covering printable Lo/So characters that render as nothing and that no category predicate reaches without also refusing every CJK ideograph.

## Three call sites, not two

`authorize_sibling` landed with es#173 **after** the original branch was cut, and reached for the same `not text.strip()`. It records an authority grant with the same reader, so it takes the same predicate here rather than being left as a known instance of a class fixed elsewhere.

Pinned by a targeted control. With only that one line reverted, `strip()` still catches empty, space and nbsp, while zwsp, bom, vs16 and cgj pass and a checkpoint is appended:

```
ok   sibling-grant-refuses-empty
ok   sibling-grant-refuses-space
ok   sibling-grant-refuses-nbsp
FAIL sibling-grant-refuses-zwsp
FAIL sibling-grant-refuses-bom
FAIL sibling-grant-refuses-vs16
FAIL sibling-grant-refuses-cgj
FAIL sibling-grant-refusal-appends-nothing
ok   sibling-grant-accepts-real-text
```

## Review thread carried forward

| Finding | Thread | Disposition |
|---|---|---|
| P2 — bound memory while scanning blank reasons | [#213 `r3857404566`](https://github.com/ZMS-Labs/epistemic-skills/pull/213#discussion_r3857404566) | Already closed on that branch by its final commit, and closed here |

Only the first eight **distinct** code points are retained, so a large blank `--reason-file` cannot make the refusal path allocate in proportion to its input. `len(text)` supplies the count and a `...` suffix reports that more existed.

## Verification

Red then green, in that order:

| State | Result |
|---|---|
| production fix reverted, new cases kept | `test_custody_mission` fails to import `_MAX_REPORTED_BLANKS`; `test_custody_cli` fails `cancel-empty-argv-exit-2`, `cancel-empty-argv-names-required-reason`, `cancel-empty-argv-no-checkpoint-write`, then aborts on the first blank case |
| fix restored | every suite exits 0 |

The full custody gate was run on `origin/main` first and on this branch second, so a new failure would be distinguishable from a pre-existing one. Both are identical: `test_mission_custody`, `test_custody_store`, `test_custody_mission`, `test_custody_cli`, `test_custody_gate`, `test_es173_cases` and `test_custody_hook` all exit 0 with zero `FAIL` lines.

**Limit on that evidence.** Measured locally on Windows under CPython 3.11. The `mission-custody-contract` job runs ubuntu-24.04 under 3.12 and has not yet been observed for this branch.

## Provenance

This pull request is agent-authored. The steward session wrote this description and the assurance block below from the actual diff.

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: Drive the CLI cancel verb with each of empty, space, U+00A0, U+200B, U+200F, U+FEFF, U+FE0F, U+2800, U+3164 and U+034F as the reason; each must exit 2 and leave no terminal checkpoint on disk, while a readable reason still exits 0 and seals one.
rollback_or_return_path: Single commit on a branch; git revert restores the prior guards, and the change only ever refuses a write, so no mission state is altered on the way in.
-->

Supersedes #213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CX5rBwjwhJZhsJY692MtT
