### PR TITLE
fix(custody): validate the remaining required-text fields, share _display_safe, and gate the unresolved path spelling

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_cli.py
@@ -32,33 +32,14 @@ import os
 import sys
 from pathlib import Path
 
-from custody_mission import CustodyError, Mission, uncompared_scope_entries
+from custody_mission import (
+    CustodyError, Mission, _display_safe, uncompared_scope_entries,
+)
 from custody_store import StoreError
 
 
 def _print_status(checkpoint: dict) -> None:
     print(json.dumps(checkpoint, indent=2, sort_keys=True, ensure_ascii=True))
-
-
-def _display_safe(text: str, *, preserve_printable_syntax: bool = False) -> str:
-    """Render terminal text without allowing control-character execution.
-
-    Raw fields use full JSON string escaping (minus the surrounding quotes).
-    A completed refusal message can also contain trusted printable syntax --
-    notably the JSON-quoted ``--scope-ack`` token that the acceptor must copy
-    exactly.  In that mode preserve printable ASCII quotes and backslashes,
-    while still JSON-escaping every control and non-ASCII code point.  Both
-    modes therefore prevent forged rows and ANSI execution and remain safe
-    on an ASCII-only console.  JSON document surfaces get the same guarantees
-    from ``_print_status``'s ``ensure_ascii=True``.
-    """
-    if preserve_printable_syntax:
-        return "".join(
-            char if " " <= char <= "~"
-            else json.dumps(char, ensure_ascii=True)[1:-1]
-            for char in text
-        )
-    return json.dumps(text, ensure_ascii=True)[1:-1]
 
 
 def _read_content(args: argparse.Namespace) -> str:

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_gate.py
@@ -26,6 +26,7 @@ from custody_mission import (
     Mission,
     _approved_by_chain,
     _ascii_case_fold,
+    _display_safe,
     _normalize_relpath,
     now_utc,
 )
@@ -313,11 +314,10 @@ def _union_entries(workspace: Path, actor: str) -> tuple[list[dict], list[dict]]
             # session log must be searchable for TAMPER (the hook's contract
             # since before the union), and the union fold must not silently
             # retire that marker.
-            print(("custody gate: TAMPER/custody error reading mission "
-                   + e["name"] + " -- its guards are NOT enforced (union "
-                   "degraded): " + reason)
-                  .encode("ascii", "backslashreplace").decode("ascii"),
-                  file=sys.stderr)
+            print(_display_safe(
+                "custody gate: TAMPER/custody error reading mission "
+                + e["name"] + " -- its guards are NOT enforced (union "
+                "degraded): " + reason), file=sys.stderr)
             degraded.append({
                 "name": e["name"], "kind": type(exc).__name__,
                 "reason": reason})

--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -59,6 +59,38 @@ _RESERVED_NOTE_PREFIXES = (
 )
 
 
