### PR TITLE
fix(seams): unwind the ancestors a PARTIAL mkdir already created

### DIFF
--- a/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/custody_mission.py
@@ -476,10 +476,30 @@ def _unwind_absent_ancestors(created: list[Path]) -> None:
     stops too. Removing a directory somebody else is now using would be a
     worse mutation than the one being undone.
 
+    A level that IS NOT THERE is skipped rather than treated as a refusal.
+    `mkdir(parents=True)` builds the chain one level at a time and can fail
+    partway, so the deepest recorded levels may never have been created at
+    all -- and a level that does not exist holds nothing, shelters nobody's
+    data, and must not stop the unwind of the levels BELOW it that this call
+    really did create. Stopping there was the whole residue: a component
+    longer than NAME_MAX left `aa/` and `aa/bb/` standing because the rmdir
+    of the too-long name raised first. The ENOTEMPTY guarantee is unchanged
+    and is enforced by `rmdir` itself, not by this skip: an ancestor holding
+    a level that would not come away is non-empty and refuses in its turn.
+
     Failures are swallowed because this runs on the way out of a `raise`:
     the caller must see the error that failed the effect, not a cleanup
     error standing in front of it."""
     for directory in created:
+        try:
+            if not directory.exists():
+                continue
+        except OSError:
+            # Existence undecidable at this level. Skipping is the same
+            # conservative direction as above -- nothing is removed here --
+            # while still letting a level this call demonstrably created be
+            # unwound. A non-empty ancestor still refuses on its own rmdir.
+            continue
         try:
             directory.rmdir()
         except OSError:
@@ -1918,9 +1938,18 @@ class Mission:
         # it declines to touch: a write that landed bytes and then failed to
         # receipt them leaves a non-empty directory, and the artifact's own
         # bytes are not this cleanup's to delete.
+        # The mkdir is INSIDE the try. mkdir(parents=True) creates the chain one
+        # level at a time and can fail partway — a long component raises OSError
+        # [Errno 36] after the shallower parents already exist — so leaving it
+        # outside left exactly the residue this seam is about, and contradicted
+        # the sentence above about unwinding "on the way out of any raise".
+        # `created_parents` is still read BEFORE the mkdir, which is the part
+        # that has to happen first: Path.mkdir reports nothing about what it
+        # made, and re-deriving it afterwards cannot tell our directory from one
+        # a concurrent writer created in between.
         created_parents = _absent_ancestors(target.parent)
-        target.parent.mkdir(parents=True, exist_ok=True)
         try:
+            target.parent.mkdir(parents=True, exist_ok=True)
             target.write_bytes(data)
             receipt = {
                 "record": "receipt@1",

--- a/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
+++ b/plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py
@@ -2726,6 +2726,57 @@ def test_failed_effect_removes_the_directories_it_created(
           (workspace / "esrm" / "deep" / "x.txt").exists())
 
 
+def test_failed_mkdir_removes_the_ancestors_it_already_created(
+        workspace: Path) -> None:
+    """The unwind must cover a FAILURE INSIDE THE MKDIR, not only after it.
+
+    The first cut of the es#169 fix left `target.parent.mkdir(parents=True)`
+    outside the try, so only a failure after the directories existed was
+    unwound. But mkdir(parents=True) builds the chain one level at a time
+    and can fail partway: a component longer than NAME_MAX raises OSError
+    [Errno 36] after the shallower parents are already on disk. That is the
+    same unreceipted residue the issue names, and the seam comment claimed
+    it was unwound "on the way out of any raise" while it was not.
+
+    No injection is needed here -- the filesystem itself supplies the
+    partial failure, which is why this case is worth having alongside the
+    injected-write one."""
+    m = open_mission(workspace, "m-mkdir-partial", "Fail inside the mkdir.")
+    m.approve()
+    cps_before = sorted(
+        (workspace / "missions" / "m-mkdir-partial" / "checkpoints")
+        .glob("*.json"))
+
+    too_long = "z" * 300  # > NAME_MAX (255) on every mainstream filesystem
+    try:
+        m.record_effect(f"aa/bb/{too_long}/x.txt", "data", "req-partial")
+        check("partial-mkdir-propagates-the-error", False)
+    except OSError:
+        check("partial-mkdir-propagates-the-error", True)
+
+    check("partial-mkdir-minted-no-receipt",
+          not list((workspace / "missions" / "m-mkdir-partial" / "receipts")
+                   .glob("*.json")))
+    check("partial-mkdir-committed-no-checkpoint",
+          sorted((workspace / "missions" / "m-mkdir-partial" / "checkpoints")
+                 .glob("*.json")) == cps_before)
+    # THE PROPERTY: `aa` and `aa/bb` were created by this call and must be gone.
+    check("partial-mkdir-left-no-created-ancestor",
+          not (workspace / "aa").exists())
+
+    # CONTROL: still only what THIS call created. A pre-existing ancestor on
+    # the failing path survives, so the assertion above cannot pass by an
+    # unwind that climbs out of its own scope.
+    (workspace / "cc").mkdir()
+    try:
+        m.record_effect(f"cc/dd/{too_long}/y.txt", "data", "req-partial-2")
+        check("partial-mkdir-propagates-the-error-2", False)
+    except OSError:
+        check("partial-mkdir-propagates-the-error-2", True)
+    check("partial-mkdir-kept-the-caller-s-own-directory",
+          (workspace / "cc").is_dir() and not (workspace / "cc" / "dd").exists())
+
+
 def test_accept_requires_verifying_and_separation(workspace: Path) -> None:
     m = open_mission(workspace, "m-accept", "Finish task.")
     m.approve()
@@ -6636,6 +6687,7 @@ TESTS = [
     test_corrupt_receipt_degrades_to_drift,
     test_effect_duplicate_id_leaves_workspace_untouched,
     test_failed_effect_removes_the_directories_it_created,
+    test_failed_mkdir_removes_the_ancestors_it_already_created,
     test_accept_requires_verifying_and_separation,
     test_fail_is_clearable,
     test_operator_tier,


### PR DESCRIPTION
Follow-up to #245, from its adversarial review — which landed after I had already merged that PR. **Seam 1 of #169 was not completely closed**, and the reviewer reproduced the residue on `#245`'s own head: writing to `aa/bb/<300 chars>/x.txt` raises `OSError [Errno 36]` and leaves `workspace/aa` and `workspace/aa/bb` standing with an empty receipts directory. That is the exact unreceipted residue #169 names, surviving the fix — while the seam comment claimed the parents were *"unwound on the way out of any raise"*.

## The review's diagnosis needed correcting

It said *"One line moves it inside the try."* **That alone does not fix it.** I mutation-tested each half separately and both are load-bearing:

| Mutation | Result |
|---|---|
| `mkdir` back outside the `try` (skip kept) | **2 failures** — `partial-mkdir-left-no-created-ancestor`, `partial-mkdir-kept-the-caller-s-own-directory` |
| unwind skip removed (`mkdir` stays inside) | **the same 2 failures** |
| both in place | **0 failures** |

**1. `target.parent.mkdir(parents=True)` moves inside the `try`.** `mkdir` builds the chain one level at a time and can fail partway, so a failure in the mkdir itself never reached the unwind at all. `_absent_ancestors` is still read **before** the mkdir — that ordering has to hold, because `Path.mkdir` reports nothing about what it made and re-deriving it afterwards cannot tell our directory from one a concurrent writer created in between.

**2. `_unwind_absent_ancestors` skips a level that is not there, instead of treating it as a refusal.** This is what actually released the residue. The recorded list is deepest-first and includes levels `mkdir` never reached; `rmdir` of the too-long name raised first, the loop `return`ed on it, and every level below — the ones this call really did create — survived. A level that does not exist holds nothing and shelters nobody's data.

The ENOTEMPTY guarantee is unchanged, and is enforced by `rmdir` itself rather than by the skip: an ancestor holding a level that would not come away is non-empty and refuses in its turn. A level whose existence is *undecidable* is also skipped — same conservative direction, nothing is removed there.

## Evidence

`test_failed_mkdir_removes_the_ancestors_it_already_created`, registered in `TESTS` so `_check_registry_is_complete` cannot let it rot into a silent pass. It needs **no injection** — the filesystem supplies the partial failure — which is why it is worth having beside the injected-`write_bytes` case rather than replacing it. It carries a control on a pre-existing ancestor (`cc/` survives while `cc/dd/` is removed), so it cannot pass by an unwind that climbs out of its own scope.

Full mission-custody contract, every step green:

| Step | Result |
|---|---|
| `test_mission_custody_jsonschema` | all green: 8 fields × 33 parity cases + compound control |
| `test_mission_custody` | 0 failures |
| `test_custody_store` | 0 failures |
| `test_custody_mission` | 0 failures |
| `test_custody_cli` | 0 failures |
| `test_custody_gate` | all green |
| `test_es173_cases` | 0 failures |
| `test_custody_hook` | all green |
| `test_custody_process_proof` | 0 failures |
| `py_compile verify_mission_custody` | clean |

Measured on Linux under CPython 3.11 in a container. The hosted `ubuntu-24.04` job has not been observed for this branch, and `contract-macos` is dispatch-only and was not run. `NAME_MAX` is 255 on every mainstream filesystem, so the 300-character component is portable in practice, but it is a filesystem property rather than a language guarantee.

## #169 still stays open

Seam 2 — `_link_count` and `_resolved_relpath` returning a silent `None` on a permission failure, with no disclosure surface on `resume` / `status --brief` to mirror `uncompared_scope_entries` — is untouched. It is a new CLI-visible surface, not a local repair.

Refs #169

<!-- assurance-metadata
assurance: R1
external_side_effect: no
irreversible: no
operator_decision_required: no
postcondition_oracle: python3 plugins/epistemic-skills/contracts/mission-custody/test_custody_mission.py exits 0 with zero FAIL lines, and in particular partial-mkdir-left-no-created-ancestor and partial-mkdir-kept-the-caller-s-own-directory pass; each fails when either half of the fix is reverted alone, observed both ways
rollback_or_return_path: git revert of this single commit restores the mkdir outside the try and the stop-on-first-failure unwind. The change only removes directories this same call created moments earlier, never an existing directory, a file, or any custody record, so reverting needs no data recovery.
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfWFqWrMnnnnZtMxCXRuyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfWFqWrMnnnnZtMxCXRuyK)_