### PR TITLE
perf(custody): make scope close linear, and stop classifying breaks by rescan

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/census_missions.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/census_missions.py
@@ -213,13 +213,24 @@ def _receipts(mission: Mission, store: MissionStore,
     the per-id lookup about every id rescans from revision 1 each time, so a
     mission with one effect per revision made this quadratic -- an estate
     walk over thousands of revisions, millions of parses.
+
+    AND THAT ONE PASS IS HANDED TO THE LOADER. Building the index here and
+    then letting `_load_receipt_checked` reach for its own put the rescan
+    straight back: the loader consults the index for every id, and once that
+    cache is keyed to checkpoint CONTENT a hit costs a full SHA-256 pass over
+    the whole cumulative chain rather than a directory listing. Measured on a
+    300-receipt mission, the census went from 303 checkpoint reads / 1.9 MiB
+    to 91,205 reads / 578 MiB. Forwarding the mapping is the same repair
+    `scope_consistency` already makes for its own fallback loads.
     """
     paths: list[str] = []
     problems: list[str] = []
+    index_built = True
     try:
         index = mission._effect_path_index()
     except (OSError, ValueError, KeyError, TypeError) as exc:
         index = {}
+        index_built = False
         problems.append(f"chain index unreadable: {type(exc).__name__}: {exc}")
     for rid in _lget(latest, "receipt_ids"):
         if not isinstance(rid, str):
@@ -232,7 +243,18 @@ def _receipts(mission: Mission, store: MissionStore,
             # RECEIPT-MISSING for a receipt that is present, intact and merely
             # newer -- telling the operator the opposite of what `resume` now
             # says about the same file.
-            receipt, _refusal, opaque = mission._load_receipt_checked(rid)
+            #
+            # ONLY A MAPPING THAT WAS ACTUALLY BUILT is forwarded. The empty
+            # dict above is a failure marker, not an answer: handing it over
+            # would tell the loader that NO id has a chained path and silently
+            # retire its own artifact_path comparison -- a forged receipt would
+            # then read as ordinary coverage on exactly the run that already
+            # could not read the chain. When the build failed the loader is
+            # called as before, raises the same error, and every id is still
+            # reported.
+            receipt, _refusal, opaque = (
+                mission._load_receipt_checked(rid, effect_paths=index)
+                if index_built else mission._load_receipt_checked(rid))
         except (OSError, ValueError) as exc:
             receipt = None
             problems.append(f"{rid}: receipt unreadable: {type(exc).__name__}")

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -1130,7 +1130,10 @@ class Mission:
         # immutable for the mission's life, so reading it once is sound and
         # keeps receipt loading off a per-call chain read.
         self._mission_id: str | None = None
-        self._effect_index_cache: tuple[int, dict[str, str]] | None = None
+        self._effect_index_cache: tuple[
+            tuple[tuple[str, str], ...],
+            tuple[dict[str, str], dict[str, str]],
+        ] | None = None
 
     # -- construction -----------------------------------------------------
 
@@ -1761,16 +1764,22 @@ class Mission:
                 self._mission_id = None
         return self._mission_id
 
-    def _load_receipt(self, request_id: str) -> dict | None:
+    def _load_receipt(
+            self, request_id: str, *,
+            effect_paths: dict[str, str] | None = None
+    ) -> dict | None:
         """None means UNLOADABLE -- absent, corrupt, schema-invalid, or
         BELONGING TO ANOTHER MISSION alike. A corrupt receipt must degrade to
         drift (RECEIPT-MISSING), never crash resume: crashing the recovery
         path on a mangled receipt is a denial of service by exactly the
         tampering drift detection exists to catch."""
-        return self._load_receipt_checked(request_id)[0]
+        return self._load_receipt_checked(
+            request_id, effect_paths=effect_paths
+        )[0]
 
     def _load_receipt_checked(
-            self, request_id: str
+            self, request_id: str, *,
+            effect_paths: dict[str, str] | None = None
     ) -> tuple[dict | None, str | None, tuple[str, str] | None]:
         """(record, refusal reason, OPAQUE). ONE implementation of the trust rule,
         two callers: `_load_receipt` wants only the verdict, while
@@ -1876,7 +1885,10 @@ class Mission:
         # raises the bar without closing that case; it is the es#118 residue,
         # and the tail anchor closes it. Disclosed in SECURITY.md rather than
         # papered over here.
-        chained = self._effect_path_index().get(request_id)
+        chained = (
+            effect_paths if effect_paths is not None
+            else self._effect_path_index()
+        ).get(request_id)
         if chained is not None and record.get("artifact_path") != chained:
             return None, (
                 f"present receipt claims {record.get('artifact_path')!r}, "
@@ -1908,7 +1920,32 @@ class Mission:
 
     def _effect_path_index(self) -> dict[str, str]:
         """Every chain-bound request id -> the path its admitting revision
-        recorded, built in ONE pass over the chain.
+        recorded. See `_effect_indexes` for how it is built."""
+        return self._effect_indexes()[0]
+
+    def _effect_kind_index(self) -> dict[str, str]:
+        """Every chain-bound request id -> HOW it was minted ('effect' or
+        'reconciled'), from the same note that records the path.
+
+        The path index removed the per-id rescan from every caller that wanted
+        all the PATHS, and left the one caller that wants all the KINDS still
+        rescanning: `continuity_breaks` asked `_historical_effect_path(...,
+        kind=True)` once per break, so a mission with many real breaks read
+        the chain from checkpoint 1 for each of them -- O(breaks x
+        checkpoints) reads on exactly the histories that have the most to
+        read. A clean chain never reaches that branch, which is why a green
+        suite did not notice.
+
+        Same keys as the path index, necessarily: both come from the same
+        note, so an id has a kind exactly when it has a path."""
+        return self._effect_indexes()[1]
+
+    def _effect_indexes(self) -> tuple[dict[str, str], dict[str, str]]:
+        """(path index, kind index), built together in ONE pass over the chain.
+
+        Built together rather than in two passes because they are two readings
+        of the SAME note: separating them would double the chain reads and
+        create a second place for the two answers to disagree.
 
         Same rule as `_historical_effect_path`, and deliberately sharing
         `_first_effect_note` with it so the two cannot drift: a reader that
@@ -1922,31 +1959,51 @@ class Mission:
         millions of JSON parses. Callers that want ALL the paths ask once.
         Ids with no derivable path are ABSENT (never mapped to a guess), so
         `.get(rid)` returns None exactly where the per-id method does."""
-        # CACHED against the checkpoint COUNT, not time: the chain is
-        # append-only, so a count that has not moved cannot have new ids in
-        # it, and a count that has moved rebuilds. Without this, binding
-        # `_load_receipt` to the chain (round 7) would have reintroduced the
-        # quadratic walk round 3 removed -- resume() loads every receipt.
+        # Cache against exact checkpoint CONTENT, not merely count. Interior
+        # rewrites are rejected by chain verification, but checkpoint@1's tail
+        # is deliberately unsealed until contract@2; a same-count tail rewrite
+        # must not leave an authority-sensitive path index stale. Reading each
+        # file once to fingerprint it preserves a linear scan and lets a cache
+        # hit avoid reparsing while still observing that supported boundary.
+        # Retain only the digest from that pass: checkpoint records are
+        # cumulative, so retaining every payload at once makes peak memory
+        # quadratic in the number of receipts. A cache miss deliberately
+        # rereads one checkpoint at a time for parsing.
         paths = self.store.checkpoint_paths()
+        fingerprint = tuple(
+            (cp_path.name, sha256_file(cp_path)) for cp_path in paths
+        )
         if self._effect_index_cache is not None \
-                and self._effect_index_cache[0] == len(paths):
+                and self._effect_index_cache[0] == fingerprint:
             return self._effect_index_cache[1]
         index: dict[str, str] = {}
-        prev_ids: list[str] = []
+        kinds: dict[str, str] = {}
+        known_ids: set[str] = set()
         prev_notes: list[str] = []
         for cp_path in paths:
             record = json.loads(cp_path.read_text(encoding="utf-8"))
             ids = record["receipt_ids"]
             notes = record["state"]["notes"]
-            fresh = [rid for rid in ids if rid not in prev_ids]
+            # Checkpoints repeat the full cumulative ID list. List membership
+            # makes comparing those cumulative prefixes cubic; request IDs
+            # are never reusable, so one mission-wide set is the exact rule.
+            fresh = [rid for rid in ids if rid not in known_ids]
             if fresh:
-                path = _first_effect_note(notes[len(prev_notes):])
+                fresh_notes = notes[len(prev_notes):]
+                path = _first_effect_note(fresh_notes)
                 if path is not None:
+                    # Both readings come from `_first_effect_note`, the one
+                    # place the rule is written, so the index cannot
+                    # paraphrase what the per-id method answers.
+                    kind = _first_effect_note(fresh_notes, kind=True)
                     for rid in fresh:
                         index.setdefault(rid, path)
-            prev_ids, prev_notes = ids, notes
-        self._effect_index_cache = (len(paths), index)
-        return index
+                        if kind is not None:
+                            kinds.setdefault(rid, kind)
+                known_ids.update(fresh)
+            prev_notes = notes
+        self._effect_index_cache = (fingerprint, (index, kinds))
+        return index, kinds
 
     def _all_receipt_ids_ever(self) -> list[str]:
         """Every request id ever admitted to receipt_ids, in the order the
@@ -2526,11 +2583,14 @@ class Mission:
         # break across the gap where the retired one honestly sat. That fires
         # on the ordinary sanctioned recovery flow, which would train stewards
         # to ignore the signal on day one.
+        effect_paths, effect_kinds = self._effect_indexes()
         by_path: dict[str, list[str]] = {}
         for request_id in self._all_receipt_ids_ever():
-            receipt = self._load_receipt(request_id)
+            receipt = self._load_receipt(
+                request_id, effect_paths=effect_paths
+            )
             rel = (receipt["artifact_path"] if receipt is not None
-                   else self._historical_effect_path(request_id))
+                   else effect_paths.get(request_id))
             if rel is None:
                 continue
             key = _normalize_relpath(rel)
@@ -2540,8 +2600,12 @@ class Mission:
         breaks: list[dict] = []
         for ids in by_path.values():
             for prior_id, next_id in zip(ids, ids[1:]):
-                prior = self._load_receipt(prior_id)
-                nxt = self._load_receipt(next_id)
+                prior = self._load_receipt(
+                    prior_id, effect_paths=effect_paths
+                )
+                nxt = self._load_receipt(
+                    next_id, effect_paths=effect_paths
+                )
                 if prior is None or nxt is None:
                     # A gap we cannot read is not evidence of a break. The
                     # missing receipt is already reported by resume as its own
@@ -2554,8 +2618,13 @@ class Mission:
                 # already caught and the steward already answered for. The
                 # break is real either way, but only an unreconciled one is
                 # news -- that is the case nothing else in the contract sees.
-                reconciled = self._historical_effect_path(
-                    nxt["request_id"], kind=True) == "reconciled"
+                # Read from the prebuilt index, NOT from a per-id rescan. This
+                # is the one branch a clean chain never reaches, so the rescan
+                # here survived the round that removed every other one: a
+                # mission with many real breaks paid a full chain walk per
+                # break. Same note, same rule, one pass.
+                reconciled = effect_kinds.get(
+                    nxt["request_id"]) == "reconciled"
                 breaks.append({
                     "artifact_path": nxt["artifact_path"],
                     "prior_request_id": prior["request_id"],
@@ -2791,8 +2860,11 @@ class Mission:
         current_by_key: dict[str, tuple[str, dict | None, str | None]] = {}
         missing: list[str] = []
         unplaceable_opaque: list[tuple[str, str]] = []
+        effect_paths = self._effect_path_index()
         for request_id in latest["receipt_ids"]:
-            receipt, _refusal, opaque = self._load_receipt_checked(request_id)
+            receipt, _refusal, opaque = self._load_receipt_checked(
+                request_id, effect_paths=effect_paths
+            )
             # KIND, not a boolean. Both opaque kinds behave identically here
             # (present, unverifiable, never "lost"), and differ only in the
             # marker and message the operator is handed.
@@ -2811,7 +2883,7 @@ class Mission:
             # Claiming the slot as an OPAQUE entry supersedes the stale
             # receipt without asserting anything this reader cannot check.
             rel = (receipt["artifact_path"] if receipt is not None
-                   else self._historical_effect_path(request_id))
+                   else effect_paths.get(request_id))
             if rel is None:
                 if kind:
                     # Unattributable but NOT lost: a receipt that is merely
@@ -3354,6 +3426,7 @@ class Mission:
         if not includes and not excludes:
             return []
         findings: list[dict] = []
+        effect_paths = self._effect_path_index()
         for request_id in self._all_receipt_ids_ever():
             # The CHAINED effect note, not the receipt file, decides which
             # artifact an id covers. A receipt is a mutable file: a schema-valid
@@ -3361,9 +3434,11 @@ class Mission:
             # artifact_path would move an out-of-scope write into scope and let
             # PASS through. The chain is tamper-evident and is already treated
             # as the sounder authority everywhere else in this module.
-            rel = self._historical_effect_path(request_id)
+            rel = effect_paths.get(request_id)
             if rel is None:
-                receipt = self._load_receipt(request_id)
+                receipt = self._load_receipt(
+                    request_id, effect_paths=effect_paths
+                )
                 rel = receipt["artifact_path"] if receipt is not None else None
             if rel is None:
                 continue

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1820,6 +1820,409 @@ def test_effect_path_index_matches_per_id(workspace: Path) -> None:
     check("index-covers-reconciled-id", index.get("req-a-again") == "notes/a.md")
 
 
+def test_effect_path_index_agrees_after_readmission(workspace: Path) -> None:
+    """The index and the per-id lookup must still agree when an id is admitted
+    with NO effect note, dropped from receipt_ids, and later RE-ADMITTED by a
+    revision that does carry one.
+
+    es#161's linear rewrite replaced the index's adjacent-checkpoint freshness
+    test (`rid not in prev_ids`) with a mission-wide first-admission set
+    (`rid not in known_ids`). That is not only a speed change. On this chain
+    the old shape treated the re-admitting revision as a fresh admission and
+    re-derived `req-x` from ITS note -- answering 'secrets/x.md' -- while
+    `_historical_effect_path` stopped at the first admission and answered
+    None. Measured on 488f252 (this PR's exact base) and on b6c6eef: index
+    'secrets/x.md' vs per-id None. The existing pin
+    (test_effect_path_index_matches_per_id) could not see it, because its
+    noteless id is never dropped and re-admitted -- so the one test that
+    exists to stop these two readers drifting was blind to the case where
+    they had already drifted.
+
+    None is the answer the contract asks for: `_effect_path_index` declares
+    that ids with no derivable path are ABSENT, never mapped to a guess, and
+    that `.get(rid)` returns None exactly where the per-id method does. The
+    consequence is deliberate and belongs in a test rather than a reviewer's
+    memory: with no chained path for such an id, `_load_receipt_checked` has
+    nothing to compare a receipt against, so the receipt file is the only
+    authority. The base's disagreeing index refused that receipt -- an
+    accident of the drift, not a rule anyone wrote down.
+
+    `record_effect` refuses any id already in the mission's history, so only
+    a direct chain write can produce this shape: legacy or hand-written
+    history, which is exactly the class the underivable-id fallback exists
+    for. If a later change deliberately teaches BOTH readers to keep scanning
+    past a noteless first admission, `readmit-index-answers-none` is the
+    check that must be updated with it -- the agreement check above it is the
+    invariant that must not be."""
+    m = open_mission(workspace, "m-readmit", "Re-admitted noteless id.")
+    m.approve()
+    m.record_effect("docs/a.md", "aa", "req-a")
+
+    def bare(note: str, *, add=None, ids=None) -> None:
+        latest, path = m.store.load_latest()
+        m._write_next(
+            latest, path, status=latest["status"], add_receipt_id=add,
+            receipt_ids=ids,
+            unresolved_verdicts=latest["state"]["unresolved_verdicts"],
+            note=note)
+
+    bare("bare progress note with no effect marker", add="req-x")
+    latest, _ = m.store.load_latest()
+    bare("bare removal note",
+         ids=[r for r in latest["receipt_ids"] if r != "req-x"])
+    bare("effect: secrets/x.md", add="req-x")
+
+    # NOT VACUOUS. Without these two the whole test would pass on a chain
+    # where the re-admission never happened -- the failure mode of a
+    # regression test whose scenario silently stops being built.
+    notes = [n for p in m.store.checkpoint_paths()
+             for n in json.loads(p.read_text(encoding="utf-8"))["state"]["notes"]]
+    check("readmit-note-is-really-in-the-chain",
+          "effect: secrets/x.md" in notes)
+    check("readmit-id-is-really-back",
+          "req-x" in m.status()["receipt_ids"]
+          and m._all_receipt_ids_ever() == ["req-a", "req-x"])
+
+    index = m._effect_path_index()
+    check("readmit-index-agrees-with-per-id",
+          index.get("req-x") == m._historical_effect_path("req-x"))
+    check("readmit-index-answers-none", index.get("req-x") is None)
+    check("readmit-first-admission-still-wins-elsewhere",
+          index.get("req-a") == "docs/a.md"
+          and m._historical_effect_path("req-a") == "docs/a.md")
+
+
+def test_scope_consistency_reuses_single_effect_index(workspace: Path) -> None:
+    """es#161: closing must not rescan the checkpoint chain per receipt."""
+    m = open_mission(
+        workspace, "m-scope-index", "One indexed scope traversal.",
+        scope_in=["docs/**"],
+    )
+    m.approve()
+    for i in range(40):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    original_index = m._effect_path_index
+    original_per_id = m._historical_effect_path
+    index_calls = 0
+    per_id_calls = 0
+
+    def counted_index():
+        nonlocal index_calls
+        index_calls += 1
+        return original_index()
+
+    def counted_per_id(request_id: str, kind: bool = False):
+        nonlocal per_id_calls
+        per_id_calls += 1
+        return original_per_id(request_id, kind)
+
+    m._effect_path_index = counted_index
+    m._historical_effect_path = counted_per_id
+    findings = m.scope_consistency()
+    check("scope-index-preserves-findings", findings == [])
+    check("scope-index-built-once", index_calls == 1)
+    check("scope-index-never-rescans-per-id", per_id_calls == 0)
+
+
+def test_scope_consistency_reuses_index_for_underivable_ids(
+        workspace: Path) -> None:
+    """The receipt fallback must not re-enumerate checkpoints for every miss.
+
+    An empty index models a legacy/noteless chain: every valid receipt must
+    supply its own path.  Before the fix, receipt validation called the same
+    index method again for every ID, retaining O(U*C) behavior.
+    """
+    m = open_mission(
+        workspace, "m-scope-index-fallback", "One fallback traversal.",
+        scope_in=["docs/**"],
+    )
+    m.approve()
+    for i in range(40):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    index_calls = 0
+
+    def underivable_index():
+        nonlocal index_calls
+        index_calls += 1
+        return {}
+
+    m._effect_path_index = underivable_index
+    findings = m.scope_consistency()
+    check("scope-fallback-preserves-receipt-findings", findings == [])
+    check("scope-fallback-index-built-once", index_calls == 1)
+
+
+def test_effect_path_index_invalidates_on_same_count_tail_rewrite(
+        workspace: Path) -> None:
+    """An unsealed checkpoint@1 tail rewrite must invalidate cached paths."""
+    m = open_mission(
+        workspace, "m-scope-index-tail", "Observe the current tail.",
+        scope_in=["docs/**"],
+    )
+    m.approve()
+    m.record_effect("docs/a.txt", "x", "req-a")
+    check("scope-tail-cache-warmed",
+          m._effect_path_index().get("req-a") == "docs/a.txt")
+
+    tail = m.store.checkpoint_paths()[-1]
+    checkpoint = json.loads(tail.read_text(encoding="utf-8"))
+    checkpoint["state"]["notes"] = [
+        "effect: secrets/a.txt" if note == "effect: docs/a.txt" else note
+        for note in checkpoint["state"]["notes"]
+    ]
+    tail.write_text(
+        json.dumps(checkpoint, indent=1, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    check("scope-tail-per-id-sees-current-path",
+          m._historical_effect_path("req-a") == "secrets/a.txt")
+    check("scope-tail-index-sees-current-path",
+          m._effect_path_index().get("req-a") == "secrets/a.txt")
+    findings = m.scope_consistency()
+    check("scope-tail-rewrite-is-not-hidden-by-cache",
+          [(f["artifact_path"], f["request_id"]) for f in findings]
+          == [("secrets/a.txt", "req-a")])
+
+
+def test_resume_and_continuity_share_one_effect_index(
+        workspace: Path) -> None:
+    """Bulk readers must fingerprint the checkpoint chain only once each.
+
+    Receipt validation binds a mutable receipt to its chain-recorded path.
+    Calling that validation without passing the already-built path index makes
+    every receipt reload fingerprint every checkpoint, even when the index
+    cache itself hits.  Repeated writes to one artifact also exercise the
+    second receipt-loading loop in ``continuity_breaks``.
+
+    The counter hooks ``_effect_indexes``, the ONE place the chain is walked,
+    rather than ``_effect_path_index``, which is now a thin accessor over it.
+    Counting the accessor would have gone quiet the moment a reader asked for
+    the kind index instead -- a green result meaning "the hook was bypassed",
+    not "the chain was walked once".
+    """
+    m = open_mission(
+        workspace, "m-reader-index", "One index per bulk reader.",
+    )
+    m.approve()
+    for i in range(16):
+        m.record_effect("docs/shared.txt", str(i), f"req-{i}")
+
+    original_index = m._effect_indexes
+    index_calls = 0
+
+    def counted_index():
+        nonlocal index_calls
+        index_calls += 1
+        return original_index()
+
+    m._effect_indexes = counted_index
+    check("resume-index-preserves-clean-result", m.resume() == [])
+    check("resume-index-built-once", index_calls == 1)
+
+    index_calls = 0
+    check("continuity-index-preserves-clean-result",
+          m.continuity_breaks() == [])
+    check("continuity-index-built-once", index_calls == 1)
+
+
+def test_effect_path_index_does_not_retain_checkpoint_bytes(
+        workspace: Path) -> None:
+    """Fingerprinting may hold one checkpoint's bytes, never the whole chain.
+
+    A bytes subclass records the maximum number of checkpoint payloads alive
+    together.  This is a positive memory-shape oracle rather than a timing or
+    source-text assertion: retaining a cumulative ``raw_records`` list makes
+    the peak grow with every checkpoint, while a streaming fingerprint plus
+    cache-miss reread keeps it constant.
+    """
+    m = open_mission(
+        workspace, "m-index-stream", "Stream checkpoint fingerprints.",
+    )
+    m.approve()
+    for i in range(12):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    original_read_bytes = Path.read_bytes
+    checkpoint_dir = m.store.checkpoints_dir
+
+    class TrackedBytes(bytes):
+        live = 0
+        peak = 0
+
+        def __new__(cls, value: bytes):
+            instance = super().__new__(cls, value)
+            cls.live += 1
+            cls.peak = max(cls.peak, cls.live)
+            return instance
+
+        def __del__(self):
+            type(self).live -= 1
+
+    def tracked_read_bytes(path: Path) -> bytes:
+        data = original_read_bytes(path)
+        if path.parent == checkpoint_dir:
+            return TrackedBytes(data)
+        return data
+
+    m._effect_index_cache = None
+    Path.read_bytes = tracked_read_bytes
+    try:
+        index = m._effect_path_index()
+    finally:
+        Path.read_bytes = original_read_bytes
+
+    check("index-stream-preserves-all-paths", len(index) == 12)
+    check("index-stream-bounds-live-checkpoint-bytes", TrackedBytes.peak <= 2)
+    check("index-stream-releases-checkpoint-bytes", TrackedBytes.live == 0)
+
+
+def test_effect_path_index_uses_set_membership(workspace: Path) -> None:
+    """Cumulative receipt-id lists must not trigger cubic comparisons.
+
+    Each checkpoint repeats all prior IDs, so list membership compares every
+    repeated prefix against the previous prefix.  Counting equality calls
+    distinguishes that cubic comparison shape from set membership's linear
+    work in the already-quadratic number of serialized IDs.
+    """
+    effect_count = 18
+    m = open_mission(
+        workspace, "m-index-membership", "Bound ID membership work.",
+    )
+    m.approve()
+    for i in range(effect_count):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+
+    original_loads = json.loads
+
+    class CountingStr(str):
+        comparisons = 0
+        __hash__ = str.__hash__
+
+        def __eq__(self, other: object) -> bool:
+            type(self).comparisons += 1
+            return super().__eq__(other)
+
+    def counted_loads(value, *args, **kwargs):
+        record = original_loads(value, *args, **kwargs)
+        if isinstance(record, dict) and isinstance(record.get("receipt_ids"), list):
+            record["receipt_ids"] = [CountingStr(rid)
+                                     for rid in record["receipt_ids"]]
+        return record
+
+    m._effect_index_cache = None
+    json.loads = counted_loads
+    try:
+        index = m._effect_path_index()
+    finally:
+        json.loads = original_loads
+
+    check("index-membership-preserves-all-paths", len(index) == effect_count)
+    check("index-membership-comparisons-are-not-cubic",
+          CountingStr.comparisons < effect_count * effect_count)
+
+
+def _count_checkpoint_reads(fn):
+    """Run `fn`; return (result, reads of files under any `checkpoints/` dir).
+
+    The oracle is FILE READS, not calls to `_effect_path_index`. A counter
+    installed on that method goes green the moment the call moves, whether or
+    not the chain is still being re-read -- and re-reading the chain is the
+    cost, not calling the method. Counting reads measures what the claim is
+    about."""
+    orig_bytes, orig_text = Path.read_bytes, Path.read_text
+    reads = 0
+
+    def counted_bytes(self):
+        nonlocal reads
+        if self.parent.name == "checkpoints":
+            reads += 1
+        return orig_bytes(self)
+
+    def counted_text(self, *args, **kwargs):
+        nonlocal reads
+        if self.parent.name == "checkpoints":
+            reads += 1
+        return orig_text(self, *args, **kwargs)
+
+    Path.read_bytes, Path.read_text = counted_bytes, counted_text
+    try:
+        return fn(), reads
+    finally:
+        Path.read_bytes, Path.read_text = orig_bytes, orig_text
+
+
+def test_census_receipts_does_not_rescan_the_chain_per_receipt(
+        workspace: Path) -> None:
+    """es#161 residue: the ESTATE WALK must not re-read the chain per receipt.
+
+    `census_missions._receipts` builds the chain index once and then calls
+    `_load_receipt_checked` for every id WITHOUT handing that index over, so
+    every receipt re-enters `_effect_path_index`. That was survivable while a
+    cache hit cost one directory listing. Keying the cache to checkpoint
+    CONTENT -- the right fix for the stale-index finding -- turns each hit
+    into a full SHA-256 pass over the whole cumulative chain, so the census
+    goes from O(C) checkpoint reads to O(R x C): measured on a 300-receipt
+    mission, 303 reads / 1.9 MiB before the content key, 91,205 reads /
+    578 MiB after it.
+
+    The same class as the finding it came from, in the sibling module the
+    optimisation exists to serve. Every other control here counts calls on a
+    `Mission` method and none of them runs the census, so none of them sees
+    it."""
+    effect_count = 24
+    m = open_mission(workspace, "m-census-io", "Bounded census chain reads.")
+    m.approve()
+    for i in range(effect_count):
+        m.record_effect(f"docs/{i}.txt", str(i), f"req-{i}")
+    latest, _ = m.store.load_latest()
+    checkpoints = len(m.store.checkpoint_paths())
+    m._effect_index_cache = None
+
+    (paths, problems, orphans), reads = _count_checkpoint_reads(
+        lambda: census_missions._receipts(m, m.store, latest))
+
+    check("census-io-preserves-every-path", len(paths) == effect_count)
+    check("census-io-reports-no-problems", not problems and not orphans)
+    # One index build reads each checkpoint at most twice (fingerprint, then
+    # parse). Anything that scales with the RECEIPT count is a per-id rescan.
+    check("census-io-does-not-rescan-per-receipt", reads <= 4 * checkpoints)
+
+
+def test_census_still_reports_receipts_when_the_index_is_unbuildable(
+        workspace: Path) -> None:
+    """The failure mode the rescan fix introduces, pinned.
+
+    Handing the census's prebuilt mapping to `_load_receipt_checked` removes
+    the rescan -- and would also hand it an EMPTY mapping on the path where
+    the index could not be built at all, silently disabling the loader's own
+    chained-path check and turning unreadable receipts into ordinary ones.
+    So the fix forwards only a mapping it actually built; when the build
+    fails the loader is called exactly as before, re-raises, and every id is
+    still reported."""
+    m = open_mission(workspace, "m-census-blind", "Index build fails.")
+    m.approve()
+    m.record_effect("docs/a.txt", "a", "req-a")
+    m.record_effect("docs/b.txt", "b", "req-b")
+    latest, _ = m.store.load_latest()
+
+    def _boom():
+        raise OSError("checkpoints unreadable")
+
+    m._effect_path_index = _boom
+    paths, problems, orphans = census_missions._receipts(m, m.store, latest)
+
+    blob = " ".join(problems)
+    check("census-blind-reports-index-failure",
+          "chain index unreadable" in blob)
+    check("census-blind-still-names-every-id",
+          all(f"{rid}: " in blob for rid in ("req-a", "req-b")))
+    check("census-blind-does-not-report-clean-coverage", paths == [])
+    check("census-blind-no-orphans-invented", orphans == [])
+
+
 def test_forged_restored_receipt_is_not_trusted(workspace: Path) -> None:
     """Round-3 finding: a schema-valid receipt planted at the lost id's path
     must not buy continuity. The chain records which artifact the id was
@@ -2003,6 +2406,64 @@ def test_superseded_receipt_never_shadows_the_current_one(workspace: Path) -> No
     m.record_effect("notes/a.md", "v3", "req-3")
     check("supersede-recovered-clean",
           m.status()["status"] == "active" and m.resume() == [])
+
+
+def test_continuity_break_classification_never_rescans_the_chain(
+        workspace: Path) -> None:
+    """A mission with MANY REAL breaks must not walk the chain once per break.
+
+    `continuity_breaks` reads every other path from the prebuilt index, but
+    classified each break by calling `_historical_effect_path(..., kind=True)`,
+    which rescans from checkpoint 1. That is O(breaks x checkpoints) reads on
+    exactly the histories that have the most to read.
+
+    It survived the round that removed every other rescan because a CLEAN
+    chain never reaches that branch: the existing cases assert an empty break
+    list, so the loop body never runs and a green suite says nothing about it.
+    This case seeds real breaks so the branch is actually exercised, and the
+    counter is on `_historical_effect_path` itself -- the thing that must not
+    happen -- rather than on elapsed time.
+    """
+    m = open_mission(workspace, "m-break-scan", "Many real breaks.")
+    m.approve()
+    target = workspace / "notes" / "a.md"
+    m.record_effect("notes/a.md", "v0", "req-0")
+    for i in range(1, 9):
+        # Tamper out of band, then re-effect WITHOUT resuming: each pair is a
+        # genuine continuity break.
+        target.write_text("tampered-%d" % i, encoding="utf-8")
+        m.record_effect("notes/a.md", "v%d" % i, "req-%d" % i)
+
+    original = m._historical_effect_path
+    rescans = []
+
+    def counted(request_id, kind=False):
+        rescans.append((request_id, kind))
+        return original(request_id, kind)
+
+    m._historical_effect_path = counted
+    breaks = m.continuity_breaks()
+    m._historical_effect_path = original
+
+    check("many-breaks-actually-seeded", len(breaks) == 8)
+    check("break-classification-does-no-per-id-rescan", rescans == [])
+    check("break-classification-still-correct",
+          all(b["already_reconciled"] is False for b in breaks))
+
+    # Negative control on the classification itself: a reconciled write must
+    # still read as reconciled through the index, or the cheap path would be
+    # cheap and wrong.
+    target.write_text("drifted", encoding="utf-8")
+    m.resume()
+    m.reconcile("notes/a.md", "repaired", "req-fixed")
+    after = m.continuity_breaks()
+    reconciled = [b for b in after if b["request_id"] == "req-fixed"]
+    check("reconciled-break-is-present", len(reconciled) == 1)
+    check("reconciled-break-reads-as-reconciled",
+          reconciled[0]["already_reconciled"] is True)
+    check("index-and-per-id-kind-agree",
+          m._effect_kind_index().get("req-fixed")
+          == m._historical_effect_path("req-fixed", kind=True))
 
 
 def test_continuity_surfaces_unreceipted_mutation(workspace: Path) -> None:
@@ -5515,6 +5976,15 @@ TESTS = [
     test_note_cannot_forge_machine_state,
     test_receipt_ids_always_carry_a_derivable_path,
     test_effect_path_index_matches_per_id,
+    test_effect_path_index_agrees_after_readmission,
+    test_scope_consistency_reuses_single_effect_index,
+    test_scope_consistency_reuses_index_for_underivable_ids,
+    test_effect_path_index_invalidates_on_same_count_tail_rewrite,
+    test_resume_and_continuity_share_one_effect_index,
+    test_effect_path_index_does_not_retain_checkpoint_bytes,
+    test_effect_path_index_uses_set_membership,
+    test_census_receipts_does_not_rescan_the_chain_per_receipt,
+    test_census_still_reports_receipts_when_the_index_is_unbuildable,
     test_foreign_mission_receipt_is_not_this_missions_receipt,
     test_cross_workspace_receipt_cannot_silence_drift,
     test_backslash_effect_path_still_loads_its_own_receipt,
@@ -5542,6 +6012,7 @@ TESTS = [
     test_obligations_match_by_artifact_not_by_string,
     test_drift_marker_matches_by_artifact,
     test_superseded_receipt_never_shadows_the_current_one,
+    test_continuity_break_classification_never_rescans_the_chain,
     test_continuity_surfaces_unreceipted_mutation,
     test_continuity_is_silent_on_sanctioned_recovery,
     test_request_ids_are_never_reusable,


### PR DESCRIPTION
Replaces #218, which cannot merge: one of its commits carries no `Signed-off-by` trailer, and the operator declined a history rewrite. This branch is cut from current `main` with signed commits, and carries the original content plus every review thread's conclusion — including the one that was still open.

## Carried forward from #218

- `_effect_path_index` caches against exact checkpoint **content** rather than checkpoint **count**, so a same-count tail rewrite cannot leave an authority-sensitive index stale. Only the digest is retained from that pass, so peak memory stays linear in the number of receipts.
- Cumulative receipt-id prefixes are compared through one mission-wide set instead of list membership, which was cubic.
- `resume`, `continuity_breaks`, the scope scan and the census take the prebuilt index instead of re-deriving a path per receipt.

## The finding that was still open

P2, index reconciliation kinds in the bulk scan ([#218 `r3858398683`](https://github.com/ZMS-Labs/epistemic-skills/pull/218#discussion_r3858398683)). Every other rescan was removed and the classification step kept one:

```python
reconciled = self._historical_effect_path(
    nxt["request_id"], kind=True) == "reconciled"
```

`_historical_effect_path` walks from checkpoint 1, and this ran once per break, so a mission with many real breaks paid checkpoint reads proportional to breaks times checkpoints — on exactly the histories that have the most to read.

**Why a green suite missed it, which is the more interesting half.** A clean chain never enters that branch. Every existing continuity case asserts an *empty* break list, so the loop body never ran. The oracle could not have failed, so its passing meant nothing about this line.

### The fix

The kind map is built in the **same pass** as the path map. `_effect_indexes` returns both; `_effect_path_index` and the new `_effect_kind_index` are thin accessors over it. Both readings come from `_first_effect_note` — the one place the rule is written — so the index cannot paraphrase what the per-id method answers. The cache holds the pair.

### One existing case moved with it

`test_resume_and_continuity_share_one_effect_index` counted calls to `_effect_path_index`. Once `continuity_breaks` asks for both maps at once, that counter observes nothing — it would have gone green **by being bypassed**. It now hooks `_effect_indexes`, the one place the chain is walked, so it still measures the property it was written to measure. The docstring records why, so the next reader does not quietly move it back.

This is a correction, not a weakening: the replacement demands strictly more, because the hooked function is the one that can actually be called.

## Verification

Red then green, in that order:

| State | Result |
|---|---|
| classification reverted to the per-id rescan, new case kept | `FAIL break-classification-does-no-per-id-rescan` — 1 failure |
| fix restored | 0 failures |

The new case seeds **eight real breaks** so the branch actually executes, and counts calls to `_historical_effect_path` — the thing that must not happen — rather than elapsed time, which would have made the assertion a benchmark rather than a proof. It carries a negative control on correctness: a reconciled write must still read as reconciled through the index, and the index's answer must equal the per-id method's for the same id.

The full custody gate was run on `origin/main` first and on this branch second, so a new failure would be distinguishable from a pre-existing one. Both are identical: `test_mission_custody`, `test_custody_store`, `test_custody_mission`, `test_custody_cli`, `test_custody_gate`, `test_es173_cases` and `test_custody_hook` all exit 0 with zero `FAIL` lines.

**Limit on that evidence.** Measured locally on Windows under CPython 3.11. The `mission-custody-contract` job runs ubuntu-24.04 under 3.12 and has not yet been observed for this branch. The performance claim is a read-count claim, established by the call counter, not a wall-clock measurement on a large mission.

## Provenance

This pull request is agent-authored. The steward session wrote this description and the assurance block below from the actual diff.

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: On a mission carrying eight genuine continuity breaks, calling continuity_breaks must invoke _historical_effect_path zero times while still returning eight breaks, and a reconciled write must read as already_reconciled through the kind index with the same answer the per-id method gives.
rollback_or_return_path: Single commit on a branch; git revert restores the prior index shape, and the change is read-path only, so no custody record is written or altered by it.
-->

Supersedes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CX5rBwjwhJZhsJY692MtT
