### PR TITLE
fix(seams): create the target directory only after every precondition holds

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -443,6 +443,49 @@ def _refuse_unrecordable_artifact_path(relpath) -> None:
             + f" in {relpath!r}")
 
 
+def _absent_ancestors(directory: Path) -> list[Path]:
+    """The ancestors of `directory`, DEEPEST FIRST, that do not exist yet.
+
+    Read BEFORE the mkdir that creates them, because afterwards the answer
+    is gone: `Path.mkdir(parents=True, exist_ok=True)` reports nothing
+    about what it made, and a directory found on the way back out cannot be
+    told apart from one a concurrent writer created in the meantime. An
+    ancestor whose existence cannot be decided (a stat that raises rather
+    than answering) is treated as ALREADY THERE -- a directory this call
+    cannot prove it created is not this call's to remove."""
+    absent: list[Path] = []
+    node = directory
+    while node != node.parent:
+        try:
+            if node.exists():
+                break
+        except OSError:
+            break
+        absent.append(node)
+        node = node.parent
+    return absent
+
+
+def _unwind_absent_ancestors(created: list[Path]) -> None:
+    """Remove the directories `_absent_ancestors` recorded, deepest first.
+
+    ONLY WHILE EMPTY, and only until the first that will not come away:
+    `rmdir` refuses a populated directory, so bytes the failed write did
+    leave behind -- or anything a concurrent writer put there -- stop the
+    unwind at that level, and every ancestor above it holds that level and
+    stops too. Removing a directory somebody else is now using would be a
+    worse mutation than the one being undone.
+
+    Failures are swallowed because this runs on the way out of a `raise`:
+    the caller must see the error that failed the effect, not a cleanup
+    error standing in front of it."""
+    for directory in created:
+        try:
+            directory.rmdir()
+        except OSError:
+            return
+
+
 def _store_identity(mission_dir: Path) -> str:
     """One store, possibly several names. `missions/alias -> missions/real`
     is two DIRECTORY NAMES over one store; every question about the store
@@ -1861,19 +1904,38 @@ class Mission:
                                      artifact_relpath)
         before_sha = sha256_file(target) if target.exists() else None
         data = content.encode("utf-8")
+        # THE DIRECTORY IS PART OF THE EFFECT. Every precondition above
+        # already runs before this mkdir -- that ordering is the
+        # refuse-before-mutate discipline the idempotency guard established
+        # -- but ordering alone only covers the failures this verb PREDICTS.
+        # A `PermissionError` at `write_bytes`, or any failure at
+        # `write_receipt`, fails AFTER the directories exist, and the
+        # freshly created parents used to survive it with no receipt and no
+        # checkpoint: an unreceipted workspace mutation minted by the verb
+        # whose whole contract is "no effect without a receipt" (es#169).
+        # So the parents this call creates are recorded before the fact and
+        # unwound on the way out of any raise. What the unwind CANNOT undo
+        # it declines to touch: a write that landed bytes and then failed to
+        # receipt them leaves a non-empty directory, and the artifact's own
+        # bytes are not this cleanup's to delete.
+        created_parents = _absent_ancestors(target.parent)
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(data)
-        receipt = {
-            "record": "receipt@1",
-            "mission_id": latest["mission_id"],
-            "request_id": request_id,
-            "actor": self.actor,
-            "utc": now_utc(),
-            "artifact_path": artifact_relpath.replace("\\", "/"),
-            "before_sha256": before_sha,
-            "after_sha256": sha256_bytes(data),
-        }
-        self.store.write_receipt(receipt)
+        try:
+            target.write_bytes(data)
+            receipt = {
+                "record": "receipt@1",
+                "mission_id": latest["mission_id"],
+                "request_id": request_id,
+                "actor": self.actor,
+                "utc": now_utc(),
+                "artifact_path": artifact_relpath.replace("\\", "/"),
+                "before_sha256": before_sha,
+                "after_sha256": sha256_bytes(data),
+            }
+            self.store.write_receipt(receipt)
+        except BaseException:
+            _unwind_absent_ancestors(created_parents)
+            raise
         return receipt
 
     def _own_mission_id(self) -> str | None:

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -2658,6 +2658,74 @@ def test_effect_duplicate_id_leaves_workspace_untouched(workspace: Path) -> None
           (workspace / "notes" / "a.md").read_text(encoding="utf-8") == "hello")
 
 
+def test_failed_effect_removes_the_directories_it_created(
+        workspace: Path) -> None:
+    """A write that mints no receipt must leave no directory behind.
+
+    `_write_effect` creates the target's parents and only then writes the
+    bytes and the receipt, so a `PermissionError` at the write -- the case
+    es#169 names -- left `esrm/deep/` standing with no receipt and no
+    checkpoint: an unreceipted workspace mutation from the verb whose whole
+    contract is "no effect without a receipt".
+
+    The failure is injected at `Path.write_bytes`, for this one target,
+    because that is the exact seam the issue names and no portable
+    filesystem trick reaches it: a read-only parent fails the MKDIR
+    instead, which creates nothing at all and so measures the ordering that
+    was already correct rather than the cleanup that was missing."""
+    m = open_mission(workspace, "m-mkdir", "Fail after the mkdir.")
+    m.approve()
+    cps_before = sorted((workspace / "missions" / "m-mkdir" / "checkpoints")
+                        .glob("*.json"))
+
+    real_write_bytes = Path.write_bytes
+    blocked = {str(workspace.resolve() / "esrm" / "deep" / "x.txt"),
+               str(workspace.resolve() / "esrm-keep" / "deep" / "y.txt")}
+
+    def refusing_write_bytes(self, data):
+        if str(self) in blocked:
+            raise PermissionError(13, "Permission denied")
+        return real_write_bytes(self, data)
+
+    # A directory the caller made itself, to prove the unwind removes only
+    # what THIS call created.
+    (workspace / "esrm-keep").mkdir()
+
+    Path.write_bytes = refusing_write_bytes
+    try:
+        try:
+            m.record_effect("esrm/deep/x.txt", "data", "req-mkdir")
+            check("failed-effect-propagates-the-write-error", False)
+        except PermissionError:
+            check("failed-effect-propagates-the-write-error", True)
+        try:
+            m.record_effect("esrm-keep/deep/y.txt", "data", "req-mkdir-2")
+            check("failed-effect-propagates-the-write-error-2", False)
+        except PermissionError:
+            check("failed-effect-propagates-the-write-error-2", True)
+    finally:
+        Path.write_bytes = real_write_bytes
+
+    check("failed-effect-minted-no-receipt",
+          not list((workspace / "missions" / "m-mkdir" / "receipts")
+                   .glob("*.json")))
+    check("failed-effect-committed-no-checkpoint",
+          sorted((workspace / "missions" / "m-mkdir" / "checkpoints")
+                 .glob("*.json")) == cps_before)
+    check("failed-effect-left-no-created-directory",
+          not (workspace / "esrm").exists())
+    check("failed-effect-removed-only-what-it-created",
+          (workspace / "esrm-keep").is_dir()
+          and not (workspace / "esrm-keep" / "deep").exists())
+
+    # CONTROL: the unwind is not always-on. A write that DOES receipt keeps
+    # the directories it made -- otherwise the fix would be deleting the
+    # workspace it is supposed to protect.
+    m.record_effect("esrm/deep/x.txt", "data", "req-mkdir-ok")
+    check("receipted-effect-keeps-its-directories",
+          (workspace / "esrm" / "deep" / "x.txt").exists())
+
+
 def test_accept_requires_verifying_and_separation(workspace: Path) -> None:
     m = open_mission(workspace, "m-accept", "Finish task.")
     m.approve()
@@ -6567,6 +6635,7 @@ TESTS = [
     test_reconcile_clears_exactly_one_marker,
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,
+    test_failed_effect_removes_the_directories_it_created,
     test_accept_requires_verifying_and_separation,
     test_fail_is_clearable,
     test_operator_tier,


### PR DESCRIPTION
Repairs the first of the two seams filed in #169: the parent directories `effect` creates could outlive a write that minted no receipt. The second seam in that issue (acceptance probes degrading to a silent `None`) is **not** touched here — see "What is deliberately not in this PR".

This repository has no `.github/PULL_REQUEST_TEMPLATE.md`; the structure below follows the shape of the recently merged custody pull requests (#241, #242, #243).

## What changed, and the evidence for it

`Mission._write_effect` ran `target.parent.mkdir(parents=True, exist_ok=True)` immediately before `target.write_bytes(data)`, with `self.store.write_receipt(receipt)` only after that. Every precondition — the idempotency check, the retired-id and ever-used-id checks, `_resolve_artifact_path`, `_refuse_store_target`, `_refuse_store_aliased_target` — already ran *before* that mkdir, so the ordering half of the issue's sketch was in fact already satisfied on `main`. What was missing was the other half: **there was no cleanup path at all**. A `PermissionError` at `write_bytes`, or any failure inside `write_receipt`, fails *after* the directories exist, and the freshly created parents survived it with no receipt and no checkpoint — an unreceipted workspace mutation minted by the verb whose whole contract is "no effect without a receipt", which is precisely what #169 names.

The fix records the directories this call is about to create, and unwinds them on the way out of any raise:

- `_absent_ancestors(directory)` walks up from the target's parent **before** the mkdir and returns the ancestors that do not exist yet, deepest first. It has to run first: `Path.mkdir(parents=True, exist_ok=True)` reports nothing about what it made, and re-deriving the answer afterwards cannot tell our directory from one a concurrent writer created in between. An ancestor whose existence cannot be *decided* (a stat that raises rather than answering) is treated as already there — a directory this call cannot prove it created is not this call's to remove.
- `_unwind_absent_ancestors(created)` `rmdir`s them deepest first, stopping at the first that will not come away. Failures are swallowed because this runs on the way out of a `raise`: the caller must see the error that failed the effect, not a cleanup error standing in front of it. The `except BaseException: … raise` shape matches `custody_store.atomic_write_json`, which already unwinds its temp file the same way.
- The write and the receipt now sit inside that `try`, so `reconcile` — the other caller of `_write_effect` — is covered by the same guard, exactly as the containment refusals are.

**Named residue, not a hidden one.** The unwind stops at a directory that is not empty. So a write that *landed bytes* and then failed to receipt them still leaves the file and the directory holding it. That case is not silently fixed and is not claimed to be: undoing it means deleting artifact bytes (and, where the target already existed, bytes this function cannot restore — it holds `before_sha256`, not the prior content). That is a destructive behaviour change and an operator's call, not this repair's. The code comment at the seam says so in those terms.

Refs #169

## Verification

Red then green, in that order, on `test_custody_mission.py`:

| State | Result |
|---|---|
| new case kept, `custody_mission.py` reverted to `main` | `FAIL failed-effect-left-no-created-directory`, `FAIL failed-effect-removed-only-what-it-created` — 2 failures, suite exits 1 |
| fix restored | 0 failures, suite exits 0 |

The new case `test_failed_effect_removes_the_directories_it_created` injects the failure at `Path.write_bytes`, for the two target paths only, delegating every other write to the real method. That is the seam the issue names, and no portable filesystem trick reaches it: a read-only parent fails the **mkdir** instead, which creates nothing at all and would therefore measure the ordering that was already correct rather than the cleanup that was missing. It asserts no receipt was minted, no checkpoint landed, and `esrm/` (two levels, both created by the call) is gone — and it carries two controls, so the assertion cannot pass by over-deleting:

- a directory the caller made itself (`esrm-keep/`) is left standing while only `esrm-keep/deep/` — the level this call created — is removed;
- an effect that *does* receipt keeps the directories it made, so the unwind is not always-on.

The case is registered in `TESTS`; `_check_registry_is_complete` would otherwise let it pass silently forever.

Every step of `mission-custody-contract.yml` was run locally on this branch, all exit 0:

`test_mission_custody_jsonschema` (all green: 8 fields x 33 parity cases), `test_mission_custody`, `py_compile verify_mission_custody`, `test_custody_store`, `test_custody_mission`, `test_custody_cli`, `test_custody_gate`, `test_es173_cases`, `test_custody_hook`, `test_custody_process_proof` — 0 failures each.

`epistemic-flexibility.yml` has no paths filter, so its whole-tree readers run on this PR too. The ones that read arbitrary files were run and pass: `check_public_content.py`, `check_no_phantom_skills.py`, `check_skill_inventory.py`, `check_description_budget.py`, `check_json_artifacts.py`, `sync_skill_surfaces.py --check`, `check_skill_run_ledger.py`, `test_v6_assurance_validator.py`, `validate_v6_assurance.py`. `check_loaded_descriptions.py` exits 0 but reports `LIVE_BLOCKED: no harness capture provided` — recorded as run, not as coverage.

**Limits on that evidence.** Measured on Linux under CPython 3.12 in a container; the hosted `ubuntu-24.04` job has not yet been observed for this branch, and `contract-macos` is dispatch-only and was not run. The remaining `epistemic-flexibility` steps (the eval fixture suites, the sentinel corpus, `check_ledger_append_only.py`, which needs a base ref) were **not run here** — the diff touches no skill, eval, ledger or workflow file they read. The unwind is exercised through an injected `PermissionError`, not a real EACCES on a real filesystem.

## What is deliberately not in this PR

Seam 2 of #169 — `_link_count` and `_resolved_relpath` returning a silent `None` on a permission failure, with no disclosure surface on `resume` / `status --brief` to mirror `uncompared_scope_entries` — is untouched. It is a new disclosure surface with a CLI-visible shape, not a local repair, and it belongs in its own change. **#169 should stay open** until it lands.

## Provenance

This pull request is agent-authored. The steward session wrote this description and the assurance block below from the actual diff.

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: python plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py exits 0 with zero FAIL lines, and in particular failed-effect-left-no-created-directory and failed-effect-removed-only-what-it-created pass — both of which fail against custody_mission.py as it stands on main.
rollback_or_return_path: One commit on a branch; git revert restores the unguarded mkdir-then-write sequence. The change only removes directories this same call created moments earlier and never touches an existing directory, a file, or any custody record, so reverting needs no data recovery.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfWFqWrMnnnnZtMxCXRuyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfWFqWrMnnnnZtMxCXRuyK)_