+def _display_safe(text: str, *, preserve_printable_syntax: bool = False) -> str:
+    """Render terminal text without allowing control-character execution.
+
+    Raw fields use full JSON string escaping (minus the surrounding quotes).
+    A completed refusal message can also contain trusted printable syntax --
+    notably the JSON-quoted ``--scope-ack`` token that the acceptor must copy
+    exactly.  In that mode preserve printable ASCII quotes and backslashes,
+    while still JSON-escaping every control and non-ASCII code point.  Both
+    modes therefore prevent forged rows and ANSI execution and remain safe
+    on an ASCII-only console.  JSON document surfaces get the same guarantees
+    from ``custody_cli._print_status``'s ``ensure_ascii=True``.
+
+    THE ONE RENDERING HELPER (es#158), so it lives in the module every
+    operator-facing surface can already import: the CLI, the gate and this
+    module's own discovery notices.  It was defined in ``custody_cli`` and
+    used only there, which left seven sibling sites escaping with
+    ``backslashreplace`` -- whose whole effect is on NON-ASCII, so a raw CR
+    and a raw ESC CSI in a filesystem-supplied directory name reached the
+    operator's terminal unchanged (es#232, measured on
+    ``Mission._discover``).  A pin in the suite keeps that retired shape out
+    of every module here, because three of the seven are best-effort logging
+    paths no fixture can schedule.
+    """
+    if preserve_printable_syntax:
+        return "".join(
+            char if " " <= char <= "~"
+            else json.dumps(char, ensure_ascii=True)[1:-1]
+            for char in text
+        )
+    return json.dumps(text, ensure_ascii=True)[1:-1]
+
+
 def _refuse_reserved_note(text: str) -> None:
     """Refuse caller text that imitates a machine-written note ON ANY LINE.
 
@@ -307,7 +339,7 @@ def _require_substantive_text(text, label: str, purpose: str) -> None:
                 more_blanks = True
     # Name the code points in ASCII. Echoing the glyphs would print the very
     # invisibility being refused, and this module's errors must survive an
-    # ASCII-only console (see custody_cli._ascii_safe).
+    # ASCII-only console (see `_display_safe`).
     shown = " ".join("U+%04X" % cp for cp in shown_blanks)
     if more_blanks:
         shown += " ..."
@@ -1293,6 +1325,16 @@ class Mission:
         _refuse_unprintable_identity(actor, "actor")
         _refuse_unprintable_identity(steward_ref, "steward_ref")
         _refuse_unprintable_identity(operator_ref, "operator_ref")
+        # The instruction is what the WHOLE mission is anchored to: scope,
+        # acceptance and every later amendment are read against it, and it is
+        # the one field `_verify_manifest` has always treated as immutable.
+        # An instruction of non-rendering code points anchors the mission to
+        # nothing a reader can recover, and unlike a bad cancel reason it can
+        # never be corrected -- the manifest is immutable from open to close.
+        # Guarded here, beside the identity checks and BEFORE the load-probe,
+        # so a refused open still touches nothing on disk (es#228).
+        _require_substantive_text(
+            instruction, "instruction", "what the mission is for")
         # PLURALITY IS LEGAL (es#173 §3): open no longer refuses on an
         # existing active mission -- the fail-open decoy is removed not by
         # handling MultipleActiveMissions better but by making the state
@@ -1518,10 +1560,9 @@ class Mission:
                         skipped.append({"name": mission_dir.name,
                                         "kind": "EpochSkew",
                                         "reason": reason})
-                        print(("custody: skipping mission dir from a NEWER "
-                               "epoch " + reason)
-                              .encode("ascii", "backslashreplace")
-                              .decode("ascii"), file=sys.stderr)
+                        print(_display_safe(
+                            "custody: skipping mission dir from a NEWER "
+                            "epoch " + reason), file=sys.stderr)
                         continue
                     except (StoreError, ValueError, TypeError, OSError):
                         pass   # ordinary damage: the name verdict below owns it
@@ -1543,10 +1584,9 @@ class Mission:
                     skipped.append({"name": mission_dir.name,
                                     "kind": "IllegalMissionId",
                                     "reason": reason})
-                    print(("custody: skipping unaddressable mission dir "
-                           + reason)
-                          .encode("ascii", "backslashreplace").decode("ascii"),
-                          file=sys.stderr)
+                    print(_display_safe(
+                        "custody: skipping unaddressable mission dir "
+                        + reason), file=sys.stderr)
                     continue
                 degradable: tuple = (StoreError, ValueError, TypeError)
                 if degrade_on_oserror:
@@ -1574,9 +1614,9 @@ class Mission:
                     skipped.append({"name": mission_dir.name,
                                     "kind": type(exc).__name__,
                                     "reason": reason})
-                    print(("custody: skipping unreadable mission dir " + reason)
-                          .encode("ascii", "backslashreplace").decode("ascii"),
-                          file=sys.stderr)
+                    print(_display_safe(
+                        "custody: skipping unreadable mission dir " + reason),
+                        file=sys.stderr)
                     continue
                 if latest["status"] not in ("completed", "cancelled"):
                     active.append({"name": mission_dir.name,
@@ -2342,12 +2382,11 @@ class Mission:
                           encoding="utf-8") as handle:
                     handle.write(line + "\n")
             except Exception as exc:  # noqa: BLE001
-                print(("custody: sibling-touch append failed for "
-                       f"{entry['name']} ({type(exc).__name__}: {exc}); "
-                       "the effect stands -- detection falls back to the "
-                       "sibling's resume-time receipt scan")
-                      .encode("ascii", "backslashreplace").decode("ascii"),
-                      file=sys.stderr)
+                print(_display_safe(
+                    "custody: sibling-touch append failed for "
+                    f"{entry['name']} ({type(exc).__name__}: {exc}); "
+                    "the effect stands -- detection falls back to the "
+                    "sibling's resume-time receipt scan"), file=sys.stderr)
 
     def _log_effect_matches(self, matches: list[dict],
                             artifact_relpath: str) -> None:
@@ -2639,6 +2678,11 @@ class Mission:
         self._verify_manifest(latest)
         if latest["status"] not in _OPEN_STATES:
             raise IllegalTransition(f"cannot note: status is {latest['status']!r}")
+        # A note is the mission's append-only narrative, and a checkpoint is
+        # permanent: a blank-shaped one spends a revision recording nothing an
+        # auditor could ever read back (es#228).
+        _require_substantive_text(
+            text, "note text", "what this checkpoint records")
         _refuse_reserved_note(text)
         new = self._write_next(latest, path, status=latest["status"], note=text)
         return new["revision"]
@@ -2652,6 +2696,12 @@ class Mission:
         # by `status`/`resume` and lives in the same checkpoint JSON, so an
         # auditor grepping the chain for a machine-note prefix hits it just the
         # same. Same guard, same reason.
+        #
+        # And the frontier is what a resuming session reads to learn where the
+        # work stands; blank-shaped, it REPLACES a readable frontier with
+        # nothing, which is worse than leaving the old one in place (es#228).
+        _require_substantive_text(
+            text, "frontier text", "what remains to be done")
         _refuse_reserved_note(text)
         new = self._write_next(latest, path, status=latest["status"], frontier=text)
         return new["revision"]
@@ -2804,10 +2854,10 @@ class Mission:
             try:
                 receipts = store.load_receipts()
             except Exception as exc:  # noqa: BLE001
-                print(("custody: sibling receipt scan skipped "
-                       f"{mission_dir.name} ({type(exc).__name__}: {exc})")
-                      .encode("ascii", "backslashreplace").decode("ascii"),
-                      file=sys.stderr)
+                print(_display_safe(
+                    "custody: sibling receipt scan skipped "
+                    f"{mission_dir.name} ({type(exc).__name__}: {exc})"),
+                    file=sys.stderr)
                 continue
             # CHAIN ADMISSION. `load_receipts` is a bare `receipts/*.json`
             # glob, so this scan used to accept evidence the sibling's own
@@ -2821,11 +2871,10 @@ class Mission:
             try:
                 sib_latest, _ = store.load_latest()
             except Exception as exc:  # noqa: BLE001
-                print(("custody: sibling receipt scan skipped "
-                       f"{mission_dir.name} (chain unreadable: "
-                       f"{type(exc).__name__}: {exc})")
-                      .encode("ascii", "backslashreplace").decode("ascii"),
-                      file=sys.stderr)
+                print(_display_safe(
+                    "custody: sibling receipt scan skipped "
+                    f"{mission_dir.name} (chain unreadable: "
+                    f"{type(exc).__name__}: {exc})"), file=sys.stderr)
                 continue
             admitted = set(sib_latest.get("receipt_ids") or ())
             minted_paths = [
@@ -3667,6 +3716,16 @@ class Mission:
         self._verify_manifest(latest)
         if verdict not in VERDICTS:
             raise CustodyError(f"unknown verdict {verdict!r}")
+        # THE SHARP ONE (es#228). A PASS SEALS the mission `completed`, and
+        # the reason is hash-chained into the acceptance-verdict record as the
+        # acceptor's account of why. Blank-shaped, it closed the mission with
+        # an acceptance no reader could recover and no transition could
+        # revisit -- the defect es#213 closed on `cancel`, landing on the
+        # transition that matters more. FAIL and the conditional verdicts take
+        # the same rule: a FAIL reason is what `clear-fail` is later matched
+        # against, so an unreadable one wedges the repair path too.
+        _require_substantive_text(
+            reason, "verdict reason", "why the verdict was reached")
         _refuse_reserved_note(reason)
         if verdict in ("PASS", "FAIL"):
             if latest["status"] != "verifying":

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py
@@ -657,6 +657,180 @@ def test_cancel_accepts_substantive_reasons() -> None:
                   ("cancelled: " + reason) in record["state"]["notes"])
 
 
+# es#228: the four required-text fields the blank-text class was NEVER closed
+# on. es#213/es#241 guarded `cancel --reason`, `amend --text` and
+# `authorize-sibling --text`; these four kept `accept --reason` able to seal a
+# mission COMPLETED with an acceptance reason no reader can recover, and
+# `open --instruction` able to anchor a whole mission to nothing.
+#
+# One row per category axis, the same axes the cancel table proves in full --
+# the per-code-point table lives there, which is where the class was found.
+_REQUIRED_TEXT_AXES = (
+    ("ascii-whitespace", 0x0020),
+    ("unicode-whitespace", 0x00A0),
+    ("zero-width", 0x200B),
+    ("rtl-and-bidi", 0x202E),
+    ("control", 0x0007),
+    ("blank-glyph", 0x3164),
+    ("zero-advance-mark", 0xFE0F),
+)
+
+
+def _blank_field_probe(ws: Path, field: str, text: str) -> tuple:
+    """Drive ONE required-text field with `text`, from a fresh workspace.
+
+    Returns (result, checkpoints dir). Every field is reached through the
+    transition that actually needs it, so a refusal is measured where an
+    operator would meet it.
+    """
+    mission_id = "req-" + field
+    checkpoints = ws / "missions" / mission_id / "checkpoints"
+    if field == "instruction":
+        return run("open", "--workspace", str(ws), "--actor", "agent:worker",
+                   "--mission-id", mission_id, "--instruction", text,
+                   "--operator", "operator:zach",
+                   "--steward", "agent:worker"), checkpoints
+    open_cli(ws, mission_id, "anchor the mission")
+    run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+    if field == "note":
+        return run("note", "--workspace", str(ws), "--actor", "agent:worker",
+                   "--text", text), checkpoints
+    if field == "frontier":
+        return run("frontier", "--workspace", str(ws),
+                   "--actor", "agent:worker", "--text", text), checkpoints
+    run("begin-verification", "--workspace", str(ws), "--actor", "agent:worker")
+    return run("accept", "--workspace", str(ws), "--actor", "agent:acceptor",
+               "--verdict", "PASS", "--acceptor", "agent:acceptor",
+               "--tier", "declared-role-separation",
+               "--reason", text), checkpoints
+
+
+# field -> (label the refusal must name, checkpoints present before the call)
+_REQUIRED_TEXT_FIELDS = (
+    ("instruction", "instruction required", 0),
+    ("note", "note text required", 2),
+    ("frontier", "frontier text required", 2),
+    ("accept", "verdict reason required", 3),
+)
+
+
+def test_every_required_text_field_refuses_a_blank_shaped_value() -> None:
+    """es#228: the blank-text class was closed on three call sites, not seven.
+
+    Measured before this fix, one U+200B per field: `open --instruction`,
+    `note --text`, `frontier --text` and `accept --reason` all exited 0.
+    `accept` is the sharp one -- it sealed the mission COMPLETED with
+    `PASS: <ZWSP>`, an acceptance reason no reader could ever recover, which
+    is the defect es#213 fixed on the cancel path landing on the transition
+    that matters more. `open --instruction` is next: the instruction is what
+    the whole mission is anchored to.
+
+    Each row proves exit 2, a diagnosis naming the field, no traceback, and
+    no checkpoint appended -- a refused transition writes nothing.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for field, names, before in _REQUIRED_TEXT_FIELDS:
+            for i, (axis, cp) in enumerate(_REQUIRED_TEXT_AXES):
+                ws = root / ("%s-%02d" % (field, i))
+                ws.mkdir(parents=True)
+                r, checkpoints = _blank_field_probe(ws, field, chr(cp))
+                tag = "%s-%s-U+%04X" % (field, axis, cp)
+                check("required-text-blank-%s-exit-2" % tag,
+                      r.returncode == 2)
+                check("required-text-blank-%s-names-the-field" % tag,
+                      names in r.stderr)
+                check("required-text-blank-%s-names-codepoint" % tag,
+                      ("U+%04X" % cp) in r.stderr)
+                check("required-text-blank-%s-no-traceback" % tag,
+                      "Traceback" not in r.stderr)
+                check("required-text-blank-%s-stderr-is-ascii" % tag,
+                      r.stderr.isascii())
+                check("required-text-blank-%s-no-checkpoint-write" % tag,
+                      len(sorted(checkpoints.glob("*.json"))
+                          if checkpoints.is_dir() else []) == before)
+
+
+def _latest_checkpoint(ws: Path, mission_id: str) -> dict:
+    """The tail checkpoint, read off disk.
+
+    Deliberately not `status`: a COMPLETED mission is no longer active, so
+    the unbound `status` verb refuses it -- and the post-state this pin has
+    to read is exactly the completed one.
+    """
+    paths = sorted((ws / "missions" / mission_id / "checkpoints").glob("*.json"))
+    return json.loads(paths[-1].read_text(encoding="utf-8"))
+
+
+def test_blank_accept_reason_cannot_seal_a_mission_completed() -> None:
+    """The post-state es#228 named, pinned on its own.
+
+    Exit 2 is not the whole claim: the sharp case is that the mission stays
+    OPEN and can still be accepted with a reason a reader can recover. A
+    refusal that nonetheless completed the mission would satisfy every check
+    above and leave the defect intact.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp) / "ws"
+        ws.mkdir(parents=True)
+        open_cli(ws, "seal", "anchor the mission")
+        run("approve", "--workspace", str(ws), "--actor", "agent:worker")
+        run("begin-verification", "--workspace", str(ws),
+            "--actor", "agent:worker")
+        blank = run("accept", "--workspace", str(ws),
+                    "--actor", "agent:acceptor", "--verdict", "PASS",
+                    "--acceptor", "agent:acceptor",
+                    "--tier", "declared-role-separation", "--reason", "\u200b")
+        check("blank-accept-refused", blank.returncode == 2)
+        check("blank-accept-left-the-mission-verifying",
+              _latest_checkpoint(ws, "seal")["status"] == "verifying")
+        verdicts = ws / "missions" / "seal" / "verdicts"
+        check("blank-accept-minted-no-verdict-record",
+              not verdicts.is_dir() or not list(verdicts.glob("*.json")))
+
+        # The transition is refused, not WEDGED: the acceptor can still close
+        # the mission with a reason a reader can recover.
+        good = run("accept", "--workspace", str(ws),
+                   "--actor", "agent:acceptor", "--verdict", "PASS",
+                   "--acceptor", "agent:acceptor",
+                   "--tier", "declared-role-separation",
+                   "--reason", "reviewed end-to-end; receipts match")
+        check("substantive-accept-still-completes", good.returncode == 0)
+        check("substantive-accept-seals-completed",
+              _latest_checkpoint(ws, "seal")["status"] == "completed")
+
+
+def test_required_text_fields_accept_substantive_values() -> None:
+    """Over-rejection is this guard's OWN failure mode -- pin it per field.
+
+    A refused-but-legitimate value does not merely annoy: a mission whose
+    instruction is refused never opens, and one whose acceptance reason is
+    refused can never be closed. The load-bearing rows are the tail, where
+    real text merely CONTAINS a zero-width, bidi or combining code point --
+    a guard written as "refuse if ANY character is Cf/Mn" would ship this
+    very defect pointed the other way.
+    """
+    accepted = (
+        ("ascii", "ship the CLI"),
+        ("single-punctuation", "."),
+        ("cjk", "\u4efb\u52a1\u5df2\u5b8c\u6210"),
+        ("hebrew-with-niqqud", "\u05d1\u05b0\u05d5\u05d8\u05dc"),
+        ("emoji-with-variation-selector", "done \u2764\ufe0f"),
+        ("contains-zwsp", "done\u200bend-to-end"),
+        ("contains-rlm", "closed\u200f by operator"),
+        ("padded-with-nbsp", "\u00a0done end-to-end\u00a0"),
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        for field, _names, _before in _REQUIRED_TEXT_FIELDS:
+            for i, (label, text) in enumerate(accepted):
+                ws = root / ("ok-%s-%02d" % (field, i))
+                ws.mkdir(parents=True)
+                r, _ = _blank_field_probe(ws, field, text)
+                check("required-text-substantive-%s-%s-exit-0"
+                      % (field, label), r.returncode == 0)
+
+
 def test_amend_refuses_blank_shaped_text() -> None:
     """`amend --text` carries the same guard idiom, so it carries the same hole.
 
@@ -1597,6 +1771,9 @@ TESTS = [
     test_cancel_refuses_blank_shaped_reason_files,
     test_cancel_accepts_substantive_reasons,
     test_amend_refuses_blank_shaped_text,
+    test_every_required_text_field_refuses_a_blank_shaped_value,
+    test_blank_accept_reason_cannot_seal_a_mission_completed,
+    test_required_text_fields_accept_substantive_values,
     test_open_stop_rules_and_acceptable_costs,
     test_open_without_stop_rules_yields_empty_lists,
     test_success_output_confirms_the_write,

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_gate.py
@@ -15,7 +15,7 @@ ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT))
 
 from custody_gate import _guard_norm_path, evaluate, run_gate  # noqa: E402
-from custody_mission import Mission  # noqa: E402
+from custody_mission import CustodyError, Mission  # noqa: E402
 from custody_store import StoreError, sha256_bytes, sha256_file  # noqa: E402
 
 FAILURES: list[str] = []
@@ -840,6 +840,62 @@ def test_verification_reread_oserror_degrades_the_union() -> None:
         check("reread-control-still-blocks", verdict["decision"] == "block")
         check("reread-control-claims-no-degradation",
               "DEGRADED" not in verdict["reason"].upper())
+
+
+def test_union_degradation_stderr_escapes_control_characters() -> None:
+    """es#232, following es#158: the union's TAMPER line renders through the
+    shared helper too.
+
+    `_union_entries` interpolates the mission name and the VERIFYING re-read's
+    exception, and escaped them with `.encode("ascii", "backslashreplace")` --
+    an escaper whose whole effect is on non-ASCII, so every C0 control passed
+    through. A raw ESC CSI on this line is a sequence the operator's terminal
+    executes, and a raw CR forges a second row in a log the hook's contract
+    says must stay greppable for TAMPER.
+
+    The re-read is failed deliberately. This arm exists for a tamper landing
+    BETWEEN discovery and the verification re-read -- an OSError naming the
+    operator's own workspace path, or a store error quoting a field published
+    in that window -- which no single-threaded fixture can schedule. What is
+    measured is what the arm PRINTS from an exception it is handed, and that
+    is the whole of the defect.
+    """
+    hostile = "ev\ril\x1b[31m\u009bFORGED-ROW"
+    with tempfile.TemporaryDirectory() as tmp:
+        ws = Path(tmp)
+        mission = Mission.open(ws, "m-degraded", "i", "operator:test",
+                               "agent:test", actor="agent:test",
+                               guard_mode="enforce", actuator_guards=GUARDS)
+        mission.approve()
+
+        def hostile_status(self):
+            raise CustodyError(hostile)
+
+        real_status = Mission.status
+        Mission.status = hostile_status
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(buf):
+                verdict = run_gate(
+                    ws, {"tool_name": "Bash", "command": "curl :7878/api",
+                         "file_path": None}, actor="hook:custody-gate")
+        finally:
+            Mission.status = real_status
+        printed = buf.getvalue()
+
+        check("union-degraded-control-reached-the-tamper-arm",
+              "TAMPER" in printed)
+        check("union-degraded-control-still-degrades",
+              verdict["decision"] == "allow"
+              and "NOT enforced" in verdict["reason"])
+        for label, raw in (("cr", "\r"), ("esc", "\x1b"), ("c1-csi", "\u009b")):
+            check("union-degraded-control-no-raw-%s-on-stderr" % label,
+                  raw not in printed)
+        check("union-degraded-control-stderr-is-ascii", printed.isascii())
+        for label, escaped in (("cr", "\\r"), ("esc", "\\u001b"),
+                               ("c1-csi", "\\u009b")):
+            check("union-degraded-control-escapes-%s" % label,
+                  escaped in printed)
 
 
 if __name__ == "__main__":

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_hook.py
@@ -1652,6 +1652,69 @@ def test_cursor_cli_project_output_stays_out_of_version_control() -> None:
               "no-rm" not in blocked.stdout + blocked.stderr)
 
 
+def test_cursor_cli_symlinked_project_dir_still_refuses() -> None:
+    """A SYMLINKED `.cursor` must not walk around the project-hooks refusal
+    (es#235, from Codex es#216 thread 3866510301).
+
+    The gate compared the REALPATH-resolved destination, so `.cursor ->
+    cursor-local` lost the `.cursor` component before the comparison ran:
+    the refusal never fired, the renderer wrote `cursor-local/hooks.json`,
+    and git left it untracked AND unignored -- committable, and still
+    auto-loaded by Cursor through `.cursor/hooks.json`.  Measured on the
+    build that filed this: exit 0 with the file written, against exit 2 for
+    an identical repo whose `.cursor` is a real directory.
+
+    Cursor reads the LOGICAL spelling and git indexes the RESOLVED one, so
+    either spelling naming `.cursor/hooks.json` is the auto-loaded shape.
+    The resolved leg keeps its own coverage in the test above -- a `.cursor`
+    reached through a symlinked PARENT only carries the component after
+    resolution -- so this pin adds the logical leg without retiring it.
+    """
+    if os.name == "nt":
+        print("  skip symlinked-.cursor pin (POSIX-scoped: a directory "
+              "symlink needs privilege on NT)")
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "symlinked-repo"
+        _git_init_repo(repo)
+        (repo / "cursor-local").mkdir()
+        try:
+            (repo / ".cursor").symlink_to("cursor-local",
+                                          target_is_directory=True)
+        except OSError:
+            print("  skip symlinked-.cursor pin (no symlink support here)")
+            return
+        destination = repo / ".cursor" / "hooks.json"
+        resolved = repo / "cursor-local" / "hooks.json"
+
+        refused = subprocess.run(
+            [sys.executable, str(CURSOR_CLI_RENDERER),
+             "--output", str(destination)],
+            cwd=str(repo), capture_output=True, text=True)
+        check("cursor-cli-symlinked-project-output-refused",
+              refused.returncode == 2)
+        check("cursor-cli-symlinked-refusal-wrote-nothing",
+              not resolved.exists() and not destination.exists())
+        check("cursor-cli-symlinked-refusal-names-gitignore",
+              ".gitignore" in refused.stderr)
+        check("cursor-cli-symlinked-refusal-names-project-hooks",
+              "project-hooks" in refused.stderr)
+
+        # ---- the documented escape still works through the link ----
+        # Ignoring the path git actually indexes is what makes the file
+        # uncommittable, so the gate must stand down once it is ignored --
+        # a refusal nothing can discharge would wedge the install.
+        (repo / ".gitignore").write_text("cursor-local/\n", encoding="utf-8")
+        rendered = subprocess.run(
+            [sys.executable, str(CURSOR_CLI_RENDERER),
+             "--output", str(destination)],
+            cwd=str(repo), capture_output=True, text=True)
+        check("cursor-cli-ignored-symlinked-project-output-renders",
+              rendered.returncode == 0)
+        check("cursor-cli-ignored-symlinked-render-wrote-the-config",
+              resolved.is_file())
+
+
 def test_cursor_cli_readme_marks_project_output_machine_local() -> None:
     """The README's project form must carry the do-not-commit instruction
     and the renderer's matcher-coverage refusal, pinned so neither sentence

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -1087,6 +1087,110 @@ def test_unreadable_root_is_never_reported_as_nothing_to_enforce(
           and "NOT established as empty" not in out_done)
 
 
+# es#232: one control-permissive payload, reused by the pins below. A raw CR
+# forges a second row in a line-oriented operator log; a raw ESC CSI and the
+# 8-bit C1 CSI (U+009B) are sequences a terminal EXECUTES. All three are C0/C1
+# controls, which is exactly the class `backslashreplace` lets through: it
+# converts non-ASCII and nothing else. Written as escapes so this source file
+# stays pure ASCII, the way the other control-character fixtures here are.
+_CONTROL_PERMISSIVE_NAME = "ev\ril\x1b[31m\u009bFORGED-ROW"
+
+
+def test_discovery_stderr_escapes_control_characters(workspace: Path) -> None:
+    """es#232, following es#158: EVERY operator-facing surface renders
+    through the ONE helper, not just the CLI's.
+
+    `_discover`'s three skip notices interpolate a filesystem-supplied
+    directory name and a store-supplied exception message, and they escaped
+    with `.encode("ascii", "backslashreplace")` -- which converts non-ASCII
+    and NOTHING else, so a raw CR and a raw ESC CSI walked straight onto the
+    operator's terminal. Measured before the fix, read through `cat -v`:
+    `custody: skipping unaddressable mission dir ev^Mil^[[31m...`.
+
+    All three sites are driven from real stores, and the payload reaches the
+    third through the EXCEPTION rather than the directory name, because a
+    legal mission id passes `_ID_RE` and the exception is the channel that
+    stays open behind it.
+    """
+    missions = workspace / "missions"
+    # The live mission is opened FIRST: `open` refuses beside an unreadable
+    # sibling, so the hostile dirs cannot exist yet.
+    live = open_mission(workspace, "m-hostile-field", "Live.")
+    live.approve()
+    hostile = _CONTROL_PERMISSIVE_NAME
+    try:
+        # (a) an epoch-CLAIMING store under an illegal, hostile name.
+        staged = open_mission(workspace / "staging", "m-skew", "Skewed.")
+        staged.approve()
+        skew_dir = missions / ("skew-" + hostile)
+        shutil.move(str(workspace / "staging" / "missions" / "m-skew"),
+                    str(skew_dir))
+        shutil.rmtree(workspace / "staging", ignore_errors=True)
+        tail = sorted((skew_dir / "checkpoints").glob("*.json"))[-1]
+        record = json.loads(tail.read_text(encoding="utf-8"))
+        record["record"] = "checkpoint@2"
+        tail.write_text(json.dumps(record, indent=1, sort_keys=True),
+                        encoding="utf-8")
+
+        # (b) an ordinary corrupt store under an illegal, hostile name.
+        corrupt = missions / ("bad-" + hostile) / "checkpoints"
+        corrupt.mkdir(parents=True)
+        (corrupt / "r00000001.json").write_text("{", encoding="utf-8")
+    except OSError:
+        print("  skip discovery-control-escape pin (this filesystem refuses "
+              "a control-character directory name)")
+        return
+
+    # (c) a LEGAL mission id whose store-supplied error quotes the payload.
+    live_tail = sorted(
+        (missions / "m-hostile-field" / "checkpoints").glob("*.json"))[-1]
+    record = json.loads(live_tail.read_text(encoding="utf-8"))
+    record["manifest"][hostile] = "x"
+    live_tail.write_text(json.dumps(record, indent=1, sort_keys=True) + "\n",
+                         encoding="utf-8")
+
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        _, skipped = Mission._discover(workspace, degrade_on_oserror=True)
+    printed = buf.getvalue()
+
+    check("discovery-control-exercises-all-three-skip-sites",
+          {"EpochSkew", "IllegalMissionId", "ChainBroken"}
+          <= {s["kind"] for s in skipped})
+    for label, raw in (("cr", "\r"), ("esc", "\x1b"), ("c1-csi", "\u009b")):
+        check("discovery-control-no-raw-%s-on-stderr" % label,
+              raw not in printed)
+    check("discovery-control-stderr-is-ascii", printed.isascii())
+    for label, escaped in (("cr", "\\r"), ("esc", "\\u001b"),
+                           ("c1-csi", "\\u009b")):
+        check("discovery-control-escapes-%s" % label, escaped in printed)
+    # Escaping is a DISPLAY act. The skip RECORDS keep the name that is
+    # actually on disk, because `--acknowledge-unreadable <dir>` has to name
+    # it -- an escaped name there would be an acknowledgement matching
+    # nothing, which `open` refuses as a typo.
+    check("discovery-control-skip-records-keep-the-raw-name",
+          any(hostile in s["name"] for s in skipped))
+
+
+def test_no_contract_module_keeps_the_control_permissive_escaper(
+        _ws: Path) -> None:
+    """es#158 asked for ONE rendering helper, not a fix per call site.
+
+    es#215 moved the CLI onto `_display_safe` and left seven siblings on
+    `.encode("ascii", "backslashreplace")`, an escaper whose whole effect is
+    on NON-ASCII: every C0 and C1 control it was reached for passed through
+    unchanged. Three of those seven are best-effort logging paths that no
+    single-threaded fixture can schedule, so the retired shape is pinned out
+    of the modules directly -- otherwise the next surface reintroduces it and
+    the behavioural pins above stay green while it does.
+    """
+    retired = '.encode("ascii", "backslashreplace")'
+    for name in ("custody_mission.py", "custody_gate.py", "custody_cli.py",
+                 "custody_hook.py", "custody_store.py", "census_missions.py"):
+        check("no-control-permissive-escaper-in-%s" % name,
+              retired not in (ROOT / name).read_text(encoding="utf-8"))
+
+
 def _skew_a_store_into(workspace: Path, name: str) -> None:
     """Move a mission opened elsewhere in beside an existing one and relabel
     its tail `checkpoint@2`, so the root holds a store this reader must skip.
@@ -6594,6 +6698,8 @@ TESTS = [
     test_census_does_not_count_unapproved_guards_as_armed,
     test_census_reports_partial_coverage_when_a_probe_fails,
     test_census_orphan_probe_failure_is_partial_not_absence,
+    test_discovery_stderr_escapes_control_characters,
+    test_no_contract_module_keeps_the_control_permissive_escaper,
 ]
 
 

--- a/plugins/epistemic-skills/hooks/render_cursor_cli_hooks.py
+++ b/plugins/epistemic-skills/hooks/render_cursor_cli_hooks.py
@@ -316,6 +316,14 @@ def render() -> dict:
     return template
 
 
+def _names_project_hooks(path: str) -> bool:
+    """True when `path`'s last two components are `.cursor/hooks.json`."""
+    parts = Path(path).parts
+    return (len(parts) >= 2
+            and parts[-2] == os.path.normcase(".cursor")
+            and parts[-1] == os.path.normcase("hooks.json"))
+
+
 def _git_probe(args: list[str], cwd: Path) -> subprocess.CompletedProcess | None:
     """Run a read-only git query; None when git itself cannot run."""
     try:
@@ -415,10 +423,19 @@ def _version_control_gate(destination: Path) -> tuple[str | None, str | None]:
     # repo/packages/app) loads packages/app/.cursor/hooks.json as the
     # project hooks file.  The destination is already known to sit inside
     # this worktree, so the final two segments decide.
-    destination_parts = Path(norm(str(destination))).parts
-    if len(destination_parts) >= 2 and \
-            destination_parts[-2] == os.path.normcase(".cursor") and \
-            destination_parts[-1] == os.path.normcase("hooks.json"):
+    #
+    # BOTH SPELLINGS decide, because they can disagree.  `norm` resolves
+    # symlinks, so a symlinked `.cursor` (`.cursor -> cursor-local`) lost
+    # the very component this comparison reads: the refusal never fired,
+    # the renderer wrote a committable `cursor-local/hooks.json`, and
+    # Cursor loaded it all the same through `.cursor/hooks.json` (Codex
+    # es#216 thread 3866510301).  The LOGICAL spelling is what Cursor
+    # reads; the RESOLVED one is what git indexes, and a `.cursor` reached
+    # through a symlinked PARENT only carries the component once resolved.
+    # Neither spelling subsumes the other, so either match refuses.
+    logical = os.path.normcase(os.path.normpath(str(destination)))
+    if _names_project_hooks(norm(str(destination))) or \
+            _names_project_hooks(logical):
         return (
             f"{destination} is a project-hooks file Cursor auto-loads "
             f"(.cursor/hooks.json at {rel_posix} in the worktree at "


### PR DESCRIPTION
Three defects in one surface -- the custody CLI's required-text validation,
its display-rendering helper, and the Cursor renderer's version-control gate.
Each was measured on `8620204` before a line was written, and each carries a
RED-first regression that was seen failing and then passing.

The repository has no `.github/PULL_REQUEST_TEMPLATE.md`; this body follows
the structure the recent custody commits use -- what changed and why, the
measurement, and red-then-green.

## Refs #228 -- four required-text fields still accept a blank-shaped value

`_require_substantive_text` existed and was wired to THREE call sites
(`cancel`, `amend_authority`, `authorize_sibling` -- es#213, then es#241,
whose own commit message scopes itself to those three). The remaining four
required-text fields kept the class open. Reproduced through `custody_cli.py`
as a subprocess with a single U+200B:

```
open --instruction   <ZWSP>   exit=0
note --text          <ZWSP>   exit=0
frontier --text      <ZWSP>   exit=0
accept --reason      <ZWSP>   exit=0   -> status: completed
```

Post-state of that run: `authority.instruction == "<ZWSP>"`, and the final
checkpoint carries `status: completed` with the note `PASS: <ZWSP>`. That is
the sharp case -- the mission is sealed COMPLETE with an acceptance reason no
reader can recover and no transition can revisit. `open --instruction` is
next: the manifest is immutable from open to close, so an instruction
anchored to nothing can never be corrected afterwards.

**Changed:** `Mission.open`, `Mission.note`, `Mission.set_frontier` and
`Mission.record_verdict` now call the same shared predicate. `open` guards
beside the identity checks and BEFORE the load-probe, so a refused open still
touches nothing on disk. No new guard was written -- this is a question of
which fields are required to be readable.

**Over-rejection is pinned per field**, because refusing a legitimate value
wedges the transition and is this guard's own failure mode: a mission whose
instruction is refused never opens, and one whose acceptance reason is refused
can never be closed. The rows include CJK, Hebrew with niqqud, an emoji with a
variation selector, and real text merely *containing* a ZWSP, an RLM or NBSP
padding.

## Refs #232 -- seven sibling control-permissive escaper sites

es#158 asked for the control-character class to be fixed at ONE rendering
helper. es#215 closed it in `custody_cli.py` only, leaving seven sites on
`.encode("ascii", "backslashreplace")` -- an escaper whose whole effect is on
NON-ASCII, so every C0 control it was reached for passed straight through.
Six were in `custody_mission.py`, one in `custody_gate.py`; the issue counted
six, and the extra one is a site added on 2026-09-02 in the same shape.

Driving `Mission._discover` over
`missions/ev<CR>il<ESC>[31mFORGED-ROW/checkpoints/r00000001.json`, read
through `cat -v`:

```
custody: skipping unaddressable mission dir ev^Mil^[[31mFORGED-ROW: IllegalMissionId: ...
```

Raw CR (forges a row in a line-oriented operator log) and raw ESC CSI (a
sequence the terminal executes), both from a filesystem-supplied name.

**Changed:** `_display_safe` moves from `custody_cli.py` to
`custody_mission.py` -- the module the CLI and the gate already import, so no
new module and no import cycle -- and all seven sites render through it.
`custody_cli.py` imports the name, so its six existing call sites are
untouched. Behaviour is otherwise unchanged: the skip RECORDS keep the on-disk
name, because `--acknowledge-unreadable <dir>` has to name the directory that
actually exists, and an escaped name there would be an acknowledgement
matching nothing.

Three of the seven are best-effort logging paths no single-threaded fixture
can schedule, so alongside the behavioural pins there is a module pin that
keeps the retired escaper shape out of every contract module. It fails today
and passes at head.

## Refs #235 -- a symlinked `.cursor` bypasses the project-hooks check

`_version_control_gate` compared the REALPATH-resolved destination against
`.cursor` / `hooks.json`, so a symlinked `.cursor` lost the component before
the comparison ran. Measured end-to-end in a git worktree with
`ln -s cursor-local .cursor`:

```
$ python3 render_cursor_cli_hooks.py --output .cursor/hooks.json
cursor-cli-hook note: ... sits inside the git worktree ... do not commit it
EXIT=0
$ git status --porcelain
?? .cursor
?? cursor-local/
```

`cursor-local/hooks.json` was written, untracked AND unignored -- committable,
and still auto-loaded by Cursor through `.cursor/hooks.json`. The identical
invocation against a real `.cursor` directory exits 2.

**Changed:** the last-two-components test is factored into
`_names_project_hooks` and applied to BOTH spellings. Cursor reads the
LOGICAL path; git indexes the RESOLVED one; and a `.cursor` reached through a
symlinked PARENT only carries the component after resolution -- neither
spelling subsumes the other, so either match refuses. The documented escape
still works: ignore the path git actually indexes and the gate stands down,
which the new case pins so the refusal cannot become one nothing can
discharge.

## Verification -- red then green, in that order

| issue | fix reverted, cases kept | fix restored |
|---|---|---|
| #228 | 116 failures across the three new CLI cases (every field x every axis; `substantive-accept-still-completes` fails because the blank accept had already sealed the mission) | 0 |
| #232 | `discovery-control-no-raw-cr-on-stderr`, `-no-raw-esc-`, `-escapes-esc`, `-escapes-c1-csi`; `union-degraded-control-{no-raw-cr,no-raw-esc,escapes-cr,escapes-esc,escapes-c1-csi}`; `no-control-permissive-escaper-in-custody_mission.py` and `-custody_gate.py` | 0 |
| #235 | `cursor-cli-symlinked-project-output-refused` and four siblings | 0 |

Every step of the `mission-custody-contract` job, run locally on this branch
(ubuntu container, CPython 3.11; CI runs 3.12):

```
test_mission_custody_jsonschema.py          rc=0  all green
test_mission_custody.py                     rc=0  0 failures
py_compile verify_mission_custody.py        rc=0
test_custody_store.py                       rc=0  0 failures
test_custody_mission.py                     rc=0  0 failures
test_custody_cli.py                         rc=0  0 failures
test_custody_gate.py                        rc=0  all green
test_es173_cases.py                         rc=0  0 failures
test_custody_hook.py                        rc=0  all green (200 ok)
test_custody_process_proof.py               rc=0  0 failures
```

The whole-tree gates the `epistemic-flexibility` job runs on every PR are
green too: `check_public_content.py`, `check_json_artifacts.py`,
`check_pin_tags.py`, `test_check_dco.py`, `check_skill_inventory.py`,
`sync_skill_surfaces.py --check`, `check_no_phantom_skills.py`,
`check_description_budget.py`, `check_loaded_descriptions.py`,
`check_skill_run_ledger.py`.

**Not run here:** the `contract-macos` job (dispatch-only) and any 3.12
execution -- this container has 3.11. The repository has no lint or type
configuration, so none was run.

Refs #228
Refs #232
Refs #235

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: python3 plugins/epistemic-skills/contracts/mission-custody/test_custody_cli.py, test_custody_mission.py, test_custody_gate.py and test_custody_hook.py all exit 0 with zero FAIL lines, and each of the new cases (required-text-blank-*, discovery-control-*, union-degraded-control-*, no-control-permissive-escaper-in-*, cursor-cli-symlinked-*) fails when its production change alone is reverted
rollback_or_return_path: git revert the merge commit; the change is confined to five files under plugins/epistemic-skills, adds no module and no persisted state, and every custody store written before or after it is read identically
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfWFqWrMnnnnZtMxCXRuyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfWFqWrMnnnnZtMxCXRuyK)